### PR TITLE
Change how venv path is modified in vim plugin

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -94,8 +94,8 @@ def _initialize_black_env(upgrade=False):
     print('DONE! You are all set, thanks for waiting ✨ 🍰 ✨')
   if first_install:
     print('Pro-tip: to upgrade Black in the future, use the :BlackUpgrade command and restart Vim.\n')
-  if sys.path[0] != virtualenv_site_packages:
-    sys.path.insert(0, virtualenv_site_packages)
+  if virtualenv_site_packages not in sys.path:
+    sys.path.append(virtualenv_site_packages)
   return True
 
 if _initialize_black_env():


### PR DESCRIPTION
- Check if black venv path is not already in `sys.path`
- Append (not insert) path so that black doesn't incorrectly import backports (e.g. `typing`)

Avoids this error if `typing` is present in venv:
```
Traceback (most recent call last):
  File "<string>", line 56, in <module>
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/black.py", line 19, in <module>
    from typing import (
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/typing.py", line 1356, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/home/josh/.virtualenvs/default/lib/python3.7/site-packages/typing.py", line 1004, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```