### PR TITLE
Feature/issue 414: vim plugin respects pyproject.toml config

### DIFF
--- a/black.py
+++ b/black.py
@@ -138,6 +138,23 @@ class FileMode(Flag):
         return mode
 
 
+def abspath_pyproject_toml(path_search_start: str) -> Optional[str]:
+    """Find the absolute filepath to a pyproject.toml if it exists"""
+    path_project_root = find_project_root(path_search_start)
+    path_pyproject_toml = path_project_root / "pyproject.toml"
+    return str(path_pyproject_toml) if path_pyproject_toml.is_file() else None
+
+
+def parse_pyproject_toml(path_config: str) -> Dict[str, Any]:
+    """Parse a pyproject toml file, pulling out relevant parts for Black
+
+    If parsing fails, will raise a toml.TomlDecodeError
+    """
+    pyproject_toml = toml.load(path_config)
+    config = pyproject_toml.get("tool", {}).get("black", {})
+    return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
+
+
 def read_pyproject_toml(
     ctx: click.Context, param: click.Parameter, value: Union[str, int, bool, None]
 ) -> Optional[str]:
@@ -148,16 +165,12 @@ def read_pyproject_toml(
     """
     assert not isinstance(value, (int, bool)), "Invalid parameter type passed"
     if not value:
-        root = find_project_root(ctx.params.get("src", ()))
-        path = root / "pyproject.toml"
-        if path.is_file():
-            value = str(path)
-        else:
+        value = abspath_pyproject_toml(ctx.params.get("src", ()))
+        if value is None:
             return None
 
     try:
-        pyproject_toml = toml.load(value)
-        config = pyproject_toml.get("tool", {}).get("black", {})
+        config = parse_pyproject_toml(value)
     except (toml.TomlDecodeError, OSError) as e:
         raise click.BadOptionUsage(f"Error reading configuration file: {e}", ctx)
 
@@ -166,9 +179,7 @@ def read_pyproject_toml(
 
     if ctx.default_map is None:
         ctx.default_map = {}
-    ctx.default_map.update(  # type: ignore  # bad types in .pyi
-        {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
-    )
+    ctx.default_map.update(config)  # type: ignore  # bad types in .pyi
     return value
 
 

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -94,15 +94,16 @@ def _initialize_black_env(upgrade=False):
 if _initialize_black_env():
   import black
   import time
+  import toml
 
 def Black():
   start = time.time()
 
-  path_pyproject_toml = black.abspath_pyproject_toml(vim.eval("pwd"))
+  path_pyproject_toml = black.abspath_pyproject_toml(vim.eval("fnamemodify(getcwd(), ':t')"))
   try:
-      config_pyproject_toml = black.parse_pyproject_toml(path_pyproject_toml)
-  except Exception:
-      config_pyproject_toml = {}
+    config_pyproject_toml = black.parse_pyproject_toml(path_pyproject_toml)
+  except Exception as exc:
+    config_pyproject_toml = {}
 
   toml_line_length = config_pyproject_toml.get("line_length")
   toml_fast = config_pyproject_toml.get("fast")

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -97,10 +97,40 @@ if _initialize_black_env():
 
 def Black():
   start = time.time()
-  fast = bool(int(vim.eval("g:black_fast")))
-  line_length = int(vim.eval("g:black_linelength"))
+
+  path_pyproject_toml = black.abspath_pyproject_toml(vim.eval("pwd"))
+  try:
+      config_pyproject_toml = black.parse_pyproject_toml(path_pyproject_toml)
+  except Exception:
+      config_pyproject_toml = {}
+
+  toml_line_length = config_pyproject_toml.get("line_length")
+  toml_fast = config_pyproject_toml.get("fast")
+  toml_skip_string_normalization = config_pyproject_toml.get(
+    "skip_string_normalization"
+  )
+
+  line_length = (
+    toml_line_length
+    if isinstance(toml_line_length, int) else
+    int(vim.eval("g:black_linelength"))
+  )
+
+  fast = (
+    toml_fast
+    if isinstance(toml_fast, bool) else
+    bool(int(vim.eval("g:black_fast")))
+  )
+
+  skip_string_normalization = (
+    toml_skip_string_normalization
+    if isinstance(toml_skip_string_normalization, bool) else
+    bool(int(vim.eval("g:black_skip_string_normalization")))
+  )
+
   mode = black.FileMode.AUTO_DETECT
-  if bool(int(vim.eval("g:black_skip_string_normalization"))):
+
+  if skip_string_normalization:
     mode |= black.FileMode.NO_STRING_NORMALIZATION
   buffer_str = '\n'.join(vim.current.buffer) + '\n'
   try:


### PR DESCRIPTION
This pull request makes the Vim plugin respect pyproject.toml without changing any public interfaces (resolves  #414)

I pulled some functionality out of read_pyproject_toml and put it into 2 separate functions: abspath_pyproject_toml and parse_pyproject_toml. These are used by the vim plugin to find and read a relevant pyproject.toml according the the already-established rules of the project.

## Regarding tests

I did not yet add tests for this modification; the original function (read_pyproject_toml) was not explicitly tested and I'm unsure what the preferred testing location would be for a bunch of pyproject.toml files.

I did run the tests using the technique recommended in the contributing guidelines and no existing tests break.