### PR TITLE
Make sure sys._base_executable is sane in Vim plugin

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -117,6 +117,12 @@ def _initialize_black_env(upgrade=False):
       print(f'Creating a virtualenv in {virtualenv_path}...')
       print('(this path can be customized in .vimrc by setting g:black_virtualenv)')
       venv.create(virtualenv_path, with_pip=True)
+    except Exception:
+      print('Encountered exception while creating virtualenv (see traceback below).')
+      print(f'Removing {virtualenv_path}...')
+      import shutil
+      shutil.rmtree(virtualenv_path)
+      raise
     finally:
       sys.executable = _executable
     first_install = True

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -111,7 +111,9 @@ def _initialize_black_env(upgrade=False):
     print('Please wait, one time setup for Black.')
     _executable = sys.executable
     try:
-      sys.executable = str(_get_python_binary(Path(sys.exec_prefix)))
+      executable = str(_get_python_binary(Path(sys.exec_prefix)))
+      sys.executable = executable
+      sys._base_executable = executable
       print(f'Creating a virtualenv in {virtualenv_path}...')
       print('(this path can be customized in .vimrc by setting g:black_virtualenv)')
       venv.create(virtualenv_path, with_pip=True)

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -110,6 +110,7 @@ def _initialize_black_env(upgrade=False):
   if not virtualenv_path.is_dir():
     print('Please wait, one time setup for Black.')
     _executable = sys.executable
+    _base_executable = getattr(sys, "_base_executable", _executable)
     try:
       executable = str(_get_python_binary(Path(sys.exec_prefix)))
       sys.executable = executable
@@ -125,6 +126,7 @@ def _initialize_black_env(upgrade=False):
       raise
     finally:
       sys.executable = _executable
+      sys._base_executable = _base_executable
     first_install = True
   if first_install:
     print('Installing Black with pip...')


### PR DESCRIPTION
Resolves #1379.

At least in Python 3.8, [the `venv` module relies on `sys._base_executable` to determine the Python executable to run](https://github.com/python/cpython/blob/f25fb6ebfec894c01bc927c9aae7924ffc826d11/Lib/venv/__init__.py#L117), but with recent versions of Vim (8.2.654 from Homebrew on macOS), this attribute is set to the *Vim* executable instead of Python: running `:python3 import sys; print(sys._base_executable)` prints `/usr/local/bin/vim`. This makes the Black Vim plugin one-time setup (i.e. virtualenv creation and Black Python package installation) fail at the ensurepip stage (because `vim -Im ensurepip ...` doesn't make any sense).

A possible workaround is to just override the `sys._base_executable` attribute, especially since the Black plugin already overrides `sys.executable` (possibly for similar reasons?) anyway. This is what the present patch does.

More generally though, is this intended behavior or a bug in recent versions of Python and/or Vim? I'm leaning towards a bug in Vim, since running `:python3 import sys; print(sys._base_executable)` in Neovim correctly prints a Python path, even with Python 3.8. Just trying to figure out whether this should be reported somewhere else as well :)