### PR TITLE
Document git's ignore-revs-file feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Actual details on _Black_ compatible configurations for various tools can be fou
 ### Migrating your code style without ruining git blame
 
 A long-standing counterargument against moving to automated code formatters like _Black_
-is that the migration will clutter up the output of `git blame`. This used to be a valid
-argument, but not anymore. Since `git` version 2.23, git natively supports
+is that the migration will clutter up the output of `git blame`. This was a valid
+argument, but since `git` version 2.23, git natively supports
 [ignoring revisions in blame](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)
 with the `--ignore-rev` option. You can also pass a file listing the revisions to ignore
 using the `--ignore-revs-file` option. The changes made by the revision will be ignored

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Actual details on _Black_ compatible configurations for various tools can be fou
 
 ### Migrating your code style without ruining git blame
 
-A long-standing counterargument against moving to automated code formatters like _Black_
-is that the migration will clutter up the output of `git blame`. This was a valid
-argument, but since `git` version 2.23, git natively supports
+A long-standing argument against moving to automated code formatters like _Black_ is
+that the migration will clutter up the output of `git blame`. This was a valid argument,
+but since `git` version 2.23, git natively supports
 [ignoring revisions in blame](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)
 with the `--ignore-rev` option. You can also pass a file listing the revisions to ignore
 using the `--ignore-revs-file` option. The changes made by the revision will be ignored

--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ $ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 **The one caveat is that GitHub and GitLab do not yet support ignoring revisions using
 in their native UI of blame.** So blame information will be cluttered with a reformating
-commit on those platforms.
+commit on those platforms. (If you'd like this feature, there's an open issue for
+[GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/31423) and please let GitHub
+know!)
 
 ### NOTE: This is a beta product
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,48 @@ should be configured to neither warn about nor overwrite _Black_'s changes.
 Actual details on _Black_ compatible configurations for various tools can be found in
 [compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md).
 
+### Migrating your code style without ruining git blame
+
+A long-standing counterargument against moving to automated code formatters like _Black_
+is that the migration will clutter up the output of `git blame`. This used to be a valid
+argument, but not anymore. Since `git` version 2.23, git natively supports
+[ignoring revisions in blame](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)
+with the `--ignore-rev` option. You can also pass a file listing the revisions to ignore
+using the `--ignore-revs-file` option. The changes made by the revision will be ignored
+when assigning blame. Lines modified by an ignored revision will be blamed on the
+previous revision that modified those lines.
+
+So when migrating your project's code style to _Black_, reformat everything and commit
+the changes (preferably in one massive commit). Then put the full 40 characters commit
+identifier(s) into a file.
+
+```
+# Migrate code style to Black
+5b4ab991dede475d393e9d69ec388fd6bd949699
+```
+
+Afterwards, you can pass that file to `git blame` and see clean amd meaningful blame
+information.
+
+```
+$ git blame important.py --ignore-revs-file .git-blame-ignore-revs
+7a1ae265 (John Smith 2019-04-15 15:55:13 -0400 1) def very_important_function(text, file):
+abdfd8b0 (Alice Doe  2019-09-23 11:39:32 -0400 2)     text = text.lstrip()
+7a1ae265 (John Smith 2019-04-15 15:55:13 -0400 3)     with open(file, "r+") as f:
+7a1ae265 (John Smith 2019-04-15 15:55:13 -0400 4)         f.write(formatted)
+```
+
+You can even configure `git` to automatically ignore revisions listed in a file on every
+call to `git blame`.
+
+```shell
+$ git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+**The one caveat is that GitHub and GitLab do not yet support ignoring revisions using
+in their native UI of blame.** So blame information will be cluttered with a reformating
+commit on those platforms.
+
 ### NOTE: This is a beta product
 
 _Black_ is already [successfully used](#used-by) by many projects, small and big. It


### PR DESCRIPTION
Resolves #1408.

## Commit message
A long-standing counterargument against moving to automated code formatters
like Black is that the migration will clutter up the output of git blame.
This used to be a valid argument, but not anymore. Since git version 2.23,
git natively supports ignoring revisions in blame with the --ignore-rev
and --ignore-revs-file options.

This isn't documented in the Black documentation. It should be as it would
put old projects wanting to migrate to Black at ease since blame won't
be ruined.

---

I personally don't like where the section is currently located. The `Installation and usage` has enough information already, but I frankly don't know where it should go. Suggestions are more than welcomed!