### PR TITLE
[vim plugin] Fix g:black_fast and g:black_(skip)_string_normalization opts

### DIFF
--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -41,8 +41,12 @@ endif
 if !exists("g:black_linelength")
   let g:black_linelength = 88
 endif
-if !exists("g:black_skip_string_normalization")
-  let g:black_skip_string_normalization = 0
+if !exists("g:black_string_normalization")
+  if exists("g:black_skip_string_normalization")
+    let g:black_string_normalization = !g:black_skip_string_normalization
+  else
+    let g:black_string_normalization = 1
+  endif
 endif
 
 python3 << EndPython3
@@ -50,6 +54,7 @@ import collections
 import os
 import sys
 import vim
+from distutils.util import strtobool
 
 
 class Flag(collections.namedtuple("FlagBase", "name, cast")):
@@ -62,15 +67,13 @@ class Flag(collections.namedtuple("FlagBase", "name, cast")):
     name = self.var_name
     if name == "line_length":
       name = name.replace("_", "")
-    if name == "string_normalization":
-      name = "skip_" + name
     return "g:black_" + name
 
 
 FLAGS = [
   Flag(name="line_length", cast=int),
-  Flag(name="fast", cast=bool),
-  Flag(name="string_normalization", cast=bool),
+  Flag(name="fast", cast=strtobool),
+  Flag(name="string_normalization", cast=strtobool),
 ]
 
 


### PR DESCRIPTION
The was a negation bug in the handling of the `g:black_skip_string_normalization` option in the (n)vim plugin. Also both this option and the `g:black_fast` option were incorrectly casted, from the string `'1'` to `bool()`, so that they were always `True`.