### PR TITLE
Primer: Hypothesis is now formatted with Black 20.8b1

### DIFF
--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -47,7 +47,7 @@
     },
     "hypothesis": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/HypothesisWorks/hypothesis.git",
       "long_checkout": false,
       "py_versions": ["all"]


### PR DESCRIPTION
Fixes the Primer CI.

Hypothesis updated from Black 19.10b0 to 20.8b1 in https://github.com/HypothesisWorks/hypothesis/pull/2610, so we now expect no formatting changes.