### PR TITLE
Fix toml hashes and make it clear that only TOML is supported

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,7 @@ click = ">=6.5"
 mypy_extensions = ">=0.4.3"
 pathspec = ">=0.6"
 regex = ">=2019.8"
-toml = "==0.10.1"
+toml = ">=0.10.1"
 typed-ast = "==1.4.0"
 typing_extensions = ">=3.7.4"
 black = {editable = true,extras = ["d"],path = "."}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0bb8f931bef89b929375c1b1337cdaf17a2a4775d546124ad308fdb6c6eebd1b"
+            "sha256": "4a6956c7c81b496d3fd7a4e3395b332d4dc9a5bed468e36e729a4039c739ad2d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -180,6 +180,8 @@
         },
         "toml": {
             "hashes": [
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88",
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
                 "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
@@ -904,6 +906,8 @@
         },
         "toml": {
             "hashes": [
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88",
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
                 "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],

--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -6,6 +6,10 @@ linters and type checkers. Some of them need a bit of tweaking to resolve the co
 Listed below are _Black_ compatible configurations in various formats for the common
 tools out there.
 
+**Please note** that _Black_ only supports the TOML file format for its configuration
+(e.g. `pyproject.toml`). The provided examples are to only configure their corresponding
+tools, using **their** supported file formats.
+
 ## isort
 
 [isort](https://pypi.org/p/isort/) helps to sort and format imports in your Python code.


### PR DESCRIPTION
Resolves #1509 

This fixes the TOML module hashes so `pipenv install (--dev)` doesn't fail. 
```console
(black) richard-26@ubuntu-laptop:~/programming/black$ pipenv install --dev
Installing dependencies from Pipfile.lock (39ad2d)…
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 73/73 — 00:06:26
``` 

Also makes it clear that only TOML is supported by Black in `docs/compatible_configs.md`. Related: #1511 