### PR TITLE
black-primer: handle singular and plural in output messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ Use [python-black](https://atom.io/packages/python-black).
 
 ### Kakoune
 
-Add the following hook to your kakrc, then run black with `:format`.
+Add the following hook to your kakrc, then run _Black_ with `:format`.
 
 ```
 hook global WinSetOption filetype=python %{
@@ -1151,7 +1151,7 @@ If you're running locally yourself to test black on lots of code try:
 ```text
 Usage: black-primer [OPTIONS]
 
-  primer - prime projects for blackening ... 🏴
+  primer - prime projects for blackening... 🏴
 
 Options:
   -c, --config PATH      JSON config file path  [default: /Users/cooper/repos/
@@ -1173,7 +1173,7 @@ Options:
 
 ### primer config file
 
-The config is `JSON` format. It's main element is the `"projects"` dictionary. Below
+The config is JSON format. Its main element is the `"projects"` dictionary. Below
 explains each parameter:
 
 ```json
@@ -1201,17 +1201,17 @@ explains each parameter:
 
 ```console
 cooper-mbp:black cooper$ ~/venvs/b/bin/black-primer
-[2020-05-17 13:06:40,830] INFO: 4 projects to run black over (lib.py:270)
+[2020-05-17 13:06:40,830] INFO: 4 projects to run Black over (lib.py:270)
 [2020-05-17 13:06:44,215] INFO: Analyzing results (lib.py:285)
 -- primer results 📊 --
 
 3 / 4 succeeded (75.0%) ✅
 1 / 4 FAILED (25.0%) 💩
- - 0 projects Disabled by config
- - 0 projects skipped due to Python Version
+ - 0 projects disabled by config
+ - 0 projects skipped due to Python version
  - 0 skipped due to long checkout
 
-Failed Projects:
+Failed projects:
 
 ## flake8-bugbear:
  - Returned 1

--- a/src/black_primer/cli.py
+++ b/src/black_primer/cli.py
@@ -109,7 +109,7 @@ async def async_main(
     default=str(DEFAULT_WORKDIR),
     type=click.Path(exists=False),
     show_default=True,
-    help="Directory Path for repo checkouts",
+    help="Directory path for repo checkouts",
 )
 @click.option(
     "-W",
@@ -121,9 +121,9 @@ async def async_main(
 )
 @click.pass_context
 def main(ctx: click.core.Context, **kwargs: Any) -> None:
-    """primer - prime projects for blackening ... 🏴"""
+    """primer - prime projects for blackening... 🏴"""
     LOG.debug(f"Starting {sys.argv[0]}")
-    # TODO: Change to asyncio.run when black >= 3.7 only
+    # TODO: Change to asyncio.run when Black >= 3.7 only
     loop = asyncio.get_event_loop()
     try:
         ctx.exit(loop.run_until_complete(async_main(**kwargs)))

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -78,9 +78,11 @@ def analyze_results(project_count: int, results: Results) -> int:
         bold=bool(results.stats["failed"]),
         fg="red",
     )
-    click.echo(f" - {results.stats['disabled']} projects Disabled by config")
+    s = "" if results.stats["disabled"] == 1 else "s"
+    click.echo(f" - {results.stats['disabled']} project{s} disabled by config")
+    s = "" if results.stats["wrong_py_ver"] == 1 else "s"
     click.echo(
-        f" - {results.stats['wrong_py_ver']} projects skipped due to Python Version"
+        f" - {results.stats['wrong_py_ver']} project{s} skipped due to Python version"
     )
     click.echo(
         f" - {results.stats['skipped_long_checkout']} skipped due to long checkout"
@@ -267,11 +269,13 @@ async def process_queue(
 
     config, queue = await load_projects_queue(Path(config_file))
     project_count = queue.qsize()
-    LOG.info(f"{project_count} projects to run black over")
+    s = "" if project_count == 1 else "s"
+    LOG.info(f"{project_count} project{s} to run Black over")
     if project_count < 1:
         return -1
 
-    LOG.debug(f"Using {workers} parallel workers to run black")
+    s = "" if workers == 1 else "s"
+    LOG.debug(f"Using {workers} parallel worker{s} to run Black")
     # Wait until we finish running all the projects before analyzing
     await asyncio.gather(
         *[

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -22,9 +22,9 @@ LOG = logging.getLogger(__name__)
 
 
 # Windows needs a ProactorEventLoop if you want to exec subprocesses
-# Startng 3.8 this is the default - Can remove when black >= 3.8
+# Starting with 3.8 this is the default - can remove when Black >= 3.8
 # mypy only respects sys.platform if directly in the evaluation
-# # https://mypy.readthedocs.io/en/latest/common_issues.html#python-version-and-system-platform-checks  # noqa: B950
+# https://mypy.readthedocs.io/en/latest/common_issues.html#python-version-and-system-platform-checks  # noqa: B950
 if sys.platform == "win32":
     asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
@@ -89,7 +89,7 @@ def analyze_results(project_count: int, results: Results) -> int:
     )
 
     if results.failed_projects:
-        click.secho("\nFailed Projects:\n", bold=True)
+        click.secho("\nFailed projects:\n", bold=True)
 
     for project_name, project_cpe in results.failed_projects.items():
         print(f"## {project_name}:")
@@ -106,7 +106,7 @@ def analyze_results(project_count: int, results: Results) -> int:
 async def black_run(
     repo_path: Path, project_config: Dict[str, Any], results: Results
 ) -> None:
-    """Run black and record failures"""
+    """Run Black and record failures"""
     cmd = [str(which(BLACK_BINARY))]
     if "cli_arguments" in project_config and project_config["cli_arguments"]:
         cmd.extend(*project_config["cli_arguments"])
@@ -203,7 +203,7 @@ async def project_runner(
     rebase: bool = False,
     keep: bool = False,
 ) -> None:
-    """Checkout project and run black on it + record result"""
+    """Check out project and run Black on it + record result"""
     loop = asyncio.get_event_loop()
     py_version = f"{version_info[0]}.{version_info[1]}"
     while True:

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -24,16 +24,16 @@ EXPECTED_ANALYSIS_OUTPUT = """\
 
 68 / 69 succeeded (98.55%) ✅
 1 / 69 FAILED (1.45%) 💩
- - 0 projects Disabled by config
- - 0 projects skipped due to Python Version
+ - 0 projects disabled by config
+ - 0 projects skipped due to Python version
  - 0 skipped due to long checkout
 
-Failed Projects:
+Failed projects:
 
 ## black:
  - Returned 69
  - stdout:
-black didn't work
+Black didn't work
 
 """
 FAKE_PROJECT_CONFIG = {
@@ -93,20 +93,20 @@ class PrimerLibTests(unittest.TestCase):
                 "success": 68,
                 "wrong_py_ver": 0,
             },
-            {"black": CalledProcessError(69, ["black"], b"black didn't work", b"")},
+            {"black": CalledProcessError(69, ["black"], b"Black didn't work", b"")},
         )
         with capture_stdout(lib.analyze_results, 69, fake_results) as analyze_stdout:
             self.assertEqual(EXPECTED_ANALYSIS_OUTPUT, analyze_stdout)
 
     @event_loop()
     def test_black_run(self) -> None:
-        """Pretend run black to ensure we cater for all scenarios"""
+        """Pretend to run Black to ensure we cater for all scenarios"""
         loop = asyncio.get_event_loop()
         repo_path = Path(gettempdir())
         project_config = deepcopy(FAKE_PROJECT_CONFIG)
         results = lib.Results({"failed": 0, "success": 0}, {})
 
-        # Test a successful black run
+        # Test a successful Black run
         with patch("black_primer.lib._gen_check_output", return_subproccess_output):
             loop.run_until_complete(lib.black_run(repo_path, project_config, results))
         self.assertEqual(1, results.stats["success"])


### PR DESCRIPTION
Done in a similar way to the main Black code, for example:

```python
s = "" if results.stats["disabled"] == 1 else "s"
click.echo(f" - {results.stats['disabled']} project{s} disabled by config")
```

Also some typos and consistency.