### PR TITLE
This MANIFEST.in not needed with setuptools_scm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include *.rst *.md LICENSE
-recursive-include blib2to3 *.txt *.py LICENSE
-recursive-include tests *.txt *.out *.diff *.py *.pyi *.pie *.toml


### PR DESCRIPTION
Fixes #1199.

When using setuptools_scm, MANIFEST.in is needed when we want to exclude tracked files, or include untracked files.

* https://github.com/pypa/setuptools_scm/blob/master/README.rst#file-finders-hook-makes-most-of-manifestin-unnecessary