### PR TITLE
Black requires Python 3.6.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _Contents:_ **[Installation and usage](#installation-and-usage)** |
 
 ### Installation
 
-_Black_ can be installed by running `pip install black`. It requires Python 3.6.0+ to
+_Black_ can be installed by running `pip install black`. It requires Python 3.6.2+ to
 run but you can reformat Python 2 code with it, too.
 
 #### Install from GitHub

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -103,9 +103,9 @@ def _get_virtualenv_site_packages(venv_path, pyver):
   return venv_path / 'lib' / f'python{pyver[0]}.{pyver[1]}' / 'site-packages'
 
 def _initialize_black_env(upgrade=False):
-  pyver = sys.version_info[:2]
-  if pyver < (3, 6):
-    print("Sorry, Black requires Python 3.6+ to run.")
+  pyver = sys.version_info[:3]
+  if pyver < (3, 6, 2):
+    print("Sorry, Black requires Python 3.6.2+ to run.")
     return False
 
   from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import sys
 import os
 
-assert sys.version_info >= (3, 6, 0), "black requires Python 3.6+"
+assert sys.version_info >= (3, 6, 2), "black requires Python 3.6.2+"
 from pathlib import Path  # noqa E402
 
 CURRENT_DIR = Path(__file__).parent
@@ -65,7 +65,7 @@ setup(
     packages=["blackd", "black", "blib2to3", "blib2to3.pgen2", "black_primer"],
     package_dir={"": "src"},
     package_data={"blib2to3": ["*.txt"], "black": ["py.typed"]},
-    python_requires=">=3.6",
+    python_requires=">=3.6.2",
     zip_safe=False,
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
Fixes https://github.com/psf/black/issues/1666.

Update README to say 3.6.2+ is required, not 3.6.0+.

Plus update the checks in `black.vim` and `setup.py` to check for 3.6.2+ rather than 3.6+ aka 3.6.0+.
