### PR TITLE
Change variable in README according to the PEP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,14 +178,14 @@ great.
 ```py3
 # in:
 
-l = [1,
+j = [1,
      2,
      3,
 ]
 
 # out:
 
-l = [1, 2, 3]
+j = [1, 2, 3]
 ```
 
 If not, *Black* will look at the contents of the first outer matching

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1041,10 +1041,10 @@ class BlackTestCase(unittest.TestCase):
         just_nl = "\n"
         with self.assertRaises(black.NothingChanged):
             black.format_file_contents(just_nl, mode=mode, fast=False)
-        same = "l = [1, 2, 3]\n"
+        same = "j = [1, 2, 3]\n"
         with self.assertRaises(black.NothingChanged):
             black.format_file_contents(same, mode=mode, fast=False)
-        different = "l = [1,2,3]"
+        different = "j = [1,2,3]"
         expected = same
         actual = black.format_file_contents(different, mode=mode, fast=False)
         self.assertEqual(expected, actual)
@@ -1072,7 +1072,7 @@ class BlackTestCase(unittest.TestCase):
 
         with patch("black.out", out), patch("black.err", err):
             with self.assertRaises(AssertionError):
-                self.assertFormatEqual("l = [1, 2, 3]", "l = [1, 2, 3,]")
+                self.assertFormatEqual("j = [1, 2, 3]", "j = [1, 2, 3,]")
 
         out_str = "".join(out_lines)
         self.assertTrue("Expected tree:" in out_str)


### PR DESCRIPTION
_Black_ is constantly aiming to follow PEP 8 and this is nicely put in the README. However, [PEP 8](https://www.python.org/dev/peps/pep-0008/#names-to-avoid) also suggests

> Never use the characters 'l' (lowercase letter el), 'O' (uppercase letter oh), or 'I' (uppercase letter eye) as single character variable names.

For this reason I have made a micro alteration and changed the variable letter `l` in an example to another variable in the spirit of PEP 8.