### PR TITLE
black.vim: Allow user to suppress output from successful reformats

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ Configuration:
 - `g:black_linelength` (defaults to `88`)
 - `g:black_skip_string_normalization` (defaults to `0`)
 - `g:black_virtualenv` (defaults to `~/.vim/black` or `~/.local/share/nvim/black`)
+- `g:black_quiet` (defaults to `1`)
 
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -39,6 +39,9 @@ endif
 if !exists("g:black_skip_string_normalization")
   let g:black_skip_string_normalization = 0
 endif
+if !exists("g:black_quiet")
+  let g:black_quiet = 0
+endif
 
 python3 << endpython3
 import os
@@ -109,6 +112,7 @@ if _initialize_black_env():
 def Black():
   start = time.time()
   fast = bool(int(vim.eval("g:black_fast")))
+  quiet = bool(int(vim.eval("g:black_quiet")))
   mode = black.FileMode(
     line_length=int(vim.eval("g:black_linelength")),
     string_normalization=not bool(int(vim.eval("g:black_skip_string_normalization"))),
@@ -118,7 +122,8 @@ def Black():
   try:
     new_buffer_str = black.format_file_contents(buffer_str, fast=fast, mode=mode)
   except black.NothingChanged:
-    print(f'Already well formatted, good job. (took {time.time() - start:.4f}s)')
+    if not quiet:
+      print(f'Already well formatted, good job. (took {time.time() - start:.4f}s)')
   except Exception as exc:
     print(exc)
   else:
@@ -136,7 +141,8 @@ def Black():
         window.cursor = cursor
       except vim.error:
         window.cursor = (len(window.buffer), 0)
-    print(f'Reformatted in {time.time() - start:.4f}s.')
+    if not quiet:
+      print(f'Reformatted in {time.time() - start:.4f}s.')
 
 def BlackUpgrade():
   _initialize_black_env(upgrade=True)


### PR DESCRIPTION
This patch adds the ability for users to `let g:black_quiet = 1` to
suppress output on `Reformatted in ...` and `Already well formatted ...`
messages.