### PR TITLE
Change black.vim error message to specify its origin.

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -14,7 +14,7 @@
 "    - restore cursor/window position after formatting
 
 if v:version < 700 || !has('python3')
-    echo "This script requires vim7.0+ with Python 3.6 support."
+    echo "The black.vim plugin requires vim7.0+ with Python 3.6 support."
     finish
 endif
 


### PR DESCRIPTION
Fixes #1230 .

This just changes the error message if the black.vim plugin is unable to load, to specify that it is coming from "The black.vim plugin" instead of "This script" when the user is viewing the message in vim.