### PR TITLE
Adding documentation to the README for import errors in vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _black_version.py
 .idea
 .eggs
 .dmypy.json
+*.swp

--- a/README.md
+++ b/README.md
@@ -814,37 +814,27 @@ The two packages that cause the problem are:
 - [regex](https://pypi.org/project/regex/)
 - [typed-ast](https://pypi.org/project/typed-ast/)
 
-To get the correct versions you need to execute this:
-
-```console
-$ source ~/.vim/black/bin/activate
-$ pip freeze | grep "\(regex\|typed-ast\)"
-regex==2020.2.20
-typed-ast==1.4.1
-```
-
 Now remove those two packages:
 
 ```console
 $ pip uninstall regex typed-ast -y
 ```
 
-Go to [`regex`'s release history](https://pypi.org/project/regex/#history), select the
-correct version and then click on _Download files_. Look for the `.tar.gz` file and
-download it.
-
-Repeat the same for [`typed-ast`](https://pypi.org/project/typed-ast/#history).
-
-Now install those packages:
+And now you can install them with:
 
 ```console
-$ cd your-download-directory
-$ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
+$ pip install --no-binary :all: regex typed-ast
 ```
 
 The C extensions will be compiled and now Vim's Python environment will match. Note that
 you need to have the GCC compiler and the Python development files installed (on
 Ubuntu/Debian do `sudo apt-get install build-essential python3-dev`).
+
+If you later want to update _Black_, you should do it like this:
+
+```console
+$ pip install -U black --no-binary regex,typed-ast
+```
 
 ### Visual Studio Code
 

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Repeat the same for [`typed-ast`](https://pypi.org/project/typed-ast/#history).
 
 Now install those packages:
 
-```bash
+```console
 $ cd your-download-directory
 $ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
 ```

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ and then click on *Download files*. Look for the `.tar.gz` file and download it.
 
 Repeat the same for [`typed-ast`](https://pypi.org/project/typed-ast/#history).
 
-Now install those packages
+Now install those packages:
 
 ```bash
 $ cd your-download-directory

--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cp
 
 Then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
 `pip` will download [Python wheels](https://pythonwheels.com/) if they are available. Python wheels
-are a new standard of distributing python packages and packages that have cython and extensions
+are a new standard of distributing Python packages and packages that have Cython and extensions
 written in C are already compiled, so the installation is much more faster. The problem here
 is that somehow the python environment inside `vim` does not match with those already compiled
 C extensions and these kind of errors are the result. Luckily there is an easy fix: installing

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ Traceback (most recent call last):
 ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cpython-37m-x86_64-linux-gnu.so: undefined symbool: PyExc_KeyboardInterrupt
 ```
 
-then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
+Then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
 `pip` will download [Python Wheels](https://pythonwheels.com/) if they are available. Python wheels
 are a new standard of distributing python packages and packages that have cython and extensions
 written in C are already compiled, so the installation is much more faster. The problem here

--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ $ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
 ```
 
 The C extensions will be compiled and now Vim's Python environment will match. Note that you need to have
-the GCC compiler and the python development files installed (on Ubuntu/Debian
+the GCC compiler and the Python development files installed (on Ubuntu/Debian
 do `sudo apt-get install build-essential python3-dev`).
 
 

--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ Then you need to install `typed_ast` and `regex` directly from the source code. 
 `pip` will download [Python wheels](https://pythonwheels.com/) if they are available. Python wheels
 are a new standard of distributing Python packages and packages that have Cython and extensions
 written in C are already compiled, so the installation is much more faster. The problem here
-is that somehow the python environment inside `vim` does not match with those already compiled
+is that somehow the Python environment inside Vim does not match with those already compiled
 C extensions and these kind of errors are the result. Luckily there is an easy fix: installing
 the packages from the source code.
 

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ regex==2020.2.20
 typed-ast==1.4.1
 ```
 
-Now remove those two packages
+Now remove those two packages:
 
 ```bash
 $ pip uninstall regex typed-ast -y

--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ default. On macOS with Homebrew run: `brew install vim`. When building Vim from 
 use: `./configure --enable-python3interp=yes`. There's many guides online how to do
 this.
 
-**I get an import error when using Black from a virtual environment**: If you get an error
+**I get an import error when using _Black_ from a virtual environment**: If you get an error
 message like this
 
 ```text

--- a/README.md
+++ b/README.md
@@ -787,6 +787,64 @@ default. On macOS with Homebrew run: `brew install vim`. When building Vim from 
 use: `./configure --enable-python3interp=yes`. There's many guides online how to do
 this.
 
+**I get an import error when using Black from a virtual environment**: If you get an error
+message like this
+
+```text
+Traceback (most recent call last):
+  File "<string>", line 63, in <module>
+  File "/home/gui/.vim/black/lib/python3.7/site-packages/black.py", line 45, in <module>
+    from typed_ast import ast3, ast27
+  File "/home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/ast3.py", line 40, in <module>
+    from typed_ast import _ast3
+ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cpython-37m-x86_64-linux-gnu.so: undefined symbo
+```
+
+then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
+`pip` will download [Python Wheels](https://pythonwheels.com/) if they are available. Python wheels
+are a new standard of distributing python packages and packages that have cython and extensions
+written in C are already compiled, so the installation is much more faster. The problem here
+is that somehow the python environment inside `vim` does not match with those already compiled
+C extensions and these kind of errors are the result. Luckily there is an easy fix: installing
+the packages from the source code.
+
+The two packages that cause the problem are:
+
+- [regex](https://pypi.org/project/regex/)
+- [typed-ast](https://pypi.org/project/typed-ast/)
+
+To get the correct versions you need to execute this:
+
+```bash
+$ source ~/.vim/black/bin/activate
+$ pip freeze | grep "\(regex\|typed-ast\)"
+regex==2020.2.20
+typed-ast==1.4.1
+```
+
+Now remove those two packages
+
+```bash
+$ pip uninstall regex typed-ast -y
+```
+
+Go to [`regex`'s release history](https://pypi.org/project/regex/#history), select the correct version
+and then click on *Download files*. Look for the `.tar.gz` file and download it.
+
+Repeat the same for [`typed-ast`](https://pypi.org/project/typed-ast/#history).
+
+Now install those packages
+
+```bash
+$ cd your-download-directory
+$ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
+```
+
+The C extensions will be compiled and now vim's python environment will match. Note that you need to have
+the GCC compiler and the python development files installed (on Ubuntu/Debian
+do `sudo apt-get install build-essential python3-dev`).
+
+
 ### Visual Studio Code
 
 Use the

--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cp
 ```
 
 Then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
-`pip` will download [Python Wheels](https://pythonwheels.com/) if they are available. Python wheels
+`pip` will download [Python wheels](https://pythonwheels.com/) if they are available. Python wheels
 are a new standard of distributing python packages and packages that have cython and extensions
 written in C are already compiled, so the installation is much more faster. The problem here
 is that somehow the python environment inside `vim` does not match with those already compiled

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ typed-ast==1.4.1
 
 Now remove those two packages:
 
-```bash
+```console
 $ pip uninstall regex typed-ast -y
 ```
 

--- a/README.md
+++ b/README.md
@@ -787,8 +787,8 @@ default. On macOS with Homebrew run: `brew install vim`. When building Vim from 
 use: `./configure --enable-python3interp=yes`. There's many guides online how to do
 this.
 
-**I get an import error when using _Black_ from a virtual environment**: If you get an error
-message like this:
+**I get an import error when using _Black_ from a virtual environment**: If you get an
+error message like this:
 
 ```text
 Traceback (most recent call last):
@@ -800,13 +800,14 @@ Traceback (most recent call last):
 ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cpython-37m-x86_64-linux-gnu.so: undefined symbool: PyExc_KeyboardInterrupt
 ```
 
-Then you need to install `typed_ast` and `regex` directly from the source code. The error happens because
-`pip` will download [Python wheels](https://pythonwheels.com/) if they are available. Python wheels
-are a new standard of distributing Python packages and packages that have Cython and extensions
-written in C are already compiled, so the installation is much more faster. The problem here
-is that somehow the Python environment inside Vim does not match with those already compiled
-C extensions and these kind of errors are the result. Luckily there is an easy fix: installing
-the packages from the source code.
+Then you need to install `typed_ast` and `regex` directly from the source code. The
+error happens because `pip` will download [Python wheels](https://pythonwheels.com/) if
+they are available. Python wheels are a new standard of distributing Python packages and
+packages that have Cython and extensions written in C are already compiled, so the
+installation is much more faster. The problem here is that somehow the Python
+environment inside Vim does not match with those already compiled C extensions and these
+kind of errors are the result. Luckily there is an easy fix: installing the packages
+from the source code.
 
 The two packages that cause the problem are:
 
@@ -828,8 +829,9 @@ Now remove those two packages:
 $ pip uninstall regex typed-ast -y
 ```
 
-Go to [`regex`'s release history](https://pypi.org/project/regex/#history), select the correct version
-and then click on *Download files*. Look for the `.tar.gz` file and download it.
+Go to [`regex`'s release history](https://pypi.org/project/regex/#history), select the
+correct version and then click on _Download files_. Look for the `.tar.gz` file and
+download it.
 
 Repeat the same for [`typed-ast`](https://pypi.org/project/typed-ast/#history).
 
@@ -840,10 +842,9 @@ $ cd your-download-directory
 $ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
 ```
 
-The C extensions will be compiled and now Vim's Python environment will match. Note that you need to have
-the GCC compiler and the Python development files installed (on Ubuntu/Debian
-do `sudo apt-get install build-essential python3-dev`).
-
+The C extensions will be compiled and now Vim's Python environment will match. Note that
+you need to have the GCC compiler and the Python development files installed (on
+Ubuntu/Debian do `sudo apt-get install build-essential python3-dev`).
 
 ### Visual Studio Code
 

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ use: `./configure --enable-python3interp=yes`. There's many guides online how to
 this.
 
 **I get an import error when using _Black_ from a virtual environment**: If you get an error
-message like this
+message like this:
 
 ```text
 Traceback (most recent call last):

--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ $ cd your-download-directory
 $ pip install regex-2020.2.20.tar.gz typed_ast-1.4.1.tar.gz
 ```
 
-The C extensions will be compiled and now vim's python environment will match. Note that you need to have
+The C extensions will be compiled and now Vim's Python environment will match. Note that you need to have
 the GCC compiler and the python development files installed (on Ubuntu/Debian
 do `sudo apt-get install build-essential python3-dev`).
 

--- a/README.md
+++ b/README.md
@@ -797,7 +797,7 @@ Traceback (most recent call last):
     from typed_ast import ast3, ast27
   File "/home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/ast3.py", line 40, in <module>
     from typed_ast import _ast3
-ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cpython-37m-x86_64-linux-gnu.so: undefined symbo
+ImportError: /home/gui/.vim/black/lib/python3.7/site-packages/typed_ast/_ast3.cpython-37m-x86_64-linux-gnu.so: undefined symbool: PyExc_KeyboardInterrupt
 ```
 
 then you need to install `typed_ast` and `regex` directly from the source code. The error happens because

--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ The two packages that cause the problem are:
 
 To get the correct versions you need to execute this:
 
-```bash
+```console
 $ source ~/.vim/black/bin/activate
 $ pip freeze | grep "\(regex\|typed-ast\)"
 regex==2020.2.20


### PR DESCRIPTION
I had the same issue as psf/black#1148 and have been searching for a
solution to this. I realized that you cannot fix it by change anything
in the code, but by re-compiling the C extensions of regex and
typed-ast. Installing this packages from the tarballs solves the
problem.