### PR TITLE
Don't allow type comments to be merged behind regular comments

### DIFF
--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -69,6 +69,20 @@ def f(
     )  # type: int
 
 
+def f(
+    x,  # not a type comment
+    y,  # type: int
+):
+    # type: (...) -> None
+    pass
+
+
+def f(
+    x,  # not a type comment
+):  # type: (int) -> None
+    pass
+
+
 def func(
     a=some_list[0],  # type: int
 ):  # type: () -> int


### PR DESCRIPTION
Type comments only apply if they are the first comment on the line,
which means that allowing them to be pushed behind a regular comment
when joining lines is a semantic change (and, indeed, one that black
catches and fails on).

(This issue discovered in the wild at Dropbox by a user who accidentally omitted a colon in a type comment and was confused to find black crashing.)