### PR TITLE
Update README.md to include appropriate command to install Vim with Python 3 on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ nnoremap <F9> :Black<CR>
 ```
 
 **How to get Vim with Python 3.6?** On Ubuntu 17.10 Vim comes with Python 3.6 by
-default. On macOS with Homebrew run: `brew install vim --with-python3`. When building
+default. On macOS with Homebrew run: `brew install vim`. When building
 Vim from source, use: `./configure --enable-python3interp=yes`. There's many guides
 online how to do this.
 

--- a/README.md
+++ b/README.md
@@ -742,9 +742,9 @@ nnoremap <F9> :Black<CR>
 ```
 
 **How to get Vim with Python 3.6?** On Ubuntu 17.10 Vim comes with Python 3.6 by
-default. On macOS with Homebrew run: `brew install vim`. When building
-Vim from source, use: `./configure --enable-python3interp=yes`. There's many guides
-online how to do this.
+default. On macOS with Homebrew run: `brew install vim`. When building Vim from source,
+use: `./configure --enable-python3interp=yes`. There's many guides online how to do
+this.
 
 ### Visual Studio Code
 


### PR DESCRIPTION
The command currently listed in README.md to install Vim with Python 3 on macOS does not work since the `--with-python3` option is removed on [this commit](https://github.com/Homebrew/homebrew-core/commit/1a5a30703721b24198ef165059756ba35813511e). Python 3 support is [enabled by default](https://github.com/Homebrew/homebrew-core/blob/a64140c4640172fea60356137e1e04356c080d72/Formula/vim.rb#L51) on Vim via Homebrew as of 2020, so you don't have to specify the option now.