### PR TITLE
docs: add mention to isort profile option

### DIFF
--- a/docs/compatible_configs.md
+++ b/docs/compatible_configs.md
@@ -16,6 +16,9 @@ tools, using **their** supported file formats.
 _Black_ also formats imports, but in a different way from isort's defaults which leads
 to conflicting changes.
 
+isort provides the following settings in a configuration profile called `black`, for
+convenience.
+
 ### Configuration
 
 ```
@@ -25,6 +28,12 @@ force_grid_wrap = 0
 use_parentheses = True
 ensure_newline_before_comments = True
 line_length = 88
+```
+
+Or, using the `black` profile included with isort:
+
+```
+profile = black
 ```
 
 ### Why those options above?
@@ -88,6 +97,13 @@ ensure_newline_before_comments = True
 line_length = 88
 ```
 
+Or, using the `black` profile included with isort:
+
+```cfg
+[settings]
+profile = black
+```
+
 </details>
 
 <details>
@@ -101,6 +117,13 @@ force_grid_wrap = 0
 use_parentheses = True
 ensure_newline_before_comments = True
 line_length = 88
+```
+
+Or, using the `black` profile included with isort:
+
+```cfg
+[isort]
+profile = black
 ```
 
 </details>


### PR DESCRIPTION
isort has a `black` profile built-in, with those settings already configured, so getting it to work with Black can be as easy as saying `profile = black` on its settings.

Sure, if the user wants to customize maximum line length or something like that, they'd most likely have to take the long approach, but if they're fine with the defaults of Black, that profile setting can be very handy.

I was quite unsure about how to correctly add those references, so I tried doing it in a way I felt was doable, but feedback is appreciated.

I'm adding it here because I've been searching for that myself for a while, and only today have I discovered isort has pre-built config profiles, and that helped me a whole lot.