### PR TITLE
Handle ImportError from multiprocessing module

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -662,9 +662,9 @@ def reformat_many(
         worker_count = min(worker_count, 61)
     try:
         executor = ProcessPoolExecutor(max_workers=worker_count)
-    except OSError:
+    except (ImportError, OSError):
         # we arrive here if the underlying system does not support multi-processing
-        # like in AWS Lambda, in which case we gracefully fallback to
+        # like in AWS Lambda or Termux, in which case we gracefully fallback to
         # a ThreadPollExecutor with just a single worker (more workers would not do us
         # any good due to the Global Interpreter Lock)
         executor = ThreadPoolExecutor(max_workers=1)


### PR DESCRIPTION
Termux's Python environment doesn't provide sem_open, but fails with a nested `ImportError` on import attempts:

```
ImportError: cannot import name 'SemLock' from '_multiprocessing'
```

This updates the existing handling for AWS Lambda to catch both `OSError` and `ImportError`.

---

<details>

<summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/synchronize.py", line 28, in <module>
    from _multiprocessing import SemLock, sem_unlink
ImportError: cannot import name 'SemLock' from '_multiprocessing' (/data/data/com.termux/files/usr/lib/python3.8/lib-dynload/_multiprocessing.cpython-38.so)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/black.py", line 4135, in patched_main
    main()
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/black.py", line 535, in main
    reformat_many(
  File "/data/data/com.termux/files/usr/lib/python3.8/site-packages/black.py", line 664, in reformat_many
    executor = ProcessPoolExecutor(max_workers=worker_count)
  File "/data/data/com.termux/files/usr/lib/python3.8/concurrent/futures/process.py", line 555, in __init__
    self._call_queue = _SafeQueue(
  File "/data/data/com.termux/files/usr/lib/python3.8/concurrent/futures/process.py", line 165, in __init__
    super().__init__(max_size, ctx=ctx)
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/queues.py", line 42, in __init__
    self._rlock = ctx.Lock()
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/context.py", line 67, in Lock
    from .synchronize import Lock
  File "/data/data/com.termux/files/usr/lib/python3.8/multiprocessing/synchronize.py", line 30, in <module>
    raise ImportError("This platform lacks a functioning sem_open" +
ImportError: This platform lacks a functioning sem_open implementation, therefore, the required synchronization primitives needed will not function, see issue 3770.
```

</details>