### PR TITLE
Add -n flag to not print emojis

### DIFF
--- a/black.py
+++ b/black.py
@@ -61,6 +61,12 @@ DEFAULT_EXCLUDES = r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))
 
+# Emojis for output strings
+EMOJIS: Dict[str, str] = {
+    "all_done": " ✨ 🍰 ✨",
+    "oh_no": " 💥 💔 💥",
+    "nothing_to_do": " 😴",
+}
 
 # types
 FileContent = str
@@ -461,7 +467,10 @@ def main(
             err(f"invalid path: {s}")
     if len(sources) == 0:
         if verbose or not quiet:
-            out("No Python files are present to be formatted. Nothing to do 😴")
+            out(
+                "No Python files are present to be formatted."
+                f"Nothing to do{EMOJIS['nothing_to_do']}"
+            )
         ctx.exit(0)
 
     if len(sources) == 1:
@@ -478,7 +487,11 @@ def main(
         )
 
     if verbose or not quiet:
-        out("Oh no! 💥 💔 💥" if report.return_code else "All done! ✨ 🍰 ✨")
+        out(
+            f"Oh no!{EMOJIS['oh_no']}"
+            if report.return_code
+            else f"All done!{EMOJIS['all_done']}"
+        )
         click.secho(str(report), err=True)
     ctx.exit(report.return_code)
 
@@ -491,7 +504,7 @@ def path_empty(
     """
     if not src:
         if verbose or not quiet:
-            out("No Path provided. Nothing to do 😴")
+            out(f"No Path provided. Nothing to do{EMOJIS['nothing_to_do']}")
             ctx.exit(0)
 
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.** I want to be able to disable emojis from being printed on success/failure

**Describe the solution you'd like** Either emojis removed entirely, or an option that disables them (this merge request implements the latter in `-n/--no-emojis`)

**Describe alternatives you've considered** Running something like `black ... | sed 's/[^[:alnum:]]//g'` but this is bad design for obvious reasons. Also considered looking at any translation implementations (no emoji could be a 'dialect' of English), but I don't know how to do this in python.

