### PR TITLE
Action to automatically Blacken all pull requests

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -1,0 +1,30 @@
+# GitHub Action that uses Black to reformat the Python code in an incoming pull request.
+# If all Python code in the pull request is compliant with Black then this Action does nothing.
+# Othewrwise, Black is run and its changes are committed back to the incoming pull request.
+# https://github.com/cclauss/autoblack
+
+name: autoblack
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Black
+        run: pip install black
+      - name: Run black --check .
+        run: black --check .
+      - name: If needed, commit black changes to the pull request
+        if: failure()
+        run: |
+          black .
+          git config --global user.name 'autoblack'
+          git config --global user.email 'cclauss@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git checkout $GITHUB_HEAD_REF
+          git commit -am "fixup: Format Python code with Black"
+          git push

--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -25,6 +25,6 @@ jobs:
           git config --global user.name 'autoblack'
           git config --global user.email 'cclauss@users.noreply.github.com'
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-          git checkout $GITHUB_HEAD_REF
+          git checkout cclauss:$GITHUB_HEAD_REF
           git commit -am "fixup: Format Python code with Black"
           git push

--- a/black.py
+++ b/black.py
@@ -1,4 +1,4 @@
-import ast
+import ast 
 import asyncio
 from concurrent.futures import Executor, ProcessPoolExecutor
 from contextlib import contextmanager


### PR DESCRIPTION
GitHub Action that uses Black to reformat the Python code in incoming pull requests.

If all Python code is already Blackened then this Action gives the PR a ✅ and does nothing else.

Otherwise, Blackened code is committed back to that pull request.

This means that no pull request will have passing tests until its code is Blackened and that reformatting is _automatic_ with no pre-commit hook required.