### PR TITLE
Move vim flag cast to outside of get

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -190,7 +190,7 @@ def get_configs():
     toml_config = {}
 
   return {
-    flag.var_name: toml_config.get(flag.name, flag.cast(vim.eval(flag.vim_rc_name)))
+    flag.var_name: flag.cast(toml_config.get(flag.name, vim.eval(flag.vim_rc_name)))
     for flag in FLAGS
   }
 


### PR DESCRIPTION
With this config:

```toml
[tool.black]
line-length = 79
```

In neovim, this is loaded as a string which later causes an exception to
be thrown. This makes sure the value is always cast to an int. I'm not sure why this wouldn't affect everyone using this behavior.