### PR TITLE
Fix inline code style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ the equivalent of r-strings in Python. Multiline strings are treated as verbose 
 expressions by Black. Use `[ ]` to denote a significant space character.
 
 <details>
-<summary>Example `pyproject.toml`</summary>
+<summary>Example <code>pyproject.toml</code></summary>
 
 ```toml
 [tool.black]


### PR DESCRIPTION
Refer to `pyproject.toml` in HTML section of README with HTML code tags