### PR TITLE
Pin regex dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "appdirs",
         "toml>=0.9.4",
         "typed-ast>=1.4.0",
-        "regex",
+        "regex==2019.11.1",
         "pathspec>=0.6, <1",
         "dataclasses>=0.6; python_version < '3.7'",
         "typing_extensions>=3.7.4",


### PR DESCRIPTION
Pin the regex dependency to the last known good release. I would use a y
release but it doesn't appear that regex is using sematic versioning.
Also, it appears that the 2019.12.9 release may have issues (although it
could just be improper packaging of the wheel). See related issue
https://github.com/psf/black/issues/1207.