### PR TITLE
setup.py: rename _version.py to _black_version.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email="lukasz@langa.pl",
     url="https://github.com/psf/black",
     license="MIT",
-    py_modules=["black", "blackd", "_version"],
+    py_modules=["black", "blackd", "_black_version"],
     packages=["blib2to3", "blib2to3.pgen2"],
     package_data={"blib2to3": ["*.txt"]},
     python_requires=">=3.6",


### PR DESCRIPTION
In #1082, _version.py was renamed to _black_version.py, but the
py_modules line in setup.py wasn't changed, which meant that when
installed from source, running it failed with something like:

```
Traceback (most recent call last):
  File "~/.pyenv/versions/3.6.5/bin/black", line 5, in <module>
    from black import patched_main
  File "~/.pyenv/versions/3.6.5/lib/python3.6/site-packages/black.py", line 55, in <module>
    from _black_version import version as __version__
ModuleNotFoundError: No module named '_black_version'
```