### PR TITLE
Add the direnv base directory to the default excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Multiple contributions by:
 - [Christian Clauss](mailto:cclauss@bluewin.ch)
 - [Christian Heimes](mailto:christian@python.org)
 - [Chuck Wooters](mailto:chuck.wooters@microsoft.com)
+- [Chris Rose](mailto:offline@offby1.net)
 - Codey Oxley
 - [Cong](mailto:congusbongus@gmail.com)
 - [Cooper Ry Lees](mailto:me@cooperlees.com)

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     import colorama  # noqa: F401
 
 DEFAULT_LINE_LENGTH = 88
-DEFAULT_EXCLUDES = r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
+DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))
 


### PR DESCRIPTION
Direnv installs a python virtualenv in `.direnv/python` which black will format recursively if this is missing.