### PR TITLE
Test Windows, macOS and Linux on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade coverage
+          python -m pip install -e ".[d]"
+
+      - name: Unit tests
+        run: |
+          coverage run tests/test_black.py


### PR DESCRIPTION
This runs tests on Windows, macOS and Ubuntu using GitHub Actions.

Tests are run on Python 3.6 and 3.7. Python 3.8 is not yet available but has been requested:

* https://github.com/actions/setup-python/issues/30

Travis CI already tests on Ubuntu, so Ubuntu could be omitted from here, but you get up to 20 parallel jobs from GH Actions, so two extra jobs won't be a problem.

(Compare: 10 with Azure Pipelines, 5 with Travis CI, 1 with AppVeyor.) 

Example build:

* https://github.com/hugovk/black/commit/2dcb39fbf8530fcd1ef891a167df5ede8afb87f2/checks?check_suite_id=274452758

---

Perhaps this might replace the Azure Pipelines PR https://github.com/psf/black/pull/731? GHA is built on top of AP, I find the GHA syntax a bit nicer. For example, the OS/Python matrix in GHA, whereas you need to repeat for each one in AP. 

Linting not added, but can be if you'd like.

This tests against the latest available OS versions, currently `windows-2019`, `macOS-10.14 ` and `ubuntu-18.04`. Also [available](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#supported-virtual-environments-and-hardware-resources) and can be added if you'd like: `windows-2016` and `ubuntu-16.04`.
