### PR TITLE
fix issue #251: isort removes newlines before standalone comments if …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _build
 .vscode
 docs/_static/pypi.svg
 .tox
+.idea
 __pycache__
 black.egg-info
 build/

--- a/tests/data/import_handling_issue_251.py
+++ b/tests/data/import_handling_issue_251.py
@@ -1,0 +1,112 @@
+"""The asyncio package, tracking PEP 3156."""
+
+# flake8: noqa
+
+from logging import (
+    ERROR,
+)
+import sys
+
+# This relies on each of the submodules having an __all__ variable.
+from .base_events import *
+from .coroutines import *
+from .events import *  # comment here
+# bugfix_1
+from .futures import *
+from .locks import *  # comment here
+from .protocols import *
+# bugfix_2
+from ..runners import *  # comment here
+from ..queues import *
+from ..streams import *
+
+from some_library import (
+    Just, Enough, Libraries, To, Fit, In, This, Nice, Split, Which, We, No, Longer, Use
+)
+from name_of_a_company.extremely_long_project_name.component.ttypes import CuteLittleServiceHandlerFactoryyy
+from name_of_a_company.extremely_long_project_name.extremely_long_component_name.ttypes import *
+
+from .a.b.c.subprocess import *
+from . import (tasks)
+from . import (A, B, C)
+from . import SomeVeryLongNameAndAllOfItsAdditionalLetters1, \
+              SomeVeryLongNameAndAllOfItsAdditionalLetters2
+# bugfix_3
+__all__ = (
+    base_events.__all__
+    + coroutines.__all__
+    + events.__all__
+    + futures.__all__
+    + locks.__all__
+    + protocols.__all__
+    + runners.__all__
+    + queues.__all__
+    + streams.__all__
+    + tasks.__all__
+)
+
+
+# output
+
+
+"""The asyncio package, tracking PEP 3156."""
+
+# flake8: noqa
+
+from logging import ERROR
+import sys
+
+# This relies on each of the submodules having an __all__ variable.
+from .base_events import *
+from .coroutines import *
+from .events import *  # comment here
+# bugfix_1
+from .futures import *
+from .locks import *  # comment here
+from .protocols import *
+# bugfix_2
+from ..runners import *  # comment here
+from ..queues import *
+from ..streams import *
+
+from some_library import (
+    Just,
+    Enough,
+    Libraries,
+    To,
+    Fit,
+    In,
+    This,
+    Nice,
+    Split,
+    Which,
+    We,
+    No,
+    Longer,
+    Use,
+)
+from name_of_a_company.extremely_long_project_name.component.ttypes import (
+    CuteLittleServiceHandlerFactoryyy,
+)
+from name_of_a_company.extremely_long_project_name.extremely_long_component_name.ttypes import *
+
+from .a.b.c.subprocess import *
+from . import tasks
+from . import A, B, C
+from . import (
+    SomeVeryLongNameAndAllOfItsAdditionalLetters1,
+    SomeVeryLongNameAndAllOfItsAdditionalLetters2,
+)
+# bugfix_3
+__all__ = (
+    base_events.__all__
+    + coroutines.__all__
+    + events.__all__
+    + futures.__all__
+    + locks.__all__
+    + protocols.__all__
+    + runners.__all__
+    + queues.__all__
+    + streams.__all__
+    + tasks.__all__
+)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -596,6 +596,14 @@ class BlackTestCase(unittest.TestCase):
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, black.FileMode())
 
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test__maybe_empty_lines(self) -> None:
+        source, expected = read_data("import_handling_issue_251")
+        actual = fs(source, mode=black.FileMode(import_mode=1))
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode(import_mode=1))
+
     def test_tab_comment_indentation(self) -> None:
         contents_tab = "if 1:\n\tif 2:\n\t\tpass\n\t# comment\n\tpass\n"
         contents_spc = "if 1:\n    if 2:\n        pass\n    # comment\n    pass\n"


### PR DESCRIPTION
With this tested commit, I'd like to give the User the ability to choose if he wants to use default Black's behavior or wants to use it with Isort, accepting its behavior. Run test:
<pre>pytest ./tests/test_black.py -k 'test__maybe_empty_lines'</pre>

For using with Isort  it's just enough to add in command line option <code>--import-mode=1</code>