### PR TITLE
Run pre-commit on Travis CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         name: black
         language: system
         entry: black
+        require_serial: true
         types: [python]
 
   - repo: https://gitlab.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,13 @@
 # "Version control integration" in README.md.
 exclude: ^(blib2to3/|profiling/|tests/data/)
 repos:
-  - repo: https://github.com/psf/black
-    rev: 19.3b0
+  - repo: local
     hooks:
       - id: black
+        name: black
+        language: system
+        entry: black
+        types: [python]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,19 @@
 # "Version control integration" in README.md.
 exclude: ^(blib2to3/|profiling/|tests/data/)
 repos:
--   repo: local
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
     hooks:
-    - id: black
-      name: black
-      language: system
-      entry: black
-      types: [python]
-    - id: flake8
-      name: flake8
-      language: system
-      entry: flake8
-      types: [python]
-    - id: mypy
-      name: mypy
-      language: system
-      entry: mypy
-      types: [python]
-      exclude: ^docs/conf.py
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.740
+    hooks:
+      - id: mypy
+        exclude: ^docs/conf.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 env:
 - TEST_CMD="coverage run tests/test_black.py"
 install:
-- pip install coverage coveralls
+- pip install coverage coveralls pre-commit
 - pip install -e '.[d]'
 script:
 - $TEST_CMD
@@ -19,7 +19,6 @@ matrix:
   include:
     - name: "lint"
       python: 3.7
-      install: pip install pre-commit
       env:
         - TEST_CMD="pre-commit run --all-files"
     - name: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-dist: xenial
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 env:
 - TEST_CMD="coverage run tests/test_black.py"
 install:
-- pip install coverage coveralls flake8 flake8-bugbear mypy
+- pip install coverage coveralls
 - pip install -e '.[d]'
 script:
 - $TEST_CMD
@@ -15,18 +17,11 @@ notifications:
   on_failure: always
 matrix:
   include:
-    - name: "mypy"
-      python: 3.6
-      env:
-        - TEST_CMD="mypy black.py blackd.py tests/test_black.py"
-    - name: "black"
+    - name: "lint"
       python: 3.7
+      install: pip install pre-commit
       env:
-        - TEST_CMD="black --check --verbose ."
-    - name: "flake8"
-      python: 3.7
-      env:
-        - TEST_CMD="flake8 black.py blackd.py tests/test_black.py"
+        - TEST_CMD="pre-commit run --all-files"
     - name: "3.6"
       python: 3.6
     - name: "3.7"


### PR DESCRIPTION
https://github.com/psf/black/pull/874#issuecomment-544261947 notes pre-commit is needed on the CI.

This adds a new lint job to run pre-commit.

Also, instead of running local versions of the lint tools, which need installing explicitly on Travis, use pinned repo versions and let pre-commit install them.

This is the standard way of running pre-commit. @asottile wrote in https://github.com/psf/black/issues/1073#issuecomment-542772450:

> `repo: local` and especially `language: system` are meant as escape hatches from the """normal way""" and have significant drawbacks (but are provided for those exceptional cases).

Finally, since pre-commit is also running Black, mypy and Flake8 in a single job, we no longer need them as separate jobs and can reduce the number from 6 to 4 (and Travis gives 5 parallel).
