### PR TITLE
Remove rpar case from can_remove_invisible_parens

### DIFF
--- a/black.py
+++ b/black.py
@@ -482,8 +482,11 @@ def reformat_one(
                 res_src = src.resolve()
                 if res_src in cache and cache[res_src] == get_cache_info(res_src):
                     changed = Changed.CACHED
-            if changed is not Changed.CACHED and format_file_in_place(
-                src, fast=fast, write_back=write_back, mode=mode
+            if (
+                changed is not Changed.CACHED
+                and format_file_in_place(
+                    src, fast=fast, write_back=write_back, mode=mode
+                )
             ):
                 changed = Changed.YES
             if (write_back is WriteBack.YES and changed is not Changed.CACHED) or (
@@ -585,8 +588,9 @@ async def schedule_formatting(
                 changed = Changed.YES if task.result() else Changed.NO
                 # If the file was written back or was successfully checked as
                 # well-formatted, store this information in the cache.
-                if write_back is WriteBack.YES or (
-                    write_back is WriteBack.CHECK and changed is Changed.NO
+                if (
+                    write_back is WriteBack.YES
+                    or (write_back is WriteBack.CHECK and changed is Changed.NO)
                 ):
                     sources_to_cache.append(src)
                 report.done(src, changed)
@@ -1281,8 +1285,9 @@ class Line:
         try:
             last_leaf = self.leaves[-1]
             ignored_ids.add(id(last_leaf))
-            if last_leaf.type == token.COMMA or (
-                last_leaf.type == token.RPAR and not last_leaf.value
+            if (
+                last_leaf.type == token.COMMA
+                or (last_leaf.type == token.RPAR and not last_leaf.value)
             ):
                 # When trailing commas or optional parens are inserted by Black for
                 # consistency, comments after the previous last element are not moved
@@ -1429,8 +1434,9 @@ class Line:
 
             if subscript_start.type == syms.subscriptlist:
                 subscript_start = child_towards(subscript_start, leaf)
-        return subscript_start is not None and any(
-            n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
+        return (
+            subscript_start is not None
+            and any(n.type in TEST_DESCENDANTS for n in subscript_start.pre_order())
         )
 
     def __str__(self) -> str:
@@ -1531,8 +1537,9 @@ class EmptyLineTracker:
         if self.previous_line.is_decorator:
             return 0, 0
 
-        if self.previous_line.depth < current_line.depth and (
-            self.previous_line.is_class or self.previous_line.is_def
+        if (
+            self.previous_line.depth < current_line.depth
+            and (self.previous_line.is_class or self.previous_line.is_def)
         ):
             return 0, 0
 
@@ -2524,8 +2531,8 @@ def bracket_split_build_line(
             normalize_prefix(leaves[0], inside_brackets=True)
             # Ensure a trailing comma for imports and standalone function arguments, but
             # be careful not to add one after any comments.
-            no_commas = original.is_def and not any(
-                l.type == token.COMMA for l in leaves
+            no_commas = (
+                original.is_def and not any(l.type == token.COMMA for l in leaves)
             )
 
             if original.is_import or no_commas:
@@ -3791,8 +3798,7 @@ def can_omit_invisible_parens(line: Line, line_length: int) -> bool:
         # opening bracket doesn't match our rule, maybe the closing will.
 
     if (
-        last.type == token.RPAR
-        or last.type == token.RBRACE
+        last.type == token.RBRACE
         or (
             # don't use indexing for omitting optional parentheses;
             # it looks weird

--- a/tests/data/composition.py
+++ b/tests/data/composition.py
@@ -154,7 +154,8 @@ class C:
             "in one line because it's too long"
         )
 
-        dis_c_instance_method = """\
+        dis_c_instance_method = (
+            """\
         %3d           0 LOAD_FAST                1 (x)
                       2 LOAD_CONST               1 (1)
                       4 COMPARE_OP               2 (==)
@@ -162,8 +163,8 @@ class C:
                       8 STORE_ATTR               0 (x)
                      10 LOAD_CONST               0 (None)
                      12 RETURN_VALUE
-        """ % (
-            _C.__init__.__code__.co_firstlineno + 1,
+        """
+            % (_C.__init__.__code__.co_firstlineno + 1,)
         )
 
         assert expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect == {

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -245,8 +245,8 @@
 -for addr_family, addr_type, addr_proto, addr_canonname, addr_sockaddr in socket.getaddrinfo('google.com', 'http'):
 +print(*lambda x: x)
 +assert not Test, "Short message"
-+assert this is ComplexTest and not requirements.fit_in_a_single_line(
-+    force=False
++assert (
++    this is ComplexTest and not requirements.fit_in_a_single_line(force=False)
 +), "Short message"
 +assert parens is TooMany
 +for (x,) in (1,), (2,), (3,):

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -475,8 +475,8 @@ print(*[] or [1])
 print(**{1: 3} if False else {x: x for x in range(3)})
 print(*lambda x: x)
 assert not Test, "Short message"
-assert this is ComplexTest and not requirements.fit_in_a_single_line(
-    force=False
+assert (
+    this is ComplexTest and not requirements.fit_in_a_single_line(force=False)
 ), "Short message"
 assert parens is TooMany
 for (x,) in (1,), (2,), (3,):


### PR DESCRIPTION
#824 is blocking adoption of Black here at @xnorai, so I tried to poke around inside Black to see what I could do to fix it. After a number of attempts I found the `RPAR` line here to be the sole culprit:

https://github.com/python/black/blob/f3bb22a828495c66d8d2dae1edf45e15fc2daddb/black.py#L3793-L3796

After removing that line, I found the resulting output to be much more palatable. The test cases that broke when I changed that, also (in my subjective opinion) are more readable after the change as well (with the exception of the `dis_c_instance_method` case, which seems different but neither better nor worse).

I looked in the history to see if there was any reason for it to be the way it is now, and I found 87b8df28c48353d3d08d7e88d178c7a567de816a, but there's not a whole lot of context offered in the commit message or surrounding changes there, other than that it's a big overhaul of how invisible parentheses were handled.

Fixes #824.