### PR TITLE
Add black version header to blackd responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,8 @@ More details can be found in [CONTRIBUTING](CONTRIBUTING.md).
 * *Black* is now able to format Python code that uses positional-only
   arguments (`/` as described in PEP-570) (#946)
 
+* `blackd` now returns the version of *Black* in the response headers (#1013)
+
 
 ### 19.3b0
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ ignore = E501,W503,E203
 ```
 
 You'll find *Black*'s own .flake8 config file is configured like this.
-If you're curious about the reasoning behind B950, 
+If you're curious about the reasoning behind B950,
 [Bugbear's documentation](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings)
 explains it.  The tl;dr is "it's like highway speed limits, we won't
 bother you if you overdo it by a few km/h".
@@ -682,7 +682,7 @@ $ where black
 
 
 
-### Wing IDE 
+### Wing IDE
 
 Wing supports black via the OS Commands tool, as explained in the Wing documentation on [pep8 formatting](https://wingware.com/doc/edit/pep8). The detailed procedure is:
 
@@ -704,7 +704,7 @@ $ black --help
 - click on **+** in **OS Commands** -> New: Command line..
   - Title: black
   - Command Line: black %s
-  - I/O Encoding: Use Default 
+  - I/O Encoding: Use Default
   - Key Binding: F1
   - [x] Raise OS Commands when executed
   - [x] Auto-save files before execution
@@ -892,6 +892,9 @@ Apart from the above, `blackd` can produce the following response codes:
 	returned in the response body.
  - `HTTP 500`: If there was any kind of error while trying to format the input.
 	The response body contains a textual representation of the error.
+
+The response headers include a `X-Black-Version` header containing the version
+of *Black*.
 
 ## Version control integration
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1662,6 +1662,13 @@ class BlackDTestCase(AioHTTPTestCase):
         )
         self.assertEqual(response.status, 400)
 
+    @skip_if_exception("ClientOSError")
+    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
+    @unittest_run_loop
+    async def test_blackd_response_black_version_header(self) -> None:
+        response = await self.client.post("/")
+        self.assertIsNotNone(response.headers.get(blackd.BLACK_VERSION_HEADER))
+
 
 if __name__ == "__main__":
     unittest.main(module="test_black")

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1562,7 +1562,7 @@ class BlackDTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_blackd_unsupported_version(self) -> None:
         response = await self.client.post(
-            "/", data=b"what", headers={blackd.VERSION_HEADER: "2"}
+            "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "2"}
         )
         self.assertEqual(response.status, 501)
 
@@ -1571,7 +1571,7 @@ class BlackDTestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_blackd_supported_version(self) -> None:
         response = await self.client.post(
-            "/", data=b"what", headers={blackd.VERSION_HEADER: "1"}
+            "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "1"}
         )
         self.assertEqual(response.status, 200)
 


### PR DESCRIPTION
This PR will add a `X-Black-Version` header to all blackd responses.

For clarity the internal constant `VERSION_HEADER` (`"X-Protocol-Version"`) has been renamed to `PROTOCOL_VERSION_HEADER`.

Closes #1013.