### PR TITLE
Fix for "# fmt: on" with decorators

### DIFF
--- a/black.py
+++ b/black.py
@@ -3109,33 +3109,40 @@ def generate_ignored_nodes(leaf: Leaf) -> Iterator[LN]:
     """
     container: Optional[LN] = container_of(leaf)
     while container is not None and container.type != token.ENDMARKER:
-        is_fmt_on = False
-        for comment in list_comments(container.prefix, is_endmarker=False):
-            if comment.value in FMT_ON:
-                is_fmt_on = True
-            elif comment.value in FMT_OFF:
-                is_fmt_on = False
-        if is_fmt_on:
+        if fmt_on(container):
             return
 
         # fix for fmt: on in children
         if contains_fmt_on_at_column(container, leaf.column):
             for child in container.children:
-                if not contains_fmt_on_at_column(child, leaf.column):
-                    yield child
-            return
+                if contains_fmt_on_at_column(child, leaf.column):
+                    return
+                yield child
         else:
             yield container
             container = container.next_sibling
 
 
+def fmt_on(container):
+    is_fmt_on = False
+    for comment in list_comments(container.prefix, is_endmarker=False):
+        if comment.value in FMT_ON:
+            is_fmt_on = True
+        elif comment.value in FMT_OFF:
+            is_fmt_on = False
+    return is_fmt_on
+
+
 def contains_fmt_on_at_column(container, column):
     for child in container.children:
-        if (isinstance(child, Node) and first_leaf_column(child) == column
-            or isinstance(child, Leaf) and child.column == column):
-            for comment in list_comments(child.prefix, is_endmarker=False):
-                if comment.value in FMT_ON:
-                    return True
+        if (
+            isinstance(child, Node)
+            and first_leaf_column(child) == column
+            or isinstance(child, Leaf)
+            and child.column == column
+        ):
+            if fmt_on(child):
+                return True
 
     return False
 

--- a/black.py
+++ b/black.py
@@ -3123,7 +3123,7 @@ def generate_ignored_nodes(leaf: Leaf) -> Iterator[LN]:
             container = container.next_sibling
 
 
-def fmt_on(container):
+def fmt_on(container: LN) -> bool:
     is_fmt_on = False
     for comment in list_comments(container.prefix, is_endmarker=False):
         if comment.value in FMT_ON:
@@ -3133,7 +3133,7 @@ def fmt_on(container):
     return is_fmt_on
 
 
-def contains_fmt_on_at_column(container, column):
+def contains_fmt_on_at_column(container: LN, column: int) -> bool:
     for child in container.children:
         if (
             isinstance(child, Node)
@@ -3147,7 +3147,7 @@ def contains_fmt_on_at_column(container, column):
     return False
 
 
-def first_leaf_column(node):
+def first_leaf_column(node: Node) -> Optional[int]:
     for child in node.children:
         if isinstance(child, Leaf):
             return child.column

--- a/tests/data/fmtonoff4.py
+++ b/tests/data/fmtonoff4.py
@@ -1,0 +1,31 @@
+# fmt: off
+@test([
+    1, 2,
+    3, 4,
+])
+# fmt: on
+def f(): pass
+
+@test([
+    1, 2,
+    3, 4,
+])
+def f(): pass
+
+# output
+
+# fmt: off
+@test([
+    1, 2,
+    3, 4,
+])
+# fmt: on
+def f():
+    pass
+
+
+@test(
+    [1, 2, 3, 4,]
+)
+def f():
+    pass

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -633,6 +633,14 @@ class BlackTestCase(unittest.TestCase):
         black.assert_stable(source, actual, black.FileMode())
 
     @patch("black.dump_to_file", dump_to_stderr)
+    def test_fmtonoff4(self) -> None:
+        source, expected = read_data("fmtonoff4")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, black.FileMode())
+
+    @patch("black.dump_to_file", dump_to_stderr)
     def test_remove_empty_parentheses_after_class(self) -> None:
         source, expected = read_data("class_blank_parentheses")
         actual = fs(source)


### PR DESCRIPTION
Re-submitting #1324 using correct email.

This is quick and likely dirty fix for #560. It is based on assumption that indentation has semantic meaning in Python so in case if `# fmt: on` exists in node children at the same column as opening `# fmt: off` we should process each child separately excluding only those before `# fmt: on`.

This seems to work for my use case which is blocking black adoption in my team and doesn't break any tests but it would be great if someone with more experience in codebase could help to polish it because I dived into black source code only two hours ago.

Thanks!