### PR TITLE
Fix async blackd tests which won't fail currently

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -3,24 +3,14 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from functools import partial, wraps
+from functools import partial
 from io import BytesIO, TextIOWrapper
 import os
 from pathlib import Path
 import re
 import sys
 from tempfile import TemporaryDirectory
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    Coroutine,
-    Generator,
-    List,
-    Tuple,
-    Iterator,
-    TypeVar,
-)
+from typing import Any, BinaryIO, Generator, List, Tuple, Iterator, TypeVar
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -32,7 +22,8 @@ from black import Feature, TargetVersion
 
 try:
     import blackd
-    from aiohttp.test_utils import TestClient, TestServer
+    from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+    from aiohttp import web
 except ImportError:
     has_blackd_deps = False
 else:
@@ -90,25 +81,14 @@ def cache_dir(exists: bool = True) -> Iterator[Path]:
 @contextmanager
 def event_loop(close: bool) -> Iterator[None]:
     policy = asyncio.get_event_loop_policy()
-    old_loop = policy.get_event_loop()
     loop = policy.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
         yield
 
     finally:
-        policy.set_event_loop(old_loop)
         if close:
             loop.close()
-
-
-def async_test(f: Callable[..., Coroutine[Any, None, R]]) -> Callable[..., None]:
-    @event_loop(close=True)
-    @wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
-        asyncio.get_event_loop().run_until_complete(f(*args, **kwargs))
-
-    return wrapper
 
 
 @contextmanager
@@ -118,6 +98,8 @@ def skip_if_exception(e: str) -> Iterator[None]:
     except Exception as exc:
         if exc.__class__.__name__ == e:
             unittest.skip(f"Encountered expected exception {exc}, skipping")
+        else:
+            raise exc
 
 
 class BlackRunner(CliRunner):
@@ -1531,108 +1513,103 @@ class BlackTestCase(unittest.TestCase):
         ):
             ff(THIS_FILE)
 
+    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
+    def test_blackd_main(self) -> None:
+        with patch("blackd.web.run_app"):
+            result = CliRunner().invoke(blackd.main, [])
+            if result.exception is not None:
+                raise result.exception
+            self.assertEqual(result.exit_code, 0)
+
+
+class BlackDTestCase(AioHTTPTestCase):
+    async def get_application(self) -> web.Application:
+        return blackd.make_app()
+
     # TODO: remove these decorators once the below is released
     # https://github.com/aio-libs/aiohttp/pull/3727
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_request_needs_formatting(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post("/", data=b"print('hello world')")
-            self.assertEqual(response.status, 200)
-            self.assertEqual(response.charset, "utf8")
-            self.assertEqual(await response.read(), b'print("hello world")\n')
+        response = await self.client.post("/", data=b"print('hello world')")
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.charset, "utf8")
+        self.assertEqual(await response.read(), b'print("hello world")\n')
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_request_no_change(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post("/", data=b'print("hello world")\n')
-            self.assertEqual(response.status, 204)
-            self.assertEqual(await response.read(), b"")
+        response = await self.client.post("/", data=b'print("hello world")\n')
+        self.assertEqual(response.status, 204)
+        self.assertEqual(await response.read(), b"")
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_request_syntax_error(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post("/", data=b"what even ( is")
-            self.assertEqual(response.status, 400)
-            content = await response.text()
-            self.assertTrue(
-                content.startswith("Cannot parse"),
-                msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
-            )
+        response = await self.client.post("/", data=b"what even ( is")
+        self.assertEqual(response.status, 400)
+        content = await response.text()
+        self.assertTrue(
+            content.startswith("Cannot parse"),
+            msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
+        )
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_unsupported_version(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post(
-                "/", data=b"what", headers={blackd.VERSION_HEADER: "2"}
-            )
-            self.assertEqual(response.status, 501)
+        response = await self.client.post(
+            "/", data=b"what", headers={blackd.VERSION_HEADER: "2"}
+        )
+        self.assertEqual(response.status, 501)
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_supported_version(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post(
-                "/", data=b"what", headers={blackd.VERSION_HEADER: "1"}
-            )
-            self.assertEqual(response.status, 200)
+        response = await self.client.post(
+            "/", data=b"what", headers={blackd.VERSION_HEADER: "1"}
+        )
+        self.assertEqual(response.status, 200)
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_invalid_python_variant(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-
-            async def check(header_value: str, expected_status: int = 400) -> None:
-                response = await client.post(
-                    "/",
-                    data=b"what",
-                    headers={blackd.PYTHON_VARIANT_HEADER: header_value},
-                )
-                self.assertEqual(response.status, expected_status)
-
-            await check("lol")
-            await check("ruby3.5")
-            await check("pyi3.6")
-            await check("py1.5")
-            await check("2.8")
-            await check("py2.8")
-            await check("3.0")
-            await check("pypy3.0")
-            await check("jython3.4")
-
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
-    async def test_blackd_pyi(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            source, expected = read_data("stub.pyi")
-            response = await client.post(
-                "/", data=source, headers={blackd.PYTHON_VARIANT_HEADER: "pyi"}
+        async def check(header_value: str, expected_status: int = 400) -> None:
+            response = await self.client.post(
+                "/", data=b"what", headers={blackd.PYTHON_VARIANT_HEADER: header_value}
             )
-            self.assertEqual(response.status, 200)
-            self.assertEqual(await response.text(), expected)
+            self.assertEqual(response.status, expected_status)
+
+        await check("lol")
+        await check("ruby3.5")
+        await check("pyi3.6")
+        await check("py1.5")
+        await check("2.8")
+        await check("py2.8")
+        await check("3.0")
+        await check("pypy3.0")
+        await check("jython3.4")
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
+    async def test_blackd_pyi(self) -> None:
+        source, expected = read_data("stub.pyi")
+        response = await self.client.post(
+            "/", data=source, headers={blackd.PYTHON_VARIANT_HEADER: "pyi"}
+        )
+        self.assertEqual(response.status, 200)
+        self.assertEqual(await response.text(), expected)
+
+    @skip_if_exception("ClientOSError")
+    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
+    @unittest_run_loop
     async def test_blackd_python_variant(self) -> None:
-        app = blackd.make_app()
         code = (
             "def f(\n"
             "    and_has_a_bunch_of,\n"
@@ -1642,56 +1619,41 @@ class BlackTestCase(unittest.TestCase):
             "):\n"
             "    pass\n"
         )
-        async with TestClient(TestServer(app)) as client:
 
-            async def check(header_value: str, expected_status: int) -> None:
-                response = await client.post(
-                    "/", data=code, headers={blackd.PYTHON_VARIANT_HEADER: header_value}
-                )
-                self.assertEqual(response.status, expected_status)
+        async def check(header_value: str, expected_status: int) -> None:
+            response = await self.client.post(
+                "/", data=code, headers={blackd.PYTHON_VARIANT_HEADER: header_value}
+            )
+            self.assertEqual(response.status, expected_status)
 
-            await check("3.6", 200)
-            await check("py3.6", 200)
-            await check("3.6,3.7", 200)
-            await check("3.6,py3.7", 200)
+        await check("3.6", 200)
+        await check("py3.6", 200)
+        await check("3.6,3.7", 200)
+        await check("3.6,py3.7", 200)
 
-            await check("2", 204)
-            await check("2.7", 204)
-            await check("py2.7", 204)
-            await check("3.4", 204)
-            await check("py3.4", 204)
+        await check("2", 204)
+        await check("2.7", 204)
+        await check("py2.7", 204)
+        await check("3.4", 204)
+        await check("py3.4", 204)
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_line_length(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post(
-                "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "7"}
-            )
-            self.assertEqual(response.status, 200)
+        response = await self.client.post(
+            "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "7"}
+        )
+        self.assertEqual(response.status, 200)
 
     @skip_if_exception("ClientOSError")
     @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    @async_test
+    @unittest_run_loop
     async def test_blackd_invalid_line_length(self) -> None:
-        app = blackd.make_app()
-        async with TestClient(TestServer(app)) as client:
-            response = await client.post(
-                "/",
-                data=b'print("hello")\n',
-                headers={blackd.LINE_LENGTH_HEADER: "NaN"},
-            )
-            self.assertEqual(response.status, 400)
-
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
-    def test_blackd_main(self) -> None:
-        with patch("blackd.web.run_app"):
-            result = CliRunner().invoke(blackd.main, [])
-            if result.exception is not None:
-                raise result.exception
-            self.assertEqual(result.exit_code, 0)
+        response = await self.client.post(
+            "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "NaN"}
+        )
+        self.assertEqual(response.status, 400)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While working on #691, I discovered that I couldn't get `blackd` tests to fail in their current form (e.g. basic sanity check asserting `1 == 2` wouldn't fail the test suite). 

I refactor the tests for `blackd` into their own `AioHTTPTestCase` which uses abstractions documented [here](https://docs.aiohttp.org/en/stable/testing.html?highlight=test#testing-aiohttp-web-servers) from `aiohttp`.  Now, tests fail reliably when they are forced to fail or when there's a legit logical error.

I also fix an exception that is thrown when no event loop is present in `event_loop`.  Additionally, I `raise` in `skip_if_exception` when an exception that shouldn't cause the test to be skipped is caught.