### PR TITLE
Remove unnecessary if-statement in maybe_make_parens_invisible_in_atom

### DIFF
--- a/black.py
+++ b/black.py
@@ -3008,8 +3008,7 @@ def maybe_make_parens_invisible_in_atom(node: LN, parent: LN) -> bool:
         # make parentheses invisible
         first.value = ""  # type: ignore
         last.value = ""  # type: ignore
-        if len(node.children) > 1:
-            maybe_make_parens_invisible_in_atom(node.children[1], parent=parent)
+        maybe_make_parens_invisible_in_atom(node.children[1], parent=parent)
         return False
 
     return True


### PR DESCRIPTION
Noticed this when working on #961.  

This if-statement is superfluous b/c right above, there's a check to see if the first and last element of the array of `node.children` have `token.LPAR` and `token.RPAR` `type`'s respectively.  If this control flow to be hit, it's impossible for the array to have only 1 element.