### PR TITLE
Prevent the vim plugin from importing system's black

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -128,7 +128,7 @@ def _initialize_black_env(upgrade=False):
   if first_install:
     print('Pro-tip: to upgrade Black in the future, use the :BlackUpgrade command and restart Vim.\n')
   if virtualenv_site_packages not in sys.path:
-    sys.path.append(virtualenv_site_packages)
+    sys.path.insert(0, virtualenv_site_packages)
   return True
 
 if _initialize_black_env():


### PR DESCRIPTION
This commit adds Black's venv before the system paths, so the plugin
imports from the venv even if Black is already installed elsewhere on the system.