### PR TITLE
Omit commit hash and date stamp from doc version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import string
 
-from setuptools_scm import get_version
+from pkg_resources import get_distribution
 from recommonmark.parser import CommonMarkParser
 
 
@@ -83,8 +83,8 @@ copyright = "2018, Łukasz Langa and contributors to Black"
 author = "Łukasz Langa and contributors to Black"
 
 # Autopopulate version
-# The full version, including alpha/beta/rc tags.
-release = get_version(root=CURRENT_DIR.parent)
+# The version, including alpha/beta/rc tags, but not commit hash and datestamps
+release = get_distribution("black").version.split("+")[0]
 # The short X.Y version.
 version = release
 for sp in "abcfr":

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 recommonmark==0.4.0
 Sphinx==1.7.2
-setuptools_scm==3.3.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,5 @@ python:
   version: 3.8
   install:
     - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .


### PR DESCRIPTION
This also removes the dependency on setuptools-scm while building the
docs.

Fixes #1104.