### PR TITLE
Remove deprecated  --py36 option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.740
+    rev: v0.761
     hooks:
       - id: mypy
         exclude: ^docs/conf.py

--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ Options:
                                   Python versions that should be supported by
                                   Black's output. [default: per-file auto-
                                   detection]
-  --py36                          Allow using Python 3.6-only syntax on all
-                                  input files.  This will put trailing commas
-                                  in function signatures and calls also after
-                                  *args and **kwargs. Deprecated; use
-                                  --target-version instead. [default: per-file
-                                  auto-detection]
   --pyi                           Format all input files like typing stubs
                                   regardless of file extension (useful when
                                   piping source on standard input).

--- a/black.py
+++ b/black.py
@@ -354,15 +354,6 @@ def target_version_option_callback(
     ),
 )
 @click.option(
-    "--py36",
-    is_flag=True,
-    help=(
-        "Allow using Python 3.6-only syntax on all input files.  This will put trailing"
-        " commas in function signatures and calls also after *args and **kwargs."
-        " Deprecated; use --target-version instead. [default: per-file auto-detection]"
-    ),
-)
-@click.option(
     "--pyi",
     is_flag=True,
     help=(
@@ -476,7 +467,6 @@ def main(
     color: bool,
     fast: bool,
     pyi: bool,
-    py36: bool,
     skip_string_normalization: bool,
     quiet: bool,
     verbose: bool,
@@ -488,17 +478,7 @@ def main(
     """The uncompromising code formatter."""
     write_back = WriteBack.from_configuration(check=check, diff=diff, color=color)
     if target_version:
-        if py36:
-            err("Cannot use both --target-version and --py36")
-            ctx.exit(2)
-        else:
-            versions = set(target_version)
-    elif py36:
-        err(
-            "--py36 is deprecated and will be removed in a future version. Use"
-            " --target-version py36 instead."
-        )
-        versions = PY36_VERSIONS
+        versions = set(target_version)
     else:
         # We'll autodetect later.
         versions = set()


### PR DESCRIPTION
The `--py36` option was deprecated in Black 19.3b0 (https://github.com/psf/black/pull/750):

> deprecated `--py36` (use `--target-version=py36` instead) (#724)

https://github.com/psf/black#193b0

It's been a year since it was deprecated, and has been deprecated in two releases (19.3b0 and 19.10b0).

Is it now time to remove the deprecation?

At least I think it would be good to remove before the non-prerelease Black release (https://github.com/psf/black/issues/517), and whilst still in beta too.
