### PR TITLE
Replace unicode empty set identifier with ascii one

### DIFF
--- a/black.py
+++ b/black.py
@@ -1784,7 +1784,7 @@ class LineGenerator(Visitor[Line]):
     def __attrs_post_init__(self) -> None:
         """You are in a twisty little maze of passages."""
         v = self.visit_stmt
-        Ø: Set[str] = set()
+        empty_set: Set[str] = set()
         self.visit_assert_stmt = partial(v, keywords={"assert"}, parens={"assert", ","})
         self.visit_if_stmt = partial(
             v, keywords={"if", "else", "elif"}, parens={"if", "elif"}
@@ -1792,16 +1792,16 @@ class LineGenerator(Visitor[Line]):
         self.visit_while_stmt = partial(v, keywords={"while", "else"}, parens={"while"})
         self.visit_for_stmt = partial(v, keywords={"for", "else"}, parens={"for", "in"})
         self.visit_try_stmt = partial(
-            v, keywords={"try", "except", "else", "finally"}, parens=Ø
+            v, keywords={"try", "except", "else", "finally"}, parens=empty_set
         )
-        self.visit_except_clause = partial(v, keywords={"except"}, parens=Ø)
-        self.visit_with_stmt = partial(v, keywords={"with"}, parens=Ø)
-        self.visit_funcdef = partial(v, keywords={"def"}, parens=Ø)
-        self.visit_classdef = partial(v, keywords={"class"}, parens=Ø)
-        self.visit_expr_stmt = partial(v, keywords=Ø, parens=ASSIGNMENTS)
+        self.visit_except_clause = partial(v, keywords={"except"}, parens=empty_set)
+        self.visit_with_stmt = partial(v, keywords={"with"}, parens=empty_set)
+        self.visit_funcdef = partial(v, keywords={"def"}, parens=empty_set)
+        self.visit_classdef = partial(v, keywords={"class"}, parens=empty_set)
+        self.visit_expr_stmt = partial(v, keywords=empty_set, parens=ASSIGNMENTS)
         self.visit_return_stmt = partial(v, keywords={"return"}, parens={"return"})
-        self.visit_import_from = partial(v, keywords=Ø, parens={"import"})
-        self.visit_del_stmt = partial(v, keywords=Ø, parens={"del"})
+        self.visit_import_from = partial(v, keywords=empty_set, parens={"import"})
+        self.visit_del_stmt = partial(v, keywords=empty_set, parens={"del"})
         self.visit_async_funcdef = self.visit_async_stmt
         self.visit_decorated = self.visit_decorators
 


### PR DESCRIPTION
Facebook's Python typechecker, [Pyre](https://pyre-check.org/), can't parse unicode source code:
```
 ƛ Could not parse file at black.py:1645:8-1645:8
          Ø: Set[str] = set()
         ^
 ƛ Could not parse 1 file due to syntax errors!
```
According to folks familiar with Pyre's internals, supporting unicode source is nontrivial. For now, let's just rename the variable from `Ø` to `empty_set`.

The irony that our Python typechecker can't handle unicode is not lost on us.