### PR TITLE
Fix internal error with type comments on lines with trailing commas

### DIFF
--- a/black.py
+++ b/black.py
@@ -1321,7 +1321,7 @@ class Line:
                     if leaf_id not in ignored_ids or comment_seen:
                         return True
 
-            comment_seen = True
+                comment_seen = True
 
         return False
 

--- a/tests/data/comments2.py
+++ b/tests/data/comments2.py
@@ -146,6 +146,7 @@ short
         ],
     )
 
+CONFIG_FILES = [CONFIG_FILE, ] + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
 
 #######################
 ### SECTION COMMENT ###
@@ -312,6 +313,8 @@ short
         [Node(statement, result), Leaf(token.NEWLINE, "\n")],  # FIXME: \r\n?
     )
 
+
+CONFIG_FILES = [CONFIG_FILE] + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
 
 #######################
 ### SECTION COMMENT ###


### PR DESCRIPTION
The code introduced in #1027 to detect whether a type comment appeared
after a regular comment in a Line would spuriously misfire when a leaf
was in the comments dict but had an empty list of comments. This can
occur as an artifact of how comments on trailing commas are handled,
it seems.

(This was discovered trying to test black out on mypy.)