### PR TITLE
greedy creation of CACHE_DIR

### DIFF
--- a/black.py
+++ b/black.py
@@ -60,7 +60,7 @@ DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))
-
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 # types
 FileContent = str
@@ -4126,7 +4126,6 @@ def write_cache(cache: Cache, sources: Iterable[Path], mode: FileMode) -> None:
     """Update the cache file."""
     cache_file = get_cache_file(mode)
     try:
-        CACHE_DIR.mkdir(parents=True, exist_ok=True)
         new_cache = {**cache, **{src.resolve(): get_cache_info(src) for src in sources}}
         with tempfile.NamedTemporaryFile(dir=str(cache_file.parent), delete=False) as f:
             pickle.dump(new_cache, f, protocol=4)


### PR DESCRIPTION
`pygram.initialize(CACHE_DIR)` has an explicit dependency on CACHE_DIR existing.

This code gets run the first time the library gets used and it tries to dump the cache files in the cache folder:
https://github.com/psf/black/blob/1ab87a3f67bc80a2e59be2692f2e2f25dd143af7/blib2to3/pgen2/driver.py#L194-L202

This fails since the `CACHE_DIR` only gets generated when the CLI is run for the first time