### PR TITLE
Change exit code to 2 when config file doesn't exist

### DIFF
--- a/black.py
+++ b/black.py
@@ -394,7 +394,7 @@ def target_version_option_callback(
 @click.option(
     "--config",
     type=click.Path(
-        exists=False, file_okay=True, dir_okay=False, readable=True, allow_dash=False
+        exists=True, file_okay=True, dir_okay=False, readable=True, allow_dash=False
     ),
     is_eager=True,
     callback=read_pyproject_toml,

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1645,6 +1645,16 @@ class BlackTestCase(unittest.TestCase):
                 raise result.exception
             self.assertEqual(result.exit_code, 0)
 
+    def test_invalid_config_return_code(self) -> None:
+        tmp_file = Path(black.dump_to_file())
+        try:
+            tmp_config = Path(black.dump_to_file())
+            tmp_config.unlink()
+            args = ["--config", str(tmp_config), str(tmp_file)]
+            self.invokeBlack(args, exit_code=2, ignore_config=False)
+        finally:
+            tmp_file.unlink()
+
 
 class BlackDTestCase(AioHTTPTestCase):
     async def get_application(self) -> web.Application:


### PR DESCRIPTION
Fixes #1360, where an invalid config file causes a return/exit code of 1. This change means this case is caught earlier, treated like any other bad parameters, and results in an exit code of 2.

Unit test fails before change is made:

```
======================================================================
FAIL: test_invalid_config_return_code (tests.test_black.BlackTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "<snip>/black/tests/test_black.py", line 1654, in test_invalid_config_return_code
    self.invokeBlack(args, exit_code=2, ignore_config=False)
  File "<snip>/black/tests/test_black.py", line 162, in invokeBlack
    self.assertEqual(result.exit_code, exit_code, msg=runner.stderr_bytes.decode())
AssertionError: 1 != 2 : Error: Could not open file <snip>/blk_h9d894at.log: Error reading configuration file: [Errno 2] No such file or directory: '<snip>/blk_h9d894at.log'
```
