### PR TITLE
ISSUE 1533: Fix --config argument description

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options:
                                   --exclude=.
 
   --version                       Show the version and exit.
-  --config FILE                   Read configuration from PATH.
+  --config FILE                   Read configuration from FILE path.
   -h, --help                      Show this message and exit.
 ```
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -471,7 +471,7 @@ def target_version_option_callback(
     ),
     is_eager=True,
     callback=read_pyproject_toml,
-    help="Read configuration from PATH.",
+    help="Read configuration from FILE path.",
 )
 @click.pass_context
 def main(


### PR DESCRIPTION
Closes #1533 

The `help` view for `--config` argument is a little unclear.
For now it looks like:
```
...
--config FILE                   Read configuration from PATH.
...
```
It says that we pass `FILE` as argument value, but the configuration will be read from the `PATH`. 

Proposal: use `FILE` instead of `PATH` in `help` view fro this argument.
It will looks like:
```
...
--config FILE                   Read configuration from FILE.
...
```