### PR TITLE
Support PEP 572 in while statements

### DIFF
--- a/blib2to3/Grammar.txt
+++ b/blib2to3/Grammar.txt
@@ -108,7 +108,7 @@ assert_stmt: 'assert' test [',' test]
 compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef | classdef | decorated | async_stmt
 async_stmt: ASYNC (funcdef | with_stmt | for_stmt)
 if_stmt: 'if' namedexpr_test ':' suite ('elif' namedexpr_test ':' suite)* ['else' ':' suite]
-while_stmt: 'while' test ':' suite ['else' ':' suite]
+while_stmt: 'while' namedexpr_test ':' suite ['else' ':' suite]
 for_stmt: 'for' exprlist 'in' testlist ':' suite ['else' ':' suite]
 try_stmt: ('try' ':' suite
            ((except_clause ':' suite)+

--- a/tests/data/pep_572.py
+++ b/tests/data/pep_572.py
@@ -38,3 +38,6 @@ if self._is_special and (ans := self._check_nans(context=context)):
 foo(b := 2, a=1)
 foo((b := 2), a=1)
 foo(c=(b := 2), a=1)
+
+while x:= f(x):
+    pass


### PR DESCRIPTION
Commit d8fa8df0526de9c0968e0a3568008f58eae45364 added support for
parsing and formatting PEP572, but it missed the posibility to add
PEP572 syntax in while statements.