### PR TITLE
Convert (most of the) configuration values from pyproject.toml to strings

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -317,12 +317,14 @@ def read_pyproject_toml(
     default_map: Dict[str, Any] = {}
     if ctx.default_map:
         default_map.update(ctx.default_map)
-    default_map.update(config)
+    default_map.update(
+        {
+            k: str(v) if not isinstance(v, collections.abc.Iterable) else v
+            for k, v in config.items()
+        }
+    )
 
-    ctx.default_map = {
-        k: str(v) if not isinstance(v, collections.abc.Iterable) else v
-        for k, v in default_map.items()
-    }
+    ctx.default_map = default_map
     return value
 
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 from abc import ABC, abstractmethod
 from collections import defaultdict
+import collections.abc
 from concurrent.futures import Executor, ThreadPoolExecutor, ProcessPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime
@@ -318,7 +319,10 @@ def read_pyproject_toml(
         default_map.update(ctx.default_map)
     default_map.update(config)
 
-    ctx.default_map = default_map
+    ctx.default_map = {
+        k: str(v) if not isinstance(v, collections.abc.Iterable) else v
+        for k, v in default_map.items()
+    }
     return value
 
 


### PR DESCRIPTION
Resolves #1458.

---

We need to convert all configuration values from the pyproject.toml
file because Click already does value processing and conversion and
it only expects the exact Python type or string. Click doesn't like
the integer `1` as a boolean for example. This also means other
unsupported types like datetime.time will be rejected by Click as
an invalid value instead of throwing an exception.

We only skip converting objects that are an instance of
collections.abc.Iterable because it's almost impossible to get back
the original iterable of a stringified iterable.

---

After this change, these following values will be accepted for each of the configuration options in `pyproject.toml`:

| Option | Accepted values |
| ---------- | ----------------------|
| Boolean type / flag type <ul> <li> `--pyi` </li> <li> `-S`  /  `--skip-string-normalization` </li> <li> `--check`</li> <li> `--diff` </li> <li> `--color` / `--no-color` </li> <li> `--fast` / `--safe` </li> <li> `--quiet` </li> <li> `--verbose` </li> </ul> | <ul> <li> Integers <ul>  <li> `0` </li> <li> `1` </li> </ul> </li> <li> Strings (case insensitive) <ul> <li> `"f"` </li> <li> `"false"`</li> <li> `"n"` </li> <li> `"no"` </li> <li> `"0"` </li> <li> `"t"`</li> <li> `"true"` </li> <li> `"y"` </li> <li> `"yes"` </li> <li> `"1"` </li> </ul> </li> <li> Boolean <ul> <li> `true` </li> <li> `True` (technically a string) </li> <li> `false` </li> <li> `False` (technically a string) </li> </ul> </li> </ul>|
| Integer type <ul> <li> `-l` / `--line-length` </li> </ul> | <ul> <li> Any integer </li> <li> Any stringified integer </li> </ul> |
| Choice type <ul> <li> `-t` / `--target-version`</li> </ul>| *The choices available for that option.* |
| Text type <ul> <li> `-c` / `--code` </li> <li> `--include` </li> <li> `--exclude` </li>  <li> `--force-exclude` </li> </ul> | *Any text still accepted.* |

And `--version`, `--help`, and `--config` are still allowed in `pyproject.toml` :laughing: 