### PR TITLE
Add comment to flake8 configuration explaining line-length mismatch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 ignore = E203, E266, E501, W503
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/README.md#line-length for more details
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
We noticed this mismatch in configuration when the configuration to our own repo. Could not see a good reason why this would be any different

Updated to match pyproject.toml configuration https://github.com/psf/black/blob/master/pyproject.toml#L9

UPDATE: changed PR so that it explains why flake8 configuration has a different line length