### PR TITLE
Include an easier way to integrate black with Pycharm

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,9 @@ $ where black
 %LocalAppData%\Programs\Python\Python36-32\Scripts\black.exe  # possible location
 ```
 
+Note that if you are using a virtual environment detected by PyCharm, this is an unneeded step.
+In this case the path to `black` is `$PyInterpreterDirectory$/black`.
+
 3. Open External tools in PyCharm/IntelliJ IDEA
 
 On macOS:

--- a/README.md
+++ b/README.md
@@ -607,8 +607,8 @@ $ where black
 %LocalAppData%\Programs\Python\Python36-32\Scripts\black.exe  # possible location
 ```
 
-Note that if you are using a virtual environment detected by PyCharm, this is an unneeded step.
-In this case the path to `black` is `$PyInterpreterDirectory$/black`.
+Note that if you are using a virtual environment detected by PyCharm, this is an
+unneeded step. In this case the path to `black` is `$PyInterpreterDirectory$/black`.
 
 3. Open External tools in PyCharm/IntelliJ IDEA
 


### PR DESCRIPTION
According to the [documentation for external tools](https://www.jetbrains.com/help/pycharm/configuring-third-party-tools.html), you can use the macro `$PyInterpreterDirectory$` to get the base directory for external tools. This makes it easier to add `black` as a file-watcher.