### PR TITLE
Restore cursor to same line of code, not same line of buffer

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -110,7 +110,29 @@ def Black():
     string_normalization=not bool(int(vim.eval("g:black_skip_string_normalization"))),
     is_pyi=vim.current.buffer.name.endswith('.pyi'),
   )
-  buffer_str = '\n'.join(vim.current.buffer) + '\n'
+  (cursor_line, cursor_column) = vim.current.window.cursor
+  cb = vim.current.buffer[:]
+  cb_bc = cb[0:cursor_line]
+  # Format all code before the cursor.
+  # Detect unclosed blocks, close them with pass.
+  last_line = cb_bc[-1]
+  if last_line.rstrip().endswith(":"):
+      cb_bc[-1] = last_line + " pass"
+  # Determine old:new cursor location mapping
+  buffer_str_before = '\n'.join(cb_bc)+'\n'
+  try:
+    new_buffer_str_before = black.format_file_contents(buffer_str_before, fast=fast, mode=mode)
+    new_cb = new_buffer_str_before.split('\n')[:-1]
+    new_cursor_line = len(new_cb)
+    new_cursor = (new_cursor_line, cursor_column)
+  except black.NothingChanged:
+    new_cursor_line = cursor_line
+    new_cursor = (new_cursor_line, cursor_column)
+  except Exception as exc:
+    print(exc)
+  # Now we know where the cursor should be
+  # when we format the entire buffer. Do it:
+  buffer_str = '\n'.join(cb) + '\n'
   try:
     new_buffer_str = black.format_file_contents(buffer_str, fast=fast, mode=mode)
   except black.NothingChanged:
@@ -118,10 +140,12 @@ def Black():
   except Exception as exc:
     print(exc)
   else:
-    cursor = vim.current.window.cursor
-    vim.current.buffer[:] = new_buffer_str.split('\n')[:-1]
+    # Replace the buffer
+    new_cb = new_buffer_str.split('\n')[:-1]
+    vim.current.buffer[:] = new_cb
+    # Restore the cursor to its rightful place
     try:
-      vim.current.window.cursor = cursor
+      vim.current.window.cursor = new_cursor
     except vim.error:
       vim.current.window.cursor = (len(vim.current.buffer), 0)
     print(f'Reformatted in {time.time() - start:.4f}s.')


### PR DESCRIPTION
This updates the way that the new cursor location in the buffer is determined. It is a two-step process. First, all code ahead of the cursor is run through the Black formatter, and the new length of the code ahead of the cursor is determined. This sets the new location of the cursor. Second, the entire buffer is run through Black, as it was previously.

The end result is that the user can call the Black formatter and have the cursor remain on the same line of code as it was before and after the Black formatting process.

To make sure the code ahead of the cursor will pass through the Black formatter okay, we check if the last line ends with `:` and if so we tack `pass` onto the end.

This pull request is not very robust to corner cases (yet). For example, if the cursor is located in the middle of a long, multi-line list of arguments.