### PR TITLE
tweak collection literals to explode with trailing comma

### DIFF
--- a/black.py
+++ b/black.py
@@ -1413,12 +1413,6 @@ class Line:
         """Remove trailing comma if there is one and it's safe."""
         if not (self.leaves and self.leaves[-1].type == token.COMMA):
             return False
-        # Temporary: for now we unconditionally leave trailing commas
-        # in imports. This goes away on the next change when trailing
-        # commas imply exploding collections to multiple lines.
-        if closing.type == token.RPAR and self.is_import:
-            self.remove_trailing_comma()
-            return True
         # We remove trailing commas only in the case of importing a
         # single name from a module.
         if not (

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -1,0 +1,138 @@
+import core, time, a
+
+from . import A, B, C
+
+# unwraps
+from foo import (
+    bar,
+)
+
+# stays wrapped
+from foo import (
+    baz,
+    qux,
+)
+
+# as doesn't get confusing when unwrapped
+from foo import (
+    xyzzy as magic,
+)
+
+a = {1,2,3,}
+b = {
+1,2,
+     3}
+c = {
+    1,
+    2,
+    3,
+}
+x = 1,
+y = narf(),
+nested = {(1,2,3),(4,5,6),}
+nested_no_trailing_comma = {(1,2,3),(4,5,6)}
+nested_long_lines = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccccccccccccccccccccccc", (1, 2, 3), "dddddddddddddddddddddddddddddddddddddddd"]
+{"oneple": (1,),}
+{"oneple": (1,)}
+['ls', 'lsoneple/%s' % (foo,)]
+x = {"oneple": (1,)}
+y = {"oneple": (1,),}
+assert False, ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s" % bar)
+
+# looping over a 1-tuple should also not get wrapped
+for x in (1,):
+    pass
+for (x,) in (1,), (2,), (3,):
+    pass
+
+[1, 2, 3,]
+
+division_result_tuple = (6/2,)
+print("foo %r", (foo.bar,))
+
+if True:
+    IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING = (
+        Config.IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING
+        | {pylons.controllers.WSGIController}
+    )
+
+if True:
+    ec2client.get_waiter('instance_stopped').wait(
+        InstanceIds=[instance.id],
+        WaiterConfig={
+            'Delay': 5,
+        })
+    ec2client.get_waiter("instance_stopped").wait(
+        InstanceIds=[instance.id],
+        WaiterConfig={"Delay": 5,},
+    )
+    ec2client.get_waiter("instance_stopped").wait(
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,},
+    )
+
+# output
+
+
+import core, time, a
+
+from . import A, B, C
+
+# unwraps
+from foo import bar
+
+# stays wrapped
+from foo import baz, qux
+
+# as doesn't get confusing when unwrapped
+from foo import xyzzy as magic
+
+a = {1, 2, 3}
+b = {1, 2, 3}
+c = {1, 2, 3}
+x = (1,)
+y = (narf(),)
+nested = {(1, 2, 3), (4, 5, 6)}
+nested_no_trailing_comma = {(1, 2, 3), (4, 5, 6)}
+nested_long_lines = [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "cccccccccccccccccccccccccccccccccccccccc",
+    (1, 2, 3),
+    "dddddddddddddddddddddddddddddddddddddddd",
+]
+{"oneple": (1,)}
+{"oneple": (1,)}
+["ls", "lsoneple/%s" % (foo,)]
+x = {"oneple": (1,)}
+y = {"oneple": (1,)}
+assert False, (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s"
+    % bar
+)
+
+# looping over a 1-tuple should also not get wrapped
+for x in (1,):
+    pass
+for (x,) in (1,), (2,), (3,):
+    pass
+
+[1, 2, 3]
+
+division_result_tuple = (6 / 2,)
+print("foo %r", (foo.bar,))
+
+if True:
+    IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING = Config.IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING | {
+        pylons.controllers.WSGIController
+    }
+
+if True:
+    ec2client.get_waiter("instance_stopped").wait(
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+    )
+    ec2client.get_waiter("instance_stopped").wait(
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+    )
+    ec2client.get_waiter("instance_stopped").wait(
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+    )

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -86,12 +86,12 @@ from foo import baz, qux
 # as doesn't get confusing when unwrapped
 from foo import xyzzy as magic
 
-a = {1, 2, 3}
+a = {1, 2, 3,}
 b = {1, 2, 3}
-c = {1, 2, 3}
+c = {1, 2, 3,}
 x = (1,)
 y = (narf(),)
-nested = {(1, 2, 3), (4, 5, 6)}
+nested = {(1, 2, 3), (4, 5, 6),}
 nested_no_trailing_comma = {(1, 2, 3), (4, 5, 6)}
 nested_long_lines = [
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -100,11 +100,11 @@ nested_long_lines = [
     (1, 2, 3),
     "dddddddddddddddddddddddddddddddddddddddd",
 ]
-{"oneple": (1,)}
+{"oneple": (1,),}
 {"oneple": (1,)}
 ["ls", "lsoneple/%s" % (foo,)]
 x = {"oneple": (1,)}
-y = {"oneple": (1,)}
+y = {"oneple": (1,),}
 assert False, (
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s"
     % bar
@@ -116,7 +116,7 @@ for x in (1,):
 for (x,) in (1,), (2,), (3,):
     pass
 
-[1, 2, 3]
+[1, 2, 3,]
 
 division_result_tuple = (6 / 2,)
 print("foo %r", (foo.bar,))
@@ -128,11 +128,11 @@ if True:
 
 if True:
     ec2client.get_waiter("instance_stopped").wait(
-        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,}
     )
     ec2client.get_waiter("instance_stopped").wait(
-        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,},
     )
     ec2client.get_waiter("instance_stopped").wait(
-        InstanceIds=[instance.id], WaiterConfig={"Delay": 5}
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,},
     )

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -86,12 +86,23 @@ from foo import baz, qux
 # as doesn't get confusing when unwrapped
 from foo import xyzzy as magic
 
-a = {1, 2, 3,}
+a = {
+    1,
+    2,
+    3,
+}
 b = {1, 2, 3}
-c = {1, 2, 3,}
+c = {
+    1,
+    2,
+    3,
+}
 x = (1,)
 y = (narf(),)
-nested = {(1, 2, 3), (4, 5, 6),}
+nested = {
+    (1, 2, 3),
+    (4, 5, 6),
+}
 nested_no_trailing_comma = {(1, 2, 3), (4, 5, 6)}
 nested_long_lines = [
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -100,11 +111,15 @@ nested_long_lines = [
     (1, 2, 3),
     "dddddddddddddddddddddddddddddddddddddddd",
 ]
-{"oneple": (1,),}
+{
+    "oneple": (1,),
+}
 {"oneple": (1,)}
 ["ls", "lsoneple/%s" % (foo,)]
 x = {"oneple": (1,)}
-y = {"oneple": (1,),}
+y = {
+    "oneple": (1,),
+}
 assert False, (
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s"
     % bar
@@ -116,7 +131,11 @@ for x in (1,):
 for (x,) in (1,), (2,), (3,):
     pass
 
-[1, 2, 3,]
+[
+    1,
+    2,
+    3,
+]
 
 division_result_tuple = (6 / 2,)
 print("foo %r", (foo.bar,))

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -81,7 +81,10 @@ from . import A, B, C
 from foo import bar
 
 # stays wrapped
-from foo import baz, qux
+from foo import (
+    baz,
+    qux,
+)
 
 # as doesn't get confusing when unwrapped
 from foo import xyzzy as magic

--- a/tests/data/comments2.py
+++ b/tests/data/comments2.py
@@ -63,7 +63,7 @@ def inline_comments_in_brackets_ruin_everything():
         parameters.children = [
             children[0],  # (1
             body,
-            children[-1],  # )1
+            children[-1]  # )1
         ]
         parameters.children = [
             children[0],
@@ -142,7 +142,7 @@ short
         syms.simple_stmt,
         [
             Node(statement, result),
-            Leaf(token.NEWLINE, '\n'),  # FIXME: \r\n?
+            Leaf(token.NEWLINE, '\n')  # FIXME: \r\n?
         ],
     )
 

--- a/tests/data/comments7.py
+++ b/tests/data/comments7.py
@@ -94,7 +94,7 @@ result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 def func():
     c = call(
-        0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1]  # type: ignore
+        0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1],  # type: ignore
     )
 
     # The type: ignore exception only applies to line length, not

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -11,7 +11,7 @@
  True
  False
  1
-@@ -29,63 +29,84 @@
+@@ -29,30 +29,37 @@
  ~great
  +value
  -1
@@ -59,16 +59,13 @@
  (1, 2)
  (1, 2, 3)
  []
- [1, 2, 3, 4, 5, 6, 7, 8, 9, (10 or A), (11 or B), (12 or C)]
--[1, 2, 3,]
-+[1, 2, 3]
+@@ -60,32 +67,46 @@
+ [1, 2, 3,]
  [*a]
  [*range(10)]
--[*a, 4, 5,]
--[4, *a, 5,]
+ [*a, 4, 5,]
+ [4, *a, 5,]
 -[this_is_a_very_long_variable_which_will_force_a_delimiter_split, element, another, *more]
-+[*a, 4, 5]
-+[4, *a, 5]
 +[
 +    this_is_a_very_long_variable_which_will_force_a_delimiter_split,
 +    element,
@@ -118,18 +115,7 @@
  call(**self.screen_kwargs)
  call(b, **self.screen_kwargs)
  lukasz.langa.pl
-@@ -94,23 +115,23 @@
- 1.0 .real
- ....__class__
- list[str]
- dict[str, int]
- tuple[str, ...]
--tuple[str, int, float, dict[str, int],]
-+tuple[str, int, float, dict[str, int]]
- very_long_variable_name_filters: t.List[
-     t.Tuple[str, t.Union[str, t.List[t.Optional[str]]]],
- ]
- xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
+@@ -104,13 +125,13 @@
      sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
  )
  xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
@@ -199,7 +185,7 @@
 +    .filter(
 +        models.Customer.account_id == account_id, models.Customer.email == email_address
 +    )
-+    .order_by(models.Customer.id.asc())
++    .order_by(models.Customer.id.asc(),)
 +    .all()
 +)
  Ø = set()
@@ -391,3 +377,4 @@
      return True
  last_call()
  # standalone comment at ENDMARKER
+ 

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -11,7 +11,7 @@
  True
  False
  1
-@@ -29,30 +29,37 @@
+@@ -29,63 +29,96 @@
  ~great
  +value
  -1
@@ -59,13 +59,28 @@
  (1, 2)
  (1, 2, 3)
  []
-@@ -60,32 +67,46 @@
- [1, 2, 3,]
+ [1, 2, 3, 4, 5, 6, 7, 8, 9, (10 or A), (11 or B), (12 or C)]
+-[1, 2, 3,]
++[
++    1,
++    2,
++    3,
++]
  [*a]
  [*range(10)]
- [*a, 4, 5,]
- [4, *a, 5,]
+-[*a, 4, 5,]
+-[4, *a, 5,]
 -[this_is_a_very_long_variable_which_will_force_a_delimiter_split, element, another, *more]
++[
++    *a,
++    4,
++    5,
++]
++[
++    4,
++    *a,
++    5,
++]
 +[
 +    this_is_a_very_long_variable_which_will_force_a_delimiter_split,
 +    element,
@@ -115,7 +130,20 @@
  call(**self.screen_kwargs)
  call(b, **self.screen_kwargs)
  lukasz.langa.pl
-@@ -104,13 +125,13 @@
+@@ -94,23 +127,25 @@
+ 1.0 .real
+ ....__class__
+ list[str]
+ dict[str, int]
+ tuple[str, ...]
+-tuple[str, int, float, dict[str, int],]
++tuple[
++    str, int, float, dict[str, int],
++]
+ very_long_variable_name_filters: t.List[
+     t.Tuple[str, t.Union[str, t.List[t.Optional[str]]]],
+ ]
+ xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
      sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
  )
  xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
@@ -132,7 +160,7 @@
  slice[0:1:2]
  slice[:]
  slice[:-1]
-@@ -134,113 +155,171 @@
+@@ -134,113 +169,171 @@
  numpy[-(c + 1) :, d]
  numpy[:, l[-2]]
  numpy[:, ::-1]

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -314,11 +314,23 @@ str or None if (1 if True else 2) else str or bytes or None
 (1, 2, 3)
 []
 [1, 2, 3, 4, 5, 6, 7, 8, 9, (10 or A), (11 or B), (12 or C)]
-[1, 2, 3,]
+[
+    1,
+    2,
+    3,
+]
 [*a]
 [*range(10)]
-[*a, 4, 5,]
-[4, *a, 5,]
+[
+    *a,
+    4,
+    5,
+]
+[
+    4,
+    *a,
+    5,
+]
 [
     this_is_a_very_long_variable_which_will_force_a_delimiter_split,
     element,
@@ -367,7 +379,9 @@ call.me(maybe)
 list[str]
 dict[str, int]
 tuple[str, ...]
-tuple[str, int, float, dict[str, int],]
+tuple[
+    str, int, float, dict[str, int],
+]
 very_long_variable_name_filters: t.List[
     t.Tuple[str, t.Union[str, t.List[t.Optional[str]]]],
 ]

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -314,11 +314,11 @@ str or None if (1 if True else 2) else str or bytes or None
 (1, 2, 3)
 []
 [1, 2, 3, 4, 5, 6, 7, 8, 9, (10 or A), (11 or B), (12 or C)]
-[1, 2, 3]
+[1, 2, 3,]
 [*a]
 [*range(10)]
-[*a, 4, 5]
-[4, *a, 5]
+[*a, 4, 5,]
+[4, *a, 5,]
 [
     this_is_a_very_long_variable_which_will_force_a_delimiter_split,
     element,
@@ -367,7 +367,7 @@ call.me(maybe)
 list[str]
 dict[str, int]
 tuple[str, ...]
-tuple[str, int, float, dict[str, int]]
+tuple[str, int, float, dict[str, int],]
 very_long_variable_name_filters: t.List[
     t.Tuple[str, t.Union[str, t.List[t.Optional[str]]]],
 ]
@@ -445,7 +445,7 @@ result = (
     .filter(
         models.Customer.account_id == account_id, models.Customer.email == email_address
     )
-    .order_by(models.Customer.id.asc())
+    .order_by(models.Customer.id.asc(),)
     .all()
 )
 Ø = set()

--- a/tests/data/fmtonoff.py
+++ b/tests/data/fmtonoff.py
@@ -150,7 +150,7 @@ def single_literal_yapf_disable():
     BAZ = {
         (1, 2, 3, 4),
         (5, 6, 7, 8),
-        (9, 10, 11, 12),
+        (9, 10, 11, 12)
     }  # yapf: disable
 cfg.rule(
     "Default", "address",

--- a/tests/data/function.py
+++ b/tests/data/function.py
@@ -230,7 +230,7 @@ def trailing_comma():
     }
 
 
-def f(a, **kwargs) -> A:
+def f(a, **kwargs,) -> A:
     return (
         yield from A(
             very_long_argument_name1=very_long_value_for_the_argument,

--- a/tests/data/function2.py
+++ b/tests/data/function2.py
@@ -24,7 +24,7 @@ def h():
 
 # output
 
-def f(a, **kwargs) -> A:
+def f(a, **kwargs,) -> A:
     with cache_dir():
         if something:
             result = CliRunner().invoke(

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -6,9 +6,9 @@ def f(a:int=1,):
 
 # output
 
-def f(a):
+def f(a,):
     ...
 
 
-def f(a: int = 1):
+def f(a: int = 1,):
     ...

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1340,6 +1340,13 @@ class BlackTestCase(unittest.TestCase):
                 self.assertIn(path, pyi_cache)
                 self.assertNotIn(path, normal_cache)
 
+    def test_collections(self) -> None:
+        source, expected = read_data("collections")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode())
+
     def test_pipe_force_py36(self) -> None:
         source, expected = read_data("force_py36")
         result = CliRunner().invoke(


### PR DESCRIPTION
This is a change I discussed with @ambv at PyCon - the commit sequence should make things clear. I didn't go to the effort of fixing up existing tests (they'll fail a lot right now), but I can if this looks like a valid approach. This is somewhere between "proof of concept" and something I'd feel happy about, but I wanted feedback on how I'm tackling this early in development since I'm very much noideadog on this code.