### PR TITLE
s/_version.py/_black_version.py/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ black.egg-info
 build/
 dist/
 pip-wheel-metadata/
-_version.py
+_black_version.py
 .idea
 .eggs

--- a/black.py
+++ b/black.py
@@ -52,7 +52,7 @@ from blib2to3.pgen2 import driver, token
 from blib2to3.pgen2.grammar import Grammar
 from blib2to3.pgen2.parse import ParseError
 
-from _version import version as __version__
+from _black_version import version as __version__
 
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950

--- a/blackd.py
+++ b/blackd.py
@@ -10,7 +10,7 @@ import aiohttp_cors
 import black
 import click
 
-from _version import version as __version__
+from _black_version import version as __version__
 
 # This is used internally by tests to shut down the server prematurely
 _stop_signal = asyncio.Event()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_long_description() -> str:
 setup(
     name="black",
     use_scm_version={
-        "write_to": "_version.py",
+        "write_to": "_black_version.py",
         "write_to_template": 'version = "{version}"\n',
     },
     description="The uncompromising code formatter.",


### PR DESCRIPTION
Some users are installing Black as a dependency in their project. Having
a _version.py in site-packages is asking for a conflict sooner or later.

Ideally we shouldn't require a separate version file at all, that's an
additional import we need to make. But I'll leave that bikeshedding for
a different time.