### PR TITLE
Update to accomodate isort 5 release changes.

### DIFF
--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -67,17 +67,11 @@ of 88 characters via `line_length = 88` as well as
 `ensure_newline_before_comments = True` to ensure spacing import sections with comments
 works the same as with _Black_.
 
----
-
-NOTE
-
-`ensure_newline_before_comments = True` only works since isort >= 5 but does not break
-older versions so you can keep it if you are running previous versions. If only isort >=
-5 is used you can add `profile = black` instead of all the options since
-[profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/) are
-available and do the configuring for you.
-
----
+**Please note** `ensure_newline_before_comments = True` only works since isort >= 5 but
+does not break older versions so you can keep it if you are running previous versions.
+If only isort >= 5 is used you can add `profile = black` instead of all the options
+since [profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/)
+are available and do the configuring for you.
 
 ### Formats
 

--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -72,7 +72,7 @@ works the same as with _Black_.
 NOTE
 
 `ensure_newline_before_comments = True` only works since isort >= 5 but does not break
-previous ones so you can keep it if you are running previous versions. If only isort >=
+older versions so you can keep it if you are running previous versions. If only isort >=
 5 is used you can add `profile = black` instead of all the options since
 [profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/) are
 available and do the configuring for you.

--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -113,10 +113,10 @@ line_length = 88
 ```toml
 [tool.isort]
 multi_line_output = 3
-include_trailing_comma = True
+include_trailing_comma = true
 force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
+use_parentheses = true
+ensure_newline_before_comments = true
 line_length = 88
 ```
 

--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -23,6 +23,7 @@ multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
+ensure_newline_before_comments = True
 line_length = 88
 ```
 
@@ -62,7 +63,17 @@ The option `force_grid_wrap = 0` is just to tell isort to only wrap imports that
 the `line_length` limit.
 
 Finally, isort should be told to wrap imports when they surpass _Black_'s default limit
-of 88 characters via `line_length = 88`.
+of 88 characters via `line_length = 88` as well as `ensure_newline_before_comments = True`
+to ensure spacing import sections with comments works the same as with _Black_.
+
+---
+
+NOTE
+
+`ensure_newline_before_comments = True` only works since isort >= 5 but does not break previous ones so you can keep it if you are running previous versions. If only isort >= 5 is used you can add `profile = black` instead of all the options since
+[profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/) are available and do the configuring for you.
+
+---
 
 ### Formats
 
@@ -75,6 +86,7 @@ multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
+ensure_newline_before_comments = True
 line_length = 88
 ```
 
@@ -89,6 +101,7 @@ multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
+ensure_newline_before_comments = True
 line_length = 88
 ```
 
@@ -100,9 +113,10 @@ line_length = 88
 ```toml
 [tool.isort]
 multi_line_output = 3
-include_trailing_comma = true
+include_trailing_comma = True
 force_grid_wrap = 0
-use_parentheses = true
+use_parentheses = True
+ensure_newline_before_comments = True
 line_length = 88
 ```
 
@@ -117,6 +131,7 @@ multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
+ensure_newline_before_comments = True
 line_length = 88
 ```
 

--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -63,15 +63,19 @@ The option `force_grid_wrap = 0` is just to tell isort to only wrap imports that
 the `line_length` limit.
 
 Finally, isort should be told to wrap imports when they surpass _Black_'s default limit
-of 88 characters via `line_length = 88` as well as `ensure_newline_before_comments = True`
-to ensure spacing import sections with comments works the same as with _Black_.
+of 88 characters via `line_length = 88` as well as
+`ensure_newline_before_comments = True` to ensure spacing import sections with comments
+works the same as with _Black_.
 
 ---
 
 NOTE
 
-`ensure_newline_before_comments = True` only works since isort >= 5 but does not break previous ones so you can keep it if you are running previous versions. If only isort >= 5 is used you can add `profile = black` instead of all the options since
-[profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/) are available and do the configuring for you.
+`ensure_newline_before_comments = True` only works since isort >= 5 but does not break
+previous ones so you can keep it if you are running previous versions. If only isort >=
+5 is used you can add `profile = black` instead of all the options since
+[profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/) are
+available and do the configuring for you.
 
 ---
 

--- a/docs/the_black_code_style.md
+++ b/docs/the_black_code_style.md
@@ -153,13 +153,14 @@ the following configuration.
 <details>
 <summary>A compatible `.isort.cfg`</summary>
 
-```
+```cfg
 [settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88
 ```
 
 The equivalent command line is:


### PR DESCRIPTION
Isort 5 introduced [profiles ](https://timothycrosley.github.io/isort/docs/configuration/profiles/) and ensure_newline_before_comments options. Either one needs to be added to work correctly with black.

Using `ensure_newline_before_comments = True` does no harm and is required for new isort releases, so it is appropriate to be put into the config examples.

Previous isort versions will not be configured with `profile = black` so the note should suffice for now. Accomodating users of previous isort versions is appropriate, especially since there are still isort incompatibilities with pylint (see PyCQA/pylint#3725) and flake8-isort (see gforcada/flake8-isort#92).

Fix #1556 