### PR TITLE
Add docstrings to fmt checking functions, add to docs

### DIFF
--- a/docs/reference/reference_functions.rst
+++ b/docs/reference/reference_functions.rst
@@ -135,6 +135,12 @@ Utilities
 
 .. autofunction:: black.generate_ignored_nodes
 
+.. autofunction:: black.is_fmt_on
+
+.. autofunction:: black.contains_fmt_on_at_column
+
+.. autofunction:: black.first_leaf_column
+
 .. autofunction:: black.generate_trailers_to_omit
 
 .. autofunction:: black.get_future_imports


### PR DESCRIPTION
Follow up from #1325

Adds docstrings to the fmt checking functions.
Renames fmt_on to is_fmt_on.
Adds the functions to the autodocs.