### PR TITLE
Make --exclude only apply to recursively found files

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1565,7 +1565,7 @@ class BlackTestCase(unittest.TestCase):
         this_abs = THIS_DIR.resolve()
         sources.extend(
             black.gen_python_files(
-                path.iterdir(), this_abs, include, [exclude], report, gitignore
+                path.iterdir(), this_abs, include, exclude, None, report, gitignore
             )
         )
         self.assertEqual(sorted(expected), sorted(sources))
@@ -1611,7 +1611,7 @@ class BlackTestCase(unittest.TestCase):
         this_abs = THIS_DIR.resolve()
         sources.extend(
             black.gen_python_files(
-                path.iterdir(), this_abs, include, [exclude], report, gitignore
+                path.iterdir(), this_abs, include, exclude, None, report, gitignore
             )
         )
         self.assertEqual(sorted(expected), sorted(sources))
@@ -1639,7 +1639,8 @@ class BlackTestCase(unittest.TestCase):
                 path.iterdir(),
                 this_abs,
                 empty,
-                [re.compile(black.DEFAULT_EXCLUDES)],
+                re.compile(black.DEFAULT_EXCLUDES),
+                None,
                 report,
                 gitignore,
             )
@@ -1666,7 +1667,8 @@ class BlackTestCase(unittest.TestCase):
                 path.iterdir(),
                 this_abs,
                 re.compile(black.DEFAULT_INCLUDES),
-                [empty],
+                empty,
+                None,
                 report,
                 gitignore,
             )
@@ -1723,7 +1725,7 @@ class BlackTestCase(unittest.TestCase):
         try:
             list(
                 black.gen_python_files(
-                    path.iterdir(), root, include, exclude, report, gitignore
+                    path.iterdir(), root, include, exclude, None, report, gitignore
                 )
             )
         except ValueError as ve:
@@ -1737,7 +1739,7 @@ class BlackTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             list(
                 black.gen_python_files(
-                    path.iterdir(), root, include, exclude, report, gitignore
+                    path.iterdir(), root, include, exclude, None, report, gitignore
                 )
             )
         path.iterdir.assert_called()


### PR DESCRIPTION
Resolves #1572.

**What this PR does:**

- Makes `--exclude` only apply to files recursively discovered in `gen_python_files()` instead of applying to all files, including files given to Black through the CLI
- Adds a test to make sure this doesn't go unnoticed again
- Also changes the output given when a file is excluded to properly say which regex matched
- Fixes a few misplaced or wrong comments

**How was this achieved?**

Before, `get_sources()` when encountering a file that was passed explicitly through the CLI would pass a single Path object list to
`gen_python_files()`. This causes bad behaviour since that function doesn't treat the `exclude` and `force_exclude` regexes differently.  Now when `get_sources()` iterates through `srcs` and encounters a file, it checks if the `force_exclude` regex matches, if not, then the file will be added to the computed sources set.

**What changes of Black's behaviour does this PR cause?**

`--exclude` will now behave as it did on `stable`.