### PR TITLE
Fix unstable formatting with some `# type: ignore`s

### DIFF
--- a/black.py
+++ b/black.py
@@ -1383,7 +1383,10 @@ class Line:
         for leaf_id, comments in self.comments.items():
             for comment in comments:
                 if is_type_comment(comment):
-                    if leaf_id not in ignored_ids or comment_seen:
+                    if comment_seen or (
+                        not is_type_comment(comment, " ignore")
+                        and leaf_id not in ignored_ids
+                    ):
                         return True
 
                 comment_seen = True

--- a/tests/data/comments2.py
+++ b/tests/data/comments2.py
@@ -148,6 +148,12 @@ short
 
 CONFIG_FILES = [CONFIG_FILE, ] + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
 
+class Test:
+    def _init_host(self, parsed) -> None:
+        if (parsed.hostname is None or  # type: ignore
+                not parsed.hostname.strip()):
+            pass
+
 #######################
 ### SECTION COMMENT ###
 #######################
@@ -311,6 +317,13 @@ short
 
 
 CONFIG_FILES = [CONFIG_FILE,] + SHARED_CONFIG_FILES + USER_CONFIG_FILES  # type: Final
+
+
+class Test:
+    def _init_host(self, parsed) -> None:
+        if parsed.hostname is None or not parsed.hostname.strip():  # type: ignore
+            pass
+
 
 #######################
 ### SECTION COMMENT ###

--- a/tests/data/comments7.py
+++ b/tests/data/comments7.py
@@ -93,9 +93,7 @@ result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 def func():
-    c = call(
-        0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1],  # type: ignore
-    )
+    c = call(0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1],)  # type: ignore
 
     # The type: ignore exception only applies to line length, not
     # other types of formatting.


### PR DESCRIPTION
`type: ignore` shouldn't block collapsing a line, since it will still
apply fine to the merged line. This prevents an issue where a reformat
causes it to shift lines and then be merged on a subsequent pass.

There is a downside to this, which is that it can cause a `type:
ignore` to apply to more code than was originally intended. There
might be a way to apply this in a more limited situation, but I'm not
sure what it is.

Fixes #1061.