### PR TITLE
delete some dead code

### DIFF
--- a/black.py
+++ b/black.py
@@ -6,7 +6,6 @@ from enum import Enum, Flag
 from functools import lru_cache, partial, wraps
 import io
 import itertools
-import keyword
 import logging
 from multiprocessing import Manager, freeze_support
 import os
@@ -777,9 +776,7 @@ class DebugVisitor(Visitor[T]):
         list(v.visit(code))
 
 
-KEYWORDS = set(keyword.kwlist)
 WHITESPACE = {token.DEDENT, token.INDENT, token.NEWLINE}
-FLOW_CONTROL = {"return", "raise", "break", "continue"}
 STATEMENT = {
     syms.if_stmt,
     syms.while_stmt,


### PR DESCRIPTION
dead code detected via [dead](https://github.com/asottile/dead)

- **`KEYWORDS`**: introduced (unreferenced) in e74117f172e29e8a980e2c9de929ad50d3769150
- **`FLOW_CONTROL`**: last referenced in e9a940d69e789ce8caf1f3c1ded786dc102df2fd

"clean" command:

```
dead --exclude '^(tests/data/|docs/conf.py|blib2to3/)' | grep -Ev '^(visit_.*|show|_stop_signal|lib2to3_unparse) '
```