### PR TITLE
Add Thonny-black-code-format plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,10 @@ hook global WinSetOption filetype=python %{
 }
 ```
 
+### Thonny
+
+Use [Thonny-black-code-format](https://github.com/Franccisco/thonny-black-code-format).
+
 ### Other editors
 
 Other editors will require external contributions.


### PR DESCRIPTION
I created a plugin for Thonny IDE. It'd be great to add it in README.md, so Thonny users will know that it exists.