### PR TITLE
Pin to Coverage 4 for Python 3.6-3.7 on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade coverage
           python -m pip install -e ".[d]"
+
+      - name: Install coverage (3.6-3.7 and Windows)
+        if: matrix.python-version <= 3.7 && startsWith(matrix.os, 'windows')
+        run: python -m pip install --upgrade "coverage<5"
+
+      - name: Install coverage (3.8+ or Ubuntu or Mac)
+        if:
+          startsWith(matrix.os , 'ubuntu') || startsWith(matrix.os , 'macOS') ||
+          matrix.python-version >= 3.8
+        run: python -m pip install --upgrade coverage
 
       - name: Unit tests
         run: |


### PR DESCRIPTION
For some reason, the new Coverage.py version 5 is failing on Windows for Python 3.6 and 3.7.

```
Run coverage run tests/test_black.py
Traceback (most recent call last):
  File "tests/test_black.py", line 1788, in <module>
    unittest.main(module="test_black")
  File "c:\hostedtoolcache\windows\python\3.6.8\x64\lib\unittest\main.py", line 64, in __init__
    self.module = __import__(module)
ModuleNotFoundError: No module named 'test_black'
##[error]Process completed with exit code 1.
```

* https://github.com/psf/black/runs/371602079

It's passing on Windows for 3.8, and all Python versions on Ubuntu and macOS.

Here's an older build that passed for everything, before Coverage.py 5 came out.

* https://github.com/psf/black/runs/343607045

This is a workaround to get the CI back to green.