### PR TITLE
Accept src as option in pyproject.toml (fixes #861)

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Multiple contributions by:
 - [LukasDrude](mailto:mail@lukas-drude.de)
 - Mahmoud Hossam
 - Mariatta
+- [Marc Rijken](mailto:marc@rijken.org)
 - [Matt VanEseltine](mailto:vaneseltine@gmail.com)
 - [Matthew Clapp](mailto:itsayellow+dev@gmail.com)
 - [Matthew Walster](mailto:matthew@walster.org)

--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ exclude = '''
 '''
 ```
 
-Note: `src`  specifies a list of source files / directories which will be formatted (which can be specified as command line argument)
+Note: `src` specifies a list of source files / directories which will be formatted
+(which can be specified as command line argument)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -322,8 +322,9 @@ exclude = '''
 '''
 ```
 
-Note: `src` specifies a list of source files / directories which will be formatted
-(which can be specified as command line argument)
+Tip: `src` specifies a list of default source files / directories which will be
+formatted when _Black_ is run with no sources provided. Sources given on the command
+line will override the list of sources provided in the configuration file.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -613,8 +613,8 @@ Multiple contributions by:
 - [Luka Sterbic](mailto:luka.sterbic@gmail.com)
 - [LukasDrude](mailto:mail@lukas-drude.de)
 - Mahmoud Hossam
-- Mariatta
 - [Marc Rijken](mailto:marc@rijken.org)
+- Mariatta
 - [Matt VanEseltine](mailto:vaneseltine@gmail.com)
 - [Matthew Clapp](mailto:itsayellow+dev@gmail.com)
 - [Matthew Walster](mailto:matthew@walster.org)

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ expressions by Black. Use `[ ]` to denote a significant space character.
 ```toml
 [tool.black]
 line-length = 88
+src = ['src']
 target-version = ['py37']
 include = '\.pyi?$'
 exclude = '''
@@ -320,6 +321,8 @@ exclude = '''
 )
 '''
 ```
+
+Note: `src`  specifies a list of source files / directories which will be formatted (which can be specified as command line argument)
 
 </details>
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -293,7 +293,10 @@ def read_pyproject_toml(
     otherwise.
     """
     if not value:
-        value = find_pyproject_toml(ctx.params.get("src", ()))
+        src = ctx.params.get("src", ())
+        if not src:
+            src = tuple(".")
+        value = find_pyproject_toml(src)
         if value is None:
             return None
 
@@ -314,6 +317,9 @@ def read_pyproject_toml(
             k: str(v) if not isinstance(v, (list, dict)) else v
             for k, v in config.items()
         }
+
+    if "src" in config and "src" not in ctx.params:
+        ctx.params["src"] = tuple(config["src"])
 
     target_version = config.get("target_version")
     if target_version is not None and not isinstance(target_version, list):

--- a/tests/test_src.toml
+++ b/tests/test_src.toml
@@ -1,0 +1,10 @@
+[tool.black]
+verbose = 1
+--check = "no"
+diff = "y"
+color = true
+line-length = 79
+target-version = ["py36", "py37", "py38"]
+exclude='\.pyi?$'
+include='\.py?$'
+src = ["setup.py"]


### PR DESCRIPTION
Add option to add src in pyprojcect.toml so black can be run without command line parameters.