### PR TITLE
Move to 'py3' tagged wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-python-tag = py36
-
 [options]
 setup_requires = setuptools_scm


### PR DESCRIPTION
- This makes black wheels to be tagged as py3 default
- `python_requires=">=3.6"` ensures we are >= 3.6

Test:
```
python3 -m venv /tmp/build_black
/tmp/build_black/bin/pip install --upgrade pip setuptools wheel
/tmp/build_black/bin/python setup.py bdist_wheel
...
black-19.10b1.dev53+g81bf9bb.d20200508-py3-none-any.whl
```

Addresses #1385