### PR TITLE
Allow Black to be run as package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ To get started right away with sensible defaults:
 black {source_file_or_directory}
 ```
 
+You can run _Black_ as a package if running it as a script doesn't work:
+
+```sh
+python -m black {source_file_or_directory}
+```
+
 ### Command line options
 
 _Black_ doesn't provide many options. You can list them by running `black --help`:

--- a/src/black/__main__.py
+++ b/src/black/__main__.py
@@ -1,0 +1,3 @@
+from black import patched_main
+
+patched_main()


### PR DESCRIPTION
Resolves #795.

Since the refactor to a package, `python -m black {src}` doesn't work. This just recovers the ability to run _Black_ through `python -m` and mentions it in the docs. 

Example run:
```console
(black) PS R:\Programming\black> python -m black setup.py
All done! ✨ ✨ 🍰✨✨
1 file left unchanged.
```