### PR TITLE
Do not crash when failing to read an entry

### DIFF
--- a/black.py
+++ b/black.py
@@ -3491,6 +3491,9 @@ def gen_python_files_in_dir(
         # Then ignore with `exclude` option.
         try:
             normalized_path = "/" + child.resolve().relative_to(root).as_posix()
+        except OSError as e:
+            report.path_ignored(child, f"cannot be read because {e}")
+            continue
         except ValueError:
             if child.is_symlink():
                 report.path_ignored(


### PR DESCRIPTION
Black would crash if any of the paths fail to be read due to permission errors etc. (I got this when running black on a project in Windows containing a WSL symlink).

Instead of straight up crash (and failing to format anything), this ignores the failed path with a report.