### PR TITLE
Test on Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       python: 3.7
     - name: "3.8"
       python: 3.8
+    - name: "3.9"
+      python: 3.9-dev
 before_deploy:
   - pip install pyinstaller
   - pyinstaller --clean -F --add-data blib2to3/:blib2to3 black.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       python: 3.8
     - name: "3.9"
       python: 3.9-dev
+  allow_failures:
+    - python: 3.9-dev
 before_deploy:
   - pip install pyinstaller
   - pyinstaller --clean -F --add-data blib2to3/:blib2to3 black.py


### PR DESCRIPTION
Python 3.9 is currently in alpha with a beta due in a couple of weeks (2020-05-18).

* https://www.python.org/dev/peps/pep-0596/#schedule

This PR tests `3.9-dev` on Travis CI, currently Python 3.9.0a6+.

However, it's failing, so as a pre-release I put it in the `allow_failures` so it won't turn the whole CI red.

The error is:
```
======================================================================
ERROR: tests.test_black (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.test_black
Traceback (most recent call last):
  File "/opt/python/3.9-dev/lib/python3.9/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/opt/python/3.9-dev/lib/python3.9/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/travis/build/hugovk/black/tests/test_black.py", line 20, in <module>
    import black
  File "/home/travis/build/hugovk/black/black.py", line 140, in <module>
    TMatchResult = TResult[Index]
  File "/opt/python/3.9-dev/lib/python3.9/typing.py", line 244, in inner
    return func(*args, **kwds)
  File "/opt/python/3.9-dev/lib/python3.9/typing.py", line 704, in __getitem__
    arg = arg[subargs]
  File "/opt/python/3.9-dev/lib/python3.9/typing.py", line 244, in inner
    return func(*args, **kwds)
  File "/opt/python/3.9-dev/lib/python3.9/typing.py", line 695, in __getitem__
    _check_generic(self, params)
  File "/opt/python/3.9-dev/lib/python3.9/typing.py", line 194, in _check_generic
    raise TypeError(f"{cls} is not a generic class")
TypeError: black.Err[black.CannotTransform] is not a generic class
```

https://travis-ci.org/github/hugovk/black/jobs/684724917