### PR TITLE
Fix typechecking under mypy 0.730

### DIFF
--- a/blib2to3/pgen2/token.pyi
+++ b/blib2to3/pgen2/token.pyi
@@ -64,7 +64,7 @@ if sys.version_info >= (3, 5):
     AWAIT: int
     ASYNC: int
 ERRORTOKEN: int
-COLONEQUAL = 59
+COLONEQUAL: int
 N_TOKENS: int
 NT_OFFSET: int
 tok_name: Dict[int, Text]

--- a/blib2to3/pgen2/token.pyi
+++ b/blib2to3/pgen2/token.pyi
@@ -64,6 +64,7 @@ if sys.version_info >= (3, 5):
     AWAIT: int
     ASYNC: int
 ERRORTOKEN: int
+COLONEQUAL = 59
 N_TOKENS: int
 NT_OFFSET: int
 tok_name: Dict[int, Text]


### PR DESCRIPTION
mypy 0.730 fixed a bug involving nonexistent attributes accessed on
modules, which caused an error since COLONEQUAL never got added to
token.pyi. Add it.