### PR TITLE
pre-commit: show diff on failure on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
           python -m pip install -e '.[d]'
 
       - name: Lint
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - name: "lint"
       python: 3.7
       env:
-        - TEST_CMD="pre-commit run --all-files"
+        - TEST_CMD="pre-commit run --all-files --show-diff-on-failure"
     - name: "3.6"
       python: 3.6
     - name: "3.7"


### PR DESCRIPTION
On the CI, if pre-commit makes changes it fails the build (eg. https://github.com/psf/black/pull/1551), but the reporter cannot see what changes exactly were made, without installing and running pre-commit locally.

But let's show the changes on the CI to save PR authors some hassle. 