### PR TITLE
coverage: omit tests/data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [report]
 omit =
   blib2to3/*
+  tests/data/*
   */site-packages/*


### PR DESCRIPTION
Noticed that when it complains about falling coverage, it's sometimes because code in tests/data isn't executed.