### PR TITLE
Skip the broken version of regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "appdirs",
         "toml>=0.9.4",
         "typed-ast>=1.4.0",
-        "regex",
+        "regex!=2019.12.9",
         "pathspec>=0.6, <1",
         "dataclasses>=0.6; python_version < '3.7'",
         "typing_extensions>=3.7.4",


### PR DESCRIPTION
Fixes https://github.com/psf/black/issues/1207

Hopefully the next release will fix https://bitbucket.org/mrabarnett/mrab-regex/issues/349/no-module-named-regex_regex-regex-is-not-a. 