### PR TITLE
Add Dropbox as a user of Black

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,8 @@ code style: pytest, tox, Pyramid, Django Channels, Hypothesis, attrs, SQLAlchemy
 Poetry, PyPA applications (Warehouse, Pipenv, virtualenv), pandas, Pillow, every Datadog
 Agent Integration, Home Assistant.
 
+The following organizations use _Black_: Dropbox.
+
 Are we missing anyone? Let us know.
 
 ## Testimonials


### PR DESCRIPTION
We've been using Black on >1 million lines of Python for a few months.