### PR TITLE
Example for using pre-commit args configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,15 +898,40 @@ repos:
 
 Then run `pre-commit install` and you're ready to go.
 
-Avoid using `args` in the hook. Instead, store necessary configuration in
-`pyproject.toml` so that editors and command-line usage of Black all behave consistently
-for your project. See _Black_'s own
+### Configuring pre-commit
+
+If you want a project-wide setting, you can store the necessary configuration in
+`pyproject.toml` so that pre-commit, editors and command-line invocation of Black all
+behave consistently for your project. See _Black_'s own
 [pyproject.toml](https://github.com/psf/black/blob/master/pyproject.toml) for an
 example.
+
+You can use `args` in the hook to separately customize how pre-commit should invoke
+_Black_.
 
 If you're already using Python 3.7, switch the `language_version` accordingly. Finally,
 `stable` is a tag that is pinned to the latest release on PyPI. If you'd rather run on
 master, this is also an option.
+
+`pre-commit` has
+[settings for all hooks](https://pre-commit.com/#adding-pre-commit-plugins-to-your-project)
+and [settings for each hook](https://pre-commit.com/#pre-commit-configyaml---hooks).
+
+```yaml
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        # Use Python 3.7
+        language_version: python3.7
+        # Customize options for black command
+        args: [--arg-for-black, "value", --flag-for-black]
+        # Include only these files
+        files: "^src/.*"
+        # Exclude patterns
+        exclude: "tests/.*$"
+```
 
 ## Ignoring unmodified files
 


### PR DESCRIPTION
I don't think it's sound advice to ask people to avoid using a configuration specifically targeting the pre-commit invocation.

For instance, pre-commit modifies files. Other invocations of black will use `--check`.

What would you think about adding an example for an expanded configuration of pre-commit?

CC: @asottile @ambv 

Refs https://github.com/psf/black/commit/489d00ed8f4fb90d5788609a474632ab5a16591f#diff-04c6e90faac2675aa89e2176d2eec7d8R733-R740