### PR TITLE
[WIP] Allow a single blank line between class and function definitions

### DIFF
--- a/black.py
+++ b/black.py
@@ -1451,6 +1451,11 @@ class EmptyLineTracker:
         if self.previous_line.is_decorator:
             return 0, 0
 
+        if self.previous_line.is_class and (
+            current_line.is_def or current_line.is_decorator
+        ):
+            return before, 0
+
         if self.previous_line.depth < current_line.depth and (
             self.previous_line.is_class or self.previous_line.is_def
         ):


### PR DESCRIPTION
Fixes #619.

However:

- it "fixes" it by allowing up to one blank line between `class` and `def`; it won't choose one over the other (nevertheless, I believe Black already does this for blank lines inside functions, so it's not totally without precedent :slightly_smiling_face: – in particular, both of the strict behaviours have been tried in the past (before #219, one blank line was enforced; now, Black removes the blank line), and both have been determined to be suboptimal)
- one test is currently failing due to the above
- there are no new tests specifically for this behaviour (is there documentation on how to write a test, or do I have to copy-paste an existing one?)
- I don't know if the way I've implemented this is actually sensible

There are several cases that weren't covered in the aforementioned issue; for example, should the following (currently rejected) be accepted? Clearly in this case it's worse than the version with no blank line, but if either class had more definitions I think it would make sense:

```python
class C:

    class Inner:
        pass
```

(which I guess would lead to something like "if the previous line is a `class`, and this line is a class/function/decorator, allow 0 or 1 leading blank lines"? should this also apply when the previous line is a `def`?)

tldr: I kind of feel like this is a bit of a hack when a proper solution would be more widely applicable, see https://github.com/ambv/black/issues/450#issuecomment-436244142. (at the same time, this is about the only irritation I run into on a regular basis, so I don't want to get in the way of merging this too much!)