### PR TITLE
Support py38-style starred expressions in return statement

### DIFF
--- a/blib2to3/Grammar.txt
+++ b/blib2to3/Grammar.txt
@@ -212,4 +212,4 @@ testlist1: test (',' test)*
 encoding_decl: NAME
 
 yield_expr: 'yield' [yield_arg]
-yield_arg: 'from' test | testlist
+yield_arg: 'from' test | testlist_star_expr

--- a/blib2to3/Grammar.txt
+++ b/blib2to3/Grammar.txt
@@ -89,7 +89,7 @@ pass_stmt: 'pass'
 flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
 break_stmt: 'break'
 continue_stmt: 'continue'
-return_stmt: 'return' [testlist]
+return_stmt: 'return' [testlist_star_expr]
 yield_stmt: yield_expr
 raise_stmt: 'raise' [test ['from' test | ',' test [',' test]]]
 import_stmt: import_name | import_from

--- a/tests/data/python38.py
+++ b/tests/data/python38.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3.8
+
+
+def starred_return():
+    my_list = ["test", "test2"]
+    return "asd", *my_list
+
+
+# output
+
+
+#!/usr/bin/env python3.8
+
+
+def starred_return():
+    my_list = ["test", "test2"]
+    return "asd", *my_list

--- a/tests/data/python38.py
+++ b/tests/data/python38.py
@@ -2,8 +2,8 @@
 
 
 def starred_return():
-    my_list = ["test", "test2"]
-    return "asd", *my_list
+    my_list = ["value2", "value3"]
+    return "value1", *my_list
 
 
 # output
@@ -13,5 +13,5 @@ def starred_return():
 
 
 def starred_return():
-    my_list = ["test", "test2"]
-    return "asd", *my_list
+    my_list = ["value2", "value3"]
+    return "value1", *my_list

--- a/tests/data/python38.py
+++ b/tests/data/python38.py
@@ -6,6 +6,11 @@ def starred_return():
     return "value1", *my_list
 
 
+def starred_yield():
+    my_list = ["value2", "value3"]
+    yield "value1", *my_list
+
+
 # output
 
 
@@ -15,3 +20,8 @@ def starred_return():
 def starred_return():
     my_list = ["value2", "value3"]
     return "value1", *my_list
+
+
+def starred_yield():
+    my_list = ["value2", "value3"]
+    yield "value1", *my_list

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -584,6 +584,21 @@ class BlackTestCase(unittest.TestCase):
         self.invokeBlack([str(source_path), "--target-version", "py37"], exit_code=123)
 
     @patch("black.dump_to_file", dump_to_stderr)
+    def test_python37(self) -> None:
+        source_path = (THIS_DIR / "data" / "python37.py").resolve()
+        source, expected = read_data("python37")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        major, minor = sys.version_info[:2]
+        if major > 3 or (major == 3 and minor >= 7):
+            black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode())
+        # ensure black can parse this when the target is 3.7
+        self.invokeBlack([str(source_path), "--target-version", "py37"])
+        # but not on 3.6, because we use async as a reserved keyword
+        self.invokeBlack([str(source_path), "--target-version", "py36"], exit_code=123)
+
+    @patch("black.dump_to_file", dump_to_stderr)
     def test_python38(self) -> None:
         source_path = (THIS_DIR / "data" / "python38.py").resolve()
         source, expected = read_data("python38")

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -584,19 +584,15 @@ class BlackTestCase(unittest.TestCase):
         self.invokeBlack([str(source_path), "--target-version", "py37"], exit_code=123)
 
     @patch("black.dump_to_file", dump_to_stderr)
-    def test_python37(self) -> None:
-        source_path = (THIS_DIR / "data" / "python37.py").resolve()
-        source, expected = read_data("python37")
+    def test_python38(self) -> None:
+        source_path = (THIS_DIR / "data" / "python38.py").resolve()
+        source, expected = read_data("python38")
         actual = fs(source)
         self.assertFormatEqual(expected, actual)
         major, minor = sys.version_info[:2]
-        if major > 3 or (major == 3 and minor >= 7):
+        if major > 3 or (major == 3 and minor >= 8):
             black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, black.FileMode())
-        # ensure black can parse this when the target is 3.7
-        self.invokeBlack([str(source_path), "--target-version", "py37"])
-        # but not on 3.6, because we use async as a reserved keyword
-        self.invokeBlack([str(source_path), "--target-version", "py36"], exit_code=123)
 
     @patch("black.dump_to_file", dump_to_stderr)
     def test_fmtonoff(self) -> None:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -600,7 +600,6 @@ class BlackTestCase(unittest.TestCase):
 
     @patch("black.dump_to_file", dump_to_stderr)
     def test_python38(self) -> None:
-        source_path = (THIS_DIR / "data" / "python38.py").resolve()
         source, expected = read_data("python38")
         actual = fs(source)
         self.assertFormatEqual(expected, actual)


### PR DESCRIPTION
### Goal

https://github.com/psf/black/issues/1091

Support `py38` starred expressions in `return` and `yield` statements. [Bug description](https://bugs.python.org/issue32117)

```python
def starred_return():
    my_list = ["value2", "value3"]
    return "value1", *my_list
```

### Investigation

Event the newest [plib2to3 grammar](https://github.com/python/cpython/blob/3.8/Lib/lib2to3/Grammar.txt#L52) does not support starred expressions in return statements, so switching to a new version will not solve the issue.

The idea is to use `return_stmt: 'return' [testlist_star_expr]` in `Grammar.txt` to support both old and new return statements.

### Changes

- Accept starred expressions in `return_stmt` 
- Accept starred expressions in `yield_stmt` 
- Add test `test_python38`

### Not done

- I did not add it as a new `Feature` so it does not require `--target-version=py38`, as it is more of a bug
