### PR TITLE
Add NPM node_modules to DEFAULT_EXCLUDES

### DIFF
--- a/black.py
+++ b/black.py
@@ -55,7 +55,8 @@ from blib2to3.pgen2.parse import ParseError
 __version__ = "19.3b0"
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = (
-    r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/"
+    r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build"
+    r"|dist|node_modules)/"
 )
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))


### PR DESCRIPTION
Projects frequently have Python and JavaScript coexisting. NPM is the de
facto standard package manager for JavaScript. Ignore third party
packages by default so projects don't need configure this.