### PR TITLE
Fix incorrect space before colon in if/while stmts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 - `Black` now respects `--skip-string-normalization` when normalizing multiline
   docstring quotes (#1637)
 
+- `Black` no longer adds an incorrect space after a parenthesized assignment expression
+  in if/while statements (#1655)
+
 - fixed a crash when PWD=/ on POSIX (#1631)
 
 ### 20.8b1

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -9,6 +9,11 @@
 - `Black` now respects `--skip-string-normalization` when normalizing multiline
   docstring quotes (#1637)
 
+- `Black` no longer adds an incorrect space after a parenthesized assignment expression
+  in if/while statements (#1655)
+
+- fixed a crash when PWD=/ on POSIX (#1631)
+
 ### 20.8b1
 
 #### _Packaging_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5190,9 +5190,9 @@ def normalize_invisible_parens(node: Node, parens_after: Set[str]) -> None:
 
         if check_lpar:
             if is_walrus_assignment(child):
-                continue
+                pass
 
-            if child.type == syms.atom:
+            elif child.type == syms.atom:
                 if maybe_make_parens_invisible_in_atom(child, parent=node):
                     wrap_in_parentheses(node, child, visible=False)
             elif is_one_tuple(child):

--- a/tests/data/pep_572.py
+++ b/tests/data/pep_572.py
@@ -2,6 +2,8 @@
 (a := a)
 if (match := pattern.search(data)) is None:
     pass
+if (match := pattern.search(data)):
+    pass
 [y := f(x), y ** 2, y ** 3]
 filtered_data = [y for x in data if (y := f(x)) is None]
 (y := f(x))
@@ -40,4 +42,6 @@ foo((b := 2), a=1)
 foo(c=(b := 2), a=1)
 
 while x := f(x):
+    pass
+while (x := f(x)):
     pass


### PR DESCRIPTION
Fixes #1174 
Fixes #1588

Previously Black would format this code

```
if (foo := True):
	print(foo)
```

as

```
if (foo := True) :
	print(foo)
```

adding an incorrect space after the RPAR. Buggy code in the
normalize_invisible_parens function caused the colon to be wrapped in
invisible parentheses. The LPAR of that pair was then prefixed with a
single space at the request of the whitespace function.

This commit fixes the accidental skipping of a pre-condition check
which must return True before parenthesis normalization of a specific
child Leaf or Node can happen. The pre-condition check being skipped
was why the colon was wrapped in invisible parentheses.