### PR TITLE
CI: Move primer to own workflow

### DIFF
--- a/.github/workflows/primer.yml
+++ b/.github/workflows/primer.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Primer
 
 on: [push, pull_request]
 
@@ -22,9 +22,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade coverage
           python -m pip install -e ".[d]"
 
-      - name: Unit tests
+      - name: Primer run
+        env:
+          pythonioencoding: utf-8
         run: |
-          coverage run -m unittest
+          black-primer


### PR DESCRIPTION
black-primer takes 3.5-5.5 mins on the CI. I suggest moving it to its own workflow:

* make it clearer what fails: black-primer or unit tests
* allow unit tests to finish sooner -> quicker feedback
* make builds more granular -> test in isolation
* make full use of the 20 GHA parallel jobs -> finish sooner

---

Is it desired to run black-primer on the full 3x3 Python/OS matrix? Fine if it is! If not, we can select just those needed (eg. `lint.yml` only needs to run on a single Python/OS).
