### PR TITLE
End 'force-exclude' help message with a period

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Options:
 
   --force-exclude TEXT            Like --exclude, but files and directories
                                   matching this regex will be excluded even
-                                  when they are passed explicitly as arguments
+                                  when they are passed explicitly as arguments.
 
   -q, --quiet                     Don't emit non-error messages to stderr.
                                   Errors are still emitted; silence those with

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -88,7 +88,7 @@ Options:
 
   --force-exclude TEXT            Like --exclude, but files and directories
                                   matching this regex will be excluded even
-                                  when they are passed explicitly as arguments
+                                  when they are passed explicitly as arguments.
 
   -q, --quiet                     Don't emit non-error messages to stderr.
                                   Errors are still emitted; silence those with

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -454,7 +454,7 @@ def target_version_option_callback(
     type=str,
     help=(
         "Like --exclude, but files and directories matching this regex will be "
-        "excluded even when they are passed explicitly as arguments"
+        "excluded even when they are passed explicitly as arguments."
     ),
 )
 @click.option(


### PR DESCRIPTION
It would be nice, if like other options help message, force-exclude's
help message also ends with a period punctuation mark.