### PR TITLE
Welcome to your new home! python/black -> psf/black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ deploy:
   skip_cleanup: true
   on:
     condition: $TRAVIS_PYTHON_VERSION == '3.6'
-    repo: python/black
+    repo: psf/black
     tags: true


### PR DESCRIPTION
> Black, your uncompromising #Python formatter, now lives under the PSF organization on GitHub! While we are just the first project under this new umbrella, I'm hearing we'll be soon joined by Requests as well. Sounds like good company :-)  (1/2)

https://twitter.com/llanga/status/1153417050024550401

> Why? The Python Steering Council and I decided that this new home provides the project all it needs (non-personal account, access to @ThePSF infrastructure, staff, and legal help) while being less misleading to the official nature of the code style. Stable release imminent! (2/2)

https://twitter.com/llanga/status/1153417052302053378

TODO

* [ ] Enable Travis CI at https://travis-ci.org/psf/black
* [ ] Enable AppVeyor at https://ci.appveyor.com/project/psf/black
* [ ] Enable Coveralls at https://coveralls.io/github/psf/black
