### PR TITLE
Fix missed cases in the `# type: ignore` logic

### DIFF
--- a/tests/data/comments2.py
+++ b/tests/data/comments2.py
@@ -235,11 +235,7 @@ def inline_comments_in_brackets_ruin_everything():
             body,
             parameters.children[-1],  # )2
         ]
-        parameters.children = [
-            parameters.what_if_this_was_actually_long.children[0],
-            body,
-            parameters.children[-1],
-        ]  # type: ignore
+        parameters.children = [parameters.what_if_this_was_actually_long.children[0], body, parameters.children[-1]]  # type: ignore
     if (
         self._proc is not None
         # has the child process finished?

--- a/tests/data/comments6.py
+++ b/tests/data/comments6.py
@@ -105,3 +105,10 @@ def func(
 
 
 result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
+
+AAAAAAAAAAAAA = [AAAAAAAAAAAAA] + SHARED_AAAAAAAAAAAAA + USER_AAAAAAAAAAAAA + AAAAAAAAAAAAA  # type: ignore
+
+call_to_some_function_asdf(
+    foo,
+    [AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBB],  # type: ignore
+)


### PR DESCRIPTION
In #1040 I had convinced myself that the type ignore logic didn't
need anything like the ignored_ids from the type comment logic, but I
was wrong, and we do.

We hit these cases in practice a bunch.