### PR TITLE
fix some docstring crashes

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -3318,7 +3318,7 @@ class StringParenStripper(StringTransformer):
         new_line.append(string_leaf)
 
         append_leaves(
-            new_line, line, LL[string_idx + 1 : rpar_idx] + LL[rpar_idx + 1 :],
+            new_line, line, LL[string_idx + 1 : rpar_idx] + LL[rpar_idx + 1 :]
         )
 
         LL[rpar_idx].remove()
@@ -6030,7 +6030,7 @@ def _stringify_ast(
                 and field == "value"
                 and isinstance(value, str)
             ):
-                normalized = re.sub(r" *(\n)+[ \t]+", r"\1 ", value).strip()
+                normalized = re.sub(r" *\n[ \t]*", "\n", value).strip()
             else:
                 normalized = value
             yield f"{'  ' * (depth+2)}{normalized!r},  # {value.__class__.__name__}"

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6030,7 +6030,7 @@ def _stringify_ast(
                 and field == "value"
                 and isinstance(value, str)
             ):
-                normalized = re.sub(r" *\n[ \t]+", "\n ", value).strip()
+                normalized = re.sub(r" *(\n)+[ \t]+", r"\1 ", value).strip()
             else:
                 normalized = value
             yield f"{'  ' * (depth+2)}{normalized!r},  # {value.__class__.__name__}"

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -46,7 +46,7 @@ def zort():
 
 def poit():
   """
-  Lorem ipsum dolor sit amet.
+  Lorem ipsum dolor sit amet.       
 
   Consectetur adipiscing elit:
    - sed do eiusmod tempor incididunt ut labore

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -58,6 +58,14 @@ def poit():
   pass
 
 
+def under_indent():
+  """
+  These lines are indented in a way that does not
+make sense.
+  """
+  pass
+
+
 def over_indent():
   """
   This has a shallow indent
@@ -132,6 +140,14 @@ def poit():
        - enim ad minim veniam
        - quis nostrud exercitation ullamco laboris nisi
      - aliquip ex ea commodo consequat
+    """
+    pass
+
+
+def under_indent():
+    """
+      These lines are indented in a way that does not
+    make sense.
     """
     pass
 


### PR DESCRIPTION
Allow removing some trailing whitespace. This fixes a few crashes I saw in our codebase.