### PR TITLE
Add option for printing a colored diff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - reindent docstrings when reindenting code around it (#1053)
+- show colored diffs (#1266)
 
 ### 19.10b0
 

--- a/black.py
+++ b/black.py
@@ -381,6 +381,11 @@ def target_version_option_callback(
     help="Don't write the files back, just output a diff for each file on stdout.",
 )
 @click.option(
+    "--color",
+    is_flag=True,
+    help="Show colored diff. Only applies when `--diff` is given.",
+)
+@click.option(
     "--fast/--safe",
     is_flag=True,
     help="If --fast given, skip temporary sanity checks. [default: --safe]",
@@ -458,6 +463,7 @@ def main(
     target_version: List[TargetVersion],
     check: bool,
     diff: bool,
+    color: bool,
     fast: bool,
     pyi: bool,
     py36: bool,

--- a/black.py
+++ b/black.py
@@ -759,9 +759,7 @@ def format_file_in_place(
 
 
 def color_diff(contents: str) -> str:
-    """
-    Color the contents returned by `diff()`.
-    """
+    """Inject the ANSI color codes to the diff."""
     lines = contents.split("\n")
     for i, line in enumerate(lines):
         if line.startswith("+++") or line.startswith("---"):

--- a/black.py
+++ b/black.py
@@ -787,9 +787,10 @@ def wrap_stream_for_windows(
     try:
         from colorama import initialise
 
-        # These are the defaults for colorama.init()
+        # We set `strip=False` so that we can don't have to modify
+        # test_express_diff_with_color.
         f = initialise.wrap_stream(
-            f, convert=None, strip=None, autoreset=False, wrap=True
+            f, convert=None, strip=False, autoreset=False, wrap=True
         )
 
         # wrap_stream returns a `colorama.AnsiToWin32.AnsiToWin32` object

--- a/black.py
+++ b/black.py
@@ -39,6 +39,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    TYPE_CHECKING,
 )
 from typing_extensions import Final
 from mypy_extensions import mypyc_attr
@@ -59,9 +60,7 @@ from blib2to3.pgen2.parse import ParseError
 
 from _black_version import version as __version__
 
-# This is needed for MyPy static type analysis.
-# See https://stackoverflow.com/a/38962160/1354930
-if False:
+if TYPE_CHECKING:
     import colorama  # noqa: F401
 
 DEFAULT_LINE_LENGTH = 88

--- a/black.py
+++ b/black.py
@@ -795,11 +795,14 @@ def format_stdin_to_stdout(
         )
         if write_back == WriteBack.YES:
             f.write(dst)
-        elif write_back == WriteBack.DIFF:
+        elif write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
             now = datetime.utcnow()
             src_name = f"STDIN\t{then} +0000"
             dst_name = f"STDOUT\t{now} +0000"
-            f.write(diff(src, dst, src_name, dst_name))
+            d = diff(src, dst, src_name, dst_name)
+            if write_back == WriteBack.COLOR_DIFF:
+                d = color_diff(d)
+            f.write(d)
         f.detach()
 
 

--- a/black.py
+++ b/black.py
@@ -392,7 +392,7 @@ def target_version_option_callback(
     help="Don't write the files back, just output a diff for each file on stdout.",
 )
 @click.option(
-    "--color",
+    "--color/--no-color",
     is_flag=True,
     help="Show colored diff. Only applies when `--diff` is given.",
 )

--- a/black.py
+++ b/black.py
@@ -140,11 +140,17 @@ class WriteBack(Enum):
     YES = 1
     DIFF = 2
     CHECK = 3
+    COLOR_DIFF = 4
 
     @classmethod
-    def from_configuration(cls, *, check: bool, diff: bool) -> "WriteBack":
+    def from_configuration(
+        cls, *, check: bool, diff: bool, color: bool = False
+    ) -> "WriteBack":
         if check and not diff:
             return cls.CHECK
+
+        if diff and color:
+            return cls.COLOR_DIFF
 
         return cls.DIFF if diff else cls.YES
 
@@ -476,7 +482,7 @@ def main(
     config: Optional[str],
 ) -> None:
     """The uncompromising code formatter."""
-    write_back = WriteBack.from_configuration(check=check, diff=diff)
+    write_back = WriteBack.from_configuration(check=check, diff=diff, color=color)
     if target_version:
         if py36:
             err("Cannot use both --target-version and --py36")
@@ -724,7 +730,7 @@ def format_file_in_place(
     if write_back == WriteBack.YES:
         with open(src, "w", encoding=encoding, newline=newline) as f:
             f.write(dst_contents)
-    elif write_back == WriteBack.DIFF:
+    elif write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
         now = datetime.utcnow()
         src_name = f"{src}\t{then} +0000"
         dst_name = f"{src}\t{now} +0000"

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,10 @@ setup(
         "typing_extensions>=3.7.4",
         "mypy_extensions>=0.4.3",
     ],
-    extras_require={"d": ["aiohttp>=3.3.2", "aiohttp-cors"]},
+    extras_require={
+        "d": ["aiohttp>=3.3.2", "aiohttp-cors"],
+        "colorama": ["colorama>=0.4.3"],
+    },
     test_suite="tests.test_black",
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -264,6 +264,28 @@ class BlackTestCase(unittest.TestCase):
         actual = actual.rstrip() + "\n"  # the diff output has a trailing space
         self.assertEqual(expected, actual)
 
+    def test_piping_diff_with_color(self) -> None:
+        source, _ = read_data("expression.py")
+        config = THIS_DIR / "data" / "empty_pyproject.toml"
+        args = [
+            "-",
+            "--fast",
+            f"--line-length={black.DEFAULT_LINE_LENGTH}",
+            "--diff",
+            "--color",
+            f"--config={config}",
+        ]
+        result = BlackRunner().invoke(
+            black.main, args, input=BytesIO(source.encode("utf8"))
+        )
+        actual = result.output
+        # Again, the contents are checked in a different test, so only look for colors.
+        self.assertIn("\033[1;37m", actual)
+        self.assertIn("\033[36m", actual)
+        self.assertIn("\033[32m", actual)
+        self.assertIn("\033[31m", actual)
+        self.assertIn("\033[0m", actual)
+
     @patch("black.dump_to_file", dump_to_stderr)
     def test_function(self) -> None:
         source, expected = read_data("function")

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -352,6 +352,25 @@ class BlackTestCase(unittest.TestCase):
             )
             self.assertEqual(expected, actual, msg)
 
+    def test_expression_diff_with_color(self) -> None:
+        source, _ = read_data("expression.py")
+        expected, _ = read_data("expression.diff")
+        tmp_file = Path(black.dump_to_file(source))
+        try:
+            result = BlackRunner().invoke(
+                black.main, ["--diff", "--color", str(tmp_file)]
+            )
+        finally:
+            os.unlink(tmp_file)
+        actual = result.output
+        # We check the contents of the diff in `test_expression_diff`. All
+        # we need to check here is that color codes exist in the result.
+        self.assertIn("\033[1;37m", actual)
+        self.assertIn("\033[36m", actual)
+        self.assertIn("\033[32m", actual)
+        self.assertIn("\033[31m", actual)
+        self.assertIn("\033[0m", actual)
+
     @patch("black.dump_to_file", dump_to_stderr)
     def test_fstring(self) -> None:
         source, expected = read_data("fstring")


### PR DESCRIPTION
Fixes #994.

This adds a `--color` option to the black command line which adds very basic color support when printing diffs.

+ The coloring mimics `git diff` because why not. Headers are Bold White, line markers Cyan, subtractions Red, and additions Green.
+ There is no change to the default behavior.
+ `--color` has no effect if `--diff` is not supplied.


## Example:

![image](https://user-images.githubusercontent.com/5386897/74064762-3756f300-49a8-11ea-8f67-67b16fd76491.png)


## Discussion

+ As is, this will not work with Windows CMD or PowerShell. In order to enable Windows support, the `colorama` package should be included. I'm not sure how you feel about adding packages all willy-nilly, so I figured the first version of this PR would not include it.
+ I opted to add `COLOR_DIFF` to `WriteBack` because that meant I didn't have to change any call signatures.
+ An initial version used an enum for `--color` which let the user choose between `always`, `none`, and `auto`. This is still doable, but will take more effort. Personally I don't much see the need for it - using a boolean is sufficient in my opinion. That said, if you'd like me to pursue it just let me know.