### PR TITLE
Handle .COLOR_DIFF in the same way as .DIFF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 - fixed a crash when PWD=/ on POSIX (#1631)
 
+- Prevent coloured diff output being interleaved with multiple files (#1673)
+
 ### 20.8b1
 
 #### _Packaging_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -661,7 +661,7 @@ def reformat_one(
                 changed = Changed.YES
         else:
             cache: Cache = {}
-            if write_back != WriteBack.DIFF:
+            if write_back not in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
                 cache = read_cache(mode)
                 res_src = src.resolve()
                 if res_src in cache and cache[res_src] == get_cache_info(res_src):
@@ -735,7 +735,7 @@ async def schedule_formatting(
     :func:`format_file_in_place`.
     """
     cache: Cache = {}
-    if write_back != WriteBack.DIFF:
+    if write_back not in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
         cache = read_cache(mode)
         sources, cached = filter_cached(cache, sources)
         for src in sorted(cached):
@@ -746,7 +746,7 @@ async def schedule_formatting(
     cancelled = []
     sources_to_cache = []
     lock = None
-    if write_back == WriteBack.DIFF:
+    if write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
         # For diff output, we need locks to ensure we don't interleave output
         # from different processes.
         manager = Manager()

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1395,9 +1395,29 @@ class BlackTestCase(unittest.TestCase):
             src = (workspace / "test.py").resolve()
             with src.open("w") as fobj:
                 fobj.write("print('hello')")
-            self.invokeBlack([str(src), "--diff"])
-            cache_file = black.get_cache_file(mode)
-            self.assertFalse(cache_file.exists())
+            with patch("black.read_cache") as read_cache, patch(
+                "black.write_cache"
+            ) as write_cache:
+                self.invokeBlack([str(src), "--diff"])
+                cache_file = black.get_cache_file(mode)
+                self.assertFalse(cache_file.exists())
+                write_cache.assert_not_called()
+                read_cache.assert_not_called()
+
+    def test_no_cache_when_writeback_color_diff(self) -> None:
+        mode = DEFAULT_MODE
+        with cache_dir() as workspace:
+            src = (workspace / "test.py").resolve()
+            with src.open("w") as fobj:
+                fobj.write("print('hello')")
+            with patch("black.read_cache") as read_cache, patch(
+                "black.write_cache"
+            ) as write_cache:
+                self.invokeBlack([str(src), "--diff", "--color"])
+                cache_file = black.get_cache_file(mode)
+                self.assertFalse(cache_file.exists())
+                write_cache.assert_not_called()
+                read_cache.assert_not_called()
 
     def test_no_cache_when_stdin(self) -> None:
         mode = DEFAULT_MODE

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1428,7 +1428,7 @@ class BlackTestCase(unittest.TestCase):
                 with src.open("w") as fobj:
                     fobj.write("print('hello')")
             with patch("black.Manager", wraps=multiprocessing.Manager) as mgr:
-                self.invokeBlack(["--diff", str(workspace)], exit_code=123)
+                self.invokeBlack(["--diff", str(workspace)], exit_code=0)
                 # this isn't quite doing what we want, but if it _isn't_
                 # called then we cannot be using the lock it provides
                 mgr.assert_called()
@@ -1441,7 +1441,7 @@ class BlackTestCase(unittest.TestCase):
                 with src.open("w") as fobj:
                     fobj.write("print('hello')")
             with patch("black.Manager", wraps=multiprocessing.Manager) as mgr:
-                self.invokeBlack(["--diff", "--color", str(workspace)], exit_code=123)
+                self.invokeBlack(["--diff", "--color", str(workspace)], exit_code=0)
                 # this isn't quite doing what we want, but if it _isn't_
                 # called then we cannot be using the lock it provides
                 mgr.assert_called()


### PR DESCRIPTION
Whilst poking around checking how diff output was generated I noticed that the behaviour for these two values seemed to not be handled consistently.

Added a couple of tests to demonstrate and resolved the points where that seems to occur.