### PR TITLE
Add .svn to default exclusion list

### DIFF
--- a/black.py
+++ b/black.py
@@ -54,9 +54,7 @@ from blib2to3.pgen2.parse import ParseError
 
 __version__ = "19.3b0"
 DEFAULT_LINE_LENGTH = 88
-DEFAULT_EXCLUDES = (
-    r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/"
-)
+DEFAULT_EXCLUDES = r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))
 


### PR DESCRIPTION
As title and per discussion in #794.  Adds this pattern to the default exclusion list so that files in `.svn` aren't included.