### PR TITLE
Back out #850

### DIFF
--- a/black.py
+++ b/black.py
@@ -1714,26 +1714,6 @@ class LineGenerator(Visitor[Line]):
                 self.current_line.append(node)
         yield from super().visit_default(node)
 
-    def visit_atom(self, node: Node) -> Iterator[Line]:
-        # Always make parentheses invisible around a single node, because it should
-        # not be needed (except in the case of yield, where removing the parentheses
-        # produces a SyntaxError).
-        if (
-            len(node.children) == 3
-            and isinstance(node.children[0], Leaf)
-            and node.children[0].type == token.LPAR
-            and isinstance(node.children[2], Leaf)
-            and node.children[2].type == token.RPAR
-            and isinstance(node.children[1], Leaf)
-            and not (
-                node.children[1].type == token.NAME
-                and node.children[1].value == "yield"
-            )
-        ):
-            node.children[0].value = ""
-            node.children[2].value = ""
-        yield from super().visit_default(node)
-
     def visit_factor(self, node: Node) -> Iterator[Line]:
         """Force parentheses between a unary op and a binary power:
 

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -171,8 +171,7 @@
 +{"2.7": dead, "3.7": long_live or die_hard}
 +{"2.7", "3.6", "3.7", "3.8", "3.9", "4.0" if gilectomy else "3.10"}
  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10 or A, 11 or B, 12 or C]
--(SomeName)
-+SomeName
+ (SomeName)
  SomeName
  (Good, Bad, Ugly)
  (i for i in (1, 2, 3))

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -424,7 +424,7 @@ numpy[np.newaxis, :]
 {"2.7": dead, "3.7": long_live or die_hard}
 {"2.7", "3.6", "3.7", "3.8", "3.9", "4.0" if gilectomy else "3.10"}
 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10 or A, 11 or B, 12 or C]
-SomeName
+(SomeName)
 SomeName
 (Good, Bad, Ugly)
 (i for i in (1, 2, 3))

--- a/tests/data/remove_parens.py
+++ b/tests/data/remove_parens.py
@@ -1,7 +1,5 @@
-print((1))
 x = (1)
 x = (1.2)
-(x) = (3)
 
 data = (
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -58,14 +56,12 @@ def example8():
 
 
 # output
-print(1)
 x = 1
 x = 1.2
-x = 3
 
 data = (
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".encode()
-)
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+).encode()
 
 
 async def show_status():
@@ -73,8 +69,8 @@ async def show_status():
         try:
             if report_host:
                 data = (
-                    f"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".encode()
-                )
+                    f"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                ).encode()
         except Exception as e:
             pass
 

--- a/tests/data/remove_parens.py
+++ b/tests/data/remove_parens.py
@@ -3,6 +3,19 @@ x = (1)
 x = (1.2)
 (x) = (3)
 
+data = (
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+).encode()
+
+async def show_status():
+    while True:
+        try:
+            if report_host:
+                data = (
+                   f"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+               ).encode()
+        except Exception as e:
+            pass
 
 def example():
     return (("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"))
@@ -49,6 +62,21 @@ print(1)
 x = 1
 x = 1.2
 x = 3
+
+data = (
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".encode()
+)
+
+
+async def show_status():
+    while True:
+        try:
+            if report_host:
+                data = (
+                    f"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".encode()
+                )
+        except Exception as e:
+            pass
 
 
 def example():


### PR DESCRIPTION
Fixes #1042 (and probably #1044 which looks like the same thing).

The issue with the "obviously unnecessary" parentheses that #850 removed is that sometimes they're necessary to help Black fit something in one line. I didn't see an obvious solution that still removes the parens #850 was intended to remove, so let's back out this change for now in the interest of unblocking a release.

This PR also adds a test adapted from the failing example in #1042, so that if we try to reapply the #850 change we don't break the same case again.