### PR TITLE
Remove deprecated use of 'setup.py test'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ assignees: ""
    - create a new virtualenv (make sure it's the same Python version);
    - clone this repository;
    - run `pip install -e .`;
-   - make sure it's sane by running `python setup.py test`; and
+   - make sure it's sane by running `python -m unittest`; and
    - run `black` like you did last time.
 
 **Additional context** Add any other context about the problem here.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
 
       - name: Unit tests
         run: |
-          coverage run tests/test_black.py
+          coverage run -m unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - $HOME/.cache/pre-commit
 env:
-  - TEST_CMD="coverage run tests/test_black.py"
+  - TEST_CMD="coverage run -m unittest"
 install:
   - pip install coverage coveralls pre-commit
   - pip install -e '.[d]'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ from the cloned _Black_ repo. It will do the correct thing.
 Before submitting pull requests, run tests with:
 
 ```
-$ python setup.py test
+$ python -m unittest
 ```
 
 ## Hygiene

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         "mypy_extensions>=0.4.3",
     ],
     extras_require={"d": ["aiohttp>=3.3.2", "aiohttp-cors"]},
-    test_suite="tests.test_black",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now use unittest as the test entry
point.