### PR TITLE
Restore all cursors, instead of only the current window

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -118,12 +118,20 @@ def Black():
   except Exception as exc:
     print(exc)
   else:
-    cursor = vim.current.window.cursor
+    current_buffer = vim.current.window.buffer
+    cursors = []
+    for i, tabpage in enumerate(vim.tabpages):
+      if tabpage.valid:
+        for j, window in enumerate(tabpage.windows):
+          if window.valid and window.buffer == current_buffer:
+            cursors.append((i, j, window.cursor))
     vim.current.buffer[:] = new_buffer_str.split('\n')[:-1]
-    try:
-      vim.current.window.cursor = cursor
-    except vim.error:
-      vim.current.window.cursor = (len(vim.current.buffer), 0)
+    for i, j, cursor in cursors:
+      window = vim.tabpages[i].windows[j]
+      try:
+        window.cursor = cursor
+      except vim.error:
+        window.cursor = (len(window.buffer), 0)
     print(f'Reformatted in {time.time() - start:.4f}s.')
 
 def BlackUpgrade():


### PR DESCRIPTION
If we have the same buffer open in multiple windows/tabs, we'll only restore the current window's cursor.

Iterate through all tabs and windows, and save/restore all cursor positions of windows that contain our buffer.

Addendum to #433.