### PR TITLE
Simple docs cleanup

### DIFF
--- a/docs/reference/reference_functions.rst
+++ b/docs/reference/reference_functions.rst
@@ -127,8 +127,6 @@ Utilities
 
 .. autofunction:: black.format_float_or_int_string
 
-.. autofunction:: black.format_int_string
-
 .. autofunction:: black.ensure_visible
 
 .. autofunction:: black.enumerate_reversed

--- a/docs/reference/reference_functions.rst
+++ b/docs/reference/reference_functions.rst
@@ -26,8 +26,6 @@ Assertions and checks
 
 .. autofunction:: black.is_one_tuple
 
-.. autofunction:: black.is_python36
-
 .. autofunction:: black.is_split_after_delimiter
 
 .. autofunction:: black.is_split_before_delimiter


### PR DESCRIPTION
This gets rid of the following warnings when building the documentation:
```
WARNING: autodoc: failed to import function 'is_python36' from module 'black'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/util/inspect.py", line 225, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'black' has no attribute 'is_python36'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/importer.py", line 193, in import_object
    obj = attrgetter(obj, attrname)
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/__init__.py", line 290, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/__init__.py", line 1562, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python3/dist-packages/sphinx/util/inspect.py", line 241, in safe_getattr
    raise AttributeError(name)
AttributeError: is_python36

WARNING: autodoc: failed to import function 'format_int_string' from module 'black'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/util/inspect.py", line 225, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'black' has no attribute 'format_int_string'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/importer.py", line 193, in import_object
    obj = attrgetter(obj, attrname)
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/__init__.py", line 290, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/__init__.py", line 1562, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/usr/lib/python3/dist-packages/sphinx/util/inspect.py", line 241, in safe_getattr
    raise AttributeError(name)
AttributeError: format_int_string

```