### PR TITLE
Fixing the documentation of how to install the vim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ Configuration:
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'psf/black'
+Plug 'psf/black', { 'branch': 'stable' }
 ```
 
 or with [Vundle](https://github.com/VundleVim/Vundle.vim):
@@ -747,8 +747,15 @@ or with [Vundle](https://github.com/VundleVim/Vundle.vim):
 Plugin 'psf/black'
 ```
 
+and execute the following in a terminal:
+
+```console
+$ cd ~/.ssh/bundle/black
+$ git checkout origin/stable -b stable
+```
+
 or you can copy the plugin from
-[plugin/black.vim](https://github.com/psf/black/tree/master/plugin/black.vim).
+[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim).
 
 ```
 mkdir -p ~/.vim/pack/python/start/black/plugin

--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ Plugin 'psf/black'
 and execute the following in a terminal:
 
 ```console
-$ cd ~/.ssh/bundle/black
+$ cd ~/.vim/bundle/black
 $ git checkout origin/stable -b stable
 ```
 


### PR DESCRIPTION
Solves the installation problem that currently exists because the current master branch is not stable. See psf/black#1304 for more information.