### PR TITLE
Fix Boolean values in pyproject.toml config

### DIFF
--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -96,9 +96,9 @@ line_length = 88
 ```toml
 [tool.isort]
 multi_line_output = 3
-include_trailing_comma = True
+include_trailing_comma = true
 force_grid_wrap = 0
-use_parentheses = True
+use_parentheses = true
 line_length = 88
 ```
 


### PR DESCRIPTION
Boolean values use lowercase identifiers in TOML.
https://github.com/toml-lang/toml#user-content-boolean