### PR TITLE
CI: Add Python 3.8 and lint to GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+          python -m pip install -e '.[d]'
+
+      - name: Lint
+        run: pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         types: [python]
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
@@ -24,7 +24,7 @@ repos:
         exclude: ^docs/conf.py
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.18.2
+    rev: 1.19.1
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]


### PR DESCRIPTION
* Run tests with Python 3.8 on Ubuntu, macOS and Windows

* Run lint

* Autoupdate pre-commit hooks

---

PyPy3 is available on GitHub Actions, but it's still on the Python 3.5 version, so we can't use that yet. But there should be an update for PyPy 7.2.0 with Python 3.6 soon.

* https://github.com/actions/setup-python/issues/16#issuecomment-555191588