### PR TITLE
Be more careful with docstrings ending with quotes + whitespace

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -2092,7 +2092,6 @@ class LineGenerator(Visitor[Line]):
             prefix = "    " * self.current_line.depth
             docstring = fix_docstring(leaf.value[3:-3], prefix)
             leaf.value = leaf.value[0:3] + docstring + leaf.value[-3:]
-            normalize_string_quotes(leaf)
 
         yield from self.visit_default(leaf)
 

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -73,10 +73,42 @@ def single_line():
     """
     pass
 
+
+def containing_quotes():
+    """No quotes here
+
+    "quotes here" """
+    pass
+
+
+def containing_unbalanced_quotes():
+    """No quotes here
+
+    quote here" """
+    pass
+
+
+def entirely_space():
+    """
+      
+    """
+    pass
+
+
+def just_quote():
+    """ " """
+    pass
+
+
+def escaped_already():
+    """
+    foo\""""
+    pass
+
 # output
 
 class MyClass:
-    """Multiline
+    """ Multiline
     class docstring
     """
 
@@ -88,7 +120,7 @@ class MyClass:
 
 
 def foo():
-    """This is a docstring with
+    """This is a docstring with             
     some lines of text here
     """
     return
@@ -146,5 +178,39 @@ def over_indent():
 
 
 def single_line():
-    """But with a newline after it!"""
+    """But with a newline after it!
+
+    """
+    pass
+
+
+def containing_quotes():
+    """No quotes here
+
+    "quotes here" """
+    pass
+
+
+def containing_unbalanced_quotes():
+    """No quotes here
+
+    quote here" """
+    pass
+
+
+def entirely_space():
+    """
+
+    """
+    pass
+
+
+def just_quote():
+    """ " """
+    pass
+
+
+def escaped_already():
+    """
+    foo\""""
     pass


### PR DESCRIPTION
The PEP 257 algorithm used in #1053 results in trimming trailing
whitespace in docstrings -- see #1415.

Adjust the algorithm to preserve leading and trailing whitespace; this
reverts the changes in #1417.  This diverges from PEP 257, but better
retains the contents of the docstring.

Fixes #1452 because we no longer can end up with four trailing quotes.