### PR TITLE
Treat all trailing commas as pre-existing, as they effectively are

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6163,6 +6163,7 @@ def assert_stable(src: str, dst: str, mode: Mode) -> None:
     newdst = format_str(dst, mode=mode)
     if dst != newdst:
         log = dump_to_file(
+            str(mode),
             diff(src, dst, "source", "first pass"),
             diff(dst, newdst, "first pass", "second pass"),
         )

--- a/tests/data/trailing_comma_optional_parens1.py
+++ b/tests/data/trailing_comma_optional_parens1.py
@@ -1,0 +1,3 @@
+if e1234123412341234.winerror not in (_winapi.ERROR_SEM_TIMEOUT,
+                        _winapi.ERROR_PIPE_BUSY) or _check_timeout(t):
+    pass

--- a/tests/data/trailing_comma_optional_parens2.py
+++ b/tests/data/trailing_comma_optional_parens2.py
@@ -1,0 +1,3 @@
+if (e123456.get_tk_patchlevel() >= (8, 6, 0, 'final') or
+    (8, 5, 8) <= get_tk_patchlevel() < (8, 6)):
+    pass

--- a/tests/data/trailing_comma_optional_parens3.py
+++ b/tests/data/trailing_comma_optional_parens3.py
@@ -1,0 +1,8 @@
+if True:
+    if True:
+        if True:
+            return _(
+                "qweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweas "
+                + "qweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqwegqweasdzxcqweasdzxc.",
+                "qweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqweasdzxcqwe",
+            ) % {"reported_username": reported_username, "report_reason": report_reason}

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -368,6 +368,27 @@ class BlackTestCase(unittest.TestCase):
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, DEFAULT_MODE)
 
+    @unittest.expectedFailure
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_trailing_comma_optional_parens_stability1(self) -> None:
+        source, _expected = read_data("trailing_comma_optional_parens1")
+        actual = fs(source)
+        black.assert_stable(source, actual, DEFAULT_MODE)
+
+    @unittest.expectedFailure
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_trailing_comma_optional_parens_stability2(self) -> None:
+        source, _expected = read_data("trailing_comma_optional_parens2")
+        actual = fs(source)
+        black.assert_stable(source, actual, DEFAULT_MODE)
+
+    @unittest.expectedFailure
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_trailing_comma_optional_parens_stability3(self) -> None:
+        source, _expected = read_data("trailing_comma_optional_parens3")
+        actual = fs(source)
+        black.assert_stable(source, actual, DEFAULT_MODE)
+
     @patch("black.dump_to_file", dump_to_stderr)
     def test_expression(self) -> None:
         source, expected = read_data("expression")


### PR DESCRIPTION
On a second pass of Black on the same file, inserted trailing commas are now pre-existing.  Doesn't make sense to differentiate between the passes then.