### PR TITLE
Don't break long lines when `type: ignore` is present

### DIFF
--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -99,5 +99,9 @@ def func(
         a[-1],  # type: ignore
     )
 
+    c = call(
+        "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa"  # type: ignore
+    )
+
 
 result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa

--- a/tests/data/comments7.py
+++ b/tests/data/comments7.py
@@ -36,6 +36,25 @@ result = (
 
 result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
 
+
+def func():
+    c = call(
+        0.0123,
+        0.0456,
+        0.0789,
+        0.0123,
+        0.0789,
+        a[-1],  # type: ignore
+    )
+
+    # The type: ignore exception only applies to line length, not
+    # other types of formatting.
+    c = call(
+        "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa",  # type: ignore
+        "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa"
+    )
+
+
 # output
 
 from .config import (
@@ -71,3 +90,26 @@ result = 1  # look ma, no comment migration xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
 
 result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
+
+
+def func():
+    c = call(
+        0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1]  # type: ignore
+    )
+
+    # The type: ignore exception only applies to line length, not
+    # other types of formatting.
+    c = call(
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",  # type: ignore
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+        "aaaaaaaa",
+    )

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -118,7 +118,7 @@
  call(**self.screen_kwargs)
  call(b, **self.screen_kwargs)
  lukasz.langa.pl
-@@ -94,23 +115,25 @@
+@@ -94,23 +115,23 @@
  1.0 .real
  ....__class__
  list[str]
@@ -132,15 +132,12 @@
  xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
      sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
  )
--xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
--    sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
--)
- xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[
-     ..., List[SomeClass]
+ xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
+     sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
+ )
+-xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[
+-    ..., List[SomeClass]
 -] = classmethod(sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__))  # type: ignore
-+] = classmethod(  # type: ignore
-+    sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
-+)
 +xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(
 +    sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
 +)  # type: ignore
@@ -149,7 +146,7 @@
  slice[0:1:2]
  slice[:]
  slice[:-1]
-@@ -134,113 +157,171 @@
+@@ -134,113 +155,171 @@
  numpy[-(c + 1) :, d]
  numpy[:, l[-2]]
  numpy[:, ::-1]

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -374,9 +374,7 @@ very_long_variable_name_filters: t.List[
 xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
     sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
 )
-xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[
-    ..., List[SomeClass]
-] = classmethod(  # type: ignore
+xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(  # type: ignore
     sync(async_xxxx_xxx_xxxx_xxxxx_xxxx_xxx.__func__)
 )
 xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = classmethod(


### PR DESCRIPTION
As Guido discussed in #997, breaking long lines with `type: ignore`s has caused 
us a lot of grief when the `type: ignore` is moved off the line with the type error. 

Fixes #997.