### PR TITLE
line_length=1 to reduce churn

### DIFF
--- a/black.py
+++ b/black.py
@@ -2402,7 +2402,9 @@ def split_line(
             # All splits failed, best effort split with no omits.
             # This mostly happens to multiline strings that are by definition
             # reported as not fitting a single line.
-            yield from right_hand_split(line, line_length, features=features)
+            # line_length=1 is silly, but somehow produces better formatting
+            # than other things we've tried so far. See #762 and #781.
+            yield from right_hand_split(line, line_length=1, features=features)
 
         if line.inside_brackets:
             split_funcs = [delimiter_split, standalone_comment_split, rhs]

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -144,9 +144,10 @@ division_result_tuple = (6 / 2,)
 print("foo %r", (foo.bar,))
 
 if True:
-    IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING = Config.IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING | {
-        pylons.controllers.WSGIController
-    }
+    IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING = (
+        Config.IGNORED_TYPES_FOR_ATTRIBUTE_CHECKING
+        | {pylons.controllers.WSGIController}
+    )
 
 if True:
     ec2client.get_waiter("instance_stopped").wait(

--- a/tests/data/composition.py
+++ b/tests/data/composition.py
@@ -166,14 +166,17 @@ class C:
             _C.__init__.__code__.co_firstlineno + 1,
         )
 
-        assert expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect == {
-            key1: value1,
-            key2: value2,
-            key3: value3,
-            key4: value4,
-            key5: value5,
-            key6: value6,
-            key7: value7,
-            key8: value8,
-            key9: value9,
-        }
+        assert (
+            expectedexpectedexpectedexpectedexpectedexpectedexpectedexpectedexpect
+            == {
+                key1: value1,
+                key2: value2,
+                key3: value3,
+                key4: value4,
+                key5: value5,
+                key6: value6,
+                key7: value7,
+                key8: value8,
+                key9: value9,
+            }
+        )


### PR DESCRIPTION
Fixes #781.

This is silly but it can help us get a release out without the unnecessary churn that #762 caused.