### PR TITLE
Fix for "# fmt: on" with decorators

### DIFF
--- a/tests/data/fmtonoff4.py
+++ b/tests/data/fmtonoff4.py
@@ -1,0 +1,31 @@
+# fmt: off
+@test([
+    1, 2,
+    3, 4,
+])
+# fmt: on
+def f(): pass
+
+@test([
+    1, 2,
+    3, 4,
+])
+def f(): pass
+
+# output
+
+# fmt: off
+@test([
+    1, 2,
+    3, 4,
+])
+# fmt: on
+def f():
+    pass
+
+
+@test(
+    [1, 2, 3, 4,]
+)
+def f():
+    pass

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -633,6 +633,14 @@ class BlackTestCase(unittest.TestCase):
         black.assert_stable(source, actual, black.FileMode())
 
     @patch("black.dump_to_file", dump_to_stderr)
+    def test_fmtonoff4(self) -> None:
+        source, expected = read_data("fmtonoff4")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode())
+
+    @patch("black.dump_to_file", dump_to_stderr)
     def test_remove_empty_parentheses_after_class(self) -> None:
         source, expected = read_data("class_blank_parentheses")
         actual = fs(source)


### PR DESCRIPTION
This is quick and likely dirty fix for #560. It is based on assumption that indentation has semantic meaning in Python so in case if `# fmt: on` exists in node children at the same column as opening `# fmt: off` we should process each child separately excluding only those before `# fmt: on`.

This seems to work for my use case which is blocking black adoption in my team and doesn't break any tests but it would be great if someone with more experience in codebase could help to polish it because I dived into black source code only two hours ago.

Thanks!