### PR TITLE
Scrollable sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,7 @@ cooper-mbp:black cooper$ ~/venvs/b/bin/black-primer
 
 Failed projects:
 
-## flake8-bugbear:
+### flake8-bugbear:
  - Returned 1
  - stdout:
 --- tests/b303_b304.py	2020-05-17 20:04:09.991227 +0000

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,38 @@
+/* Make the sidebar scrollable. Fixes https://github.com/psf/black/issues/990 */
+div.sphinxsidebar {
+  max-height: calc(100% - 18px);
+  overflow-y: auto;
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+div.sphinxsidebar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE 6, 7 and 8 */
+@media \0screen\, screen\9 {
+  div.sphinxsidebar {
+    -ms-overflow-style: none;
+  }
+}
+
+/* Hide scrollbar for IE 9 and 10 */
+/* backslash-9 removes ie11+ & old Safari 4 */
+@media screen and (min-width: 0\0) {
+  div.sphinxsidebar {
+    -ms-overflow-style: none\9;
+  }
+}
+
+/* Hide scrollbar for IE 11 and up */
+_:-ms-fullscreen,
+:root div.sphinxsidebar {
+  -ms-overflow-style: none;
+}
+
+/* Hide scrollbar for Edge */
+@supports (-ms-ime-align: auto) {
+  div.sphinxsidebar {
+    -ms-overflow-style: none;
+  }
+}


### PR DESCRIPTION
Resolves #990.

**See how the scrollable sidebar works here:**
https://ichard26-testblackdocs.readthedocs.io/en/scrollable_sidebar/

This is necessary since we have so many documentation sections that even
on a desktop screen, the navigation can sometimes be clipped. The only
annoyance is that on Firefox, the scrollbar can't be hidden :(

***Ideally this would be merged before my large refactor so I can deal with the merge conflict ahead of its merge. Or, just @ me and I'll remove the second commit so this can be merged without future conflict causing changes. The second commit is only so you can interact with the updated docs, and becomes useless once #1456 is merged.***