### PR TITLE
Fix comment formatting for slurm/pbs cluster directives.

### DIFF
--- a/black.py
+++ b/black.py
@@ -2142,8 +2142,9 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> List[ProtoComment]:
 def make_comment(content: str) -> str:
     """Return a consistently formatted comment from the given `content` string.
 
-    All comments (except for "##", "#!", "#:", '#'", "#%%") should have a single
-    space between the hash sign and the content.
+    All comments (except for "##", "#!", "#:", '#'", "#%%" and certain
+    directives) should have a single space between the hash sign and the
+    content.
 
     If `content` didn't start with a hash sign, one is provided.
     """
@@ -2153,7 +2154,7 @@ def make_comment(content: str) -> str:
 
     if content[0] == "#":
         content = content[1:]
-    if content and content[0] not in " !:#'%":
+    if content and not content.startswith(tuple(" !:#'%") + ("SBATCH", "PBS")):
         content = " " + content
     return "#" + content
 

--- a/tests/data/comments3.py
+++ b/tests/data/comments3.py
@@ -1,3 +1,5 @@
+#SBATCH directives can't have a preceding space,
+#PBS are the same.
 # The percent-percent comments are Spyder IDE cells.
 
 #%%


### PR DESCRIPTION
This change slightly updates black's comment formatting logic for a non-PEP8 edge case frequently encountered in HPC batch schedulers. 

These tools use block comments that immediately follow the `#!` header to provide default configuration parameters for a batch scheduler of the form [`#SBATCH`](https://slurm.schedmd.com/sbatch.html) or [`#PBS`](http://docs.adaptivecomputing.com/torque/4-0-2/Content/topics/commands/qsub.htm) and, unfortunately, don't support a pep8 compatible `# SBATCH` or `# PBS` syntax.

This change special cases comments beginning with these directives, as there isn't a clear way to resolve these requirements within black's existing syntax. As the directive *must* follow the shebang, `# fmt: off` escape hatches aren't a viable solution and (interestingly) don't prevent block comment reformatting in black's current implementation.

Though this is a low-usage edge case, I hope the precedent from https://github.com/psf/black/issues/68 will apply. 