### PR TITLE
Notify users of missing Python lazily

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -14,7 +14,12 @@
 "    - restore cursor/window position after formatting
 
 if v:version < 700 || !has('python3')
-    echo "This script requires vim7.0+ with Python 3.6 support."
+    func! __BLACK_MISSING()
+        echo "This command requires vim7.0+ with Python 3.6 support."
+    endfunc
+    command! Black :call __BLACK_MISSING()
+    command! BlackUpgrade :call __BLACK_MISSING()
+    command! BlackVersion :call __BLACK_MISSING()
     finish
 endif
 


### PR DESCRIPTION
Currently this message shows up with no context prior to the start of Vim. By changing this to a lazy message, the user will only be notified of a problem with the Black plugin when they are attempting to use the Black plugin.

Another possible option would be to do what YCM does, and warn in the status bar *after* vim has started, but I figured this is the most targeted at the relevant users.