### PR TITLE
Primer: pyramid and sqlalchemy are now formatted with latest Black

### DIFF
--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -77,7 +77,7 @@
     },
     "pyramid": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/Pylons/pyramid.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -98,7 +98,7 @@
     },
     "sqlalchemy": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/sqlalchemy/sqlalchemy.git",
       "long_checkout": false,
       "py_versions": ["all"]


### PR DESCRIPTION
* https://github.com/Pylons/pyramid/pull/3616
* https://github.com/sqlalchemy/sqlalchemy/commit/c3f102c9fe9811fd5286628cc6aafa5fbc324621

Turns Primer CI back green.

