### PR TITLE
docs: update `used-by` link to proper url

### DIFF
--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -167,7 +167,7 @@ know!)
 
 ## NOTE: This is a beta product
 
-_Black_ is already [successfully used](#used-by) by many projects, small and big. It
+_Black_ is already [successfully used](https://github.com/psf/black#used-by) by many projects, small and big. It
 also sports a decent test suite. However, it is still very new. Things will probably be
 wonky for a while. This is made explicit by the "Beta" trove classifier, as well as by
 the "b" in the version number. What this means for you is that **until the formatter


### PR DESCRIPTION
<img width="681" alt="image" src="https://user-images.githubusercontent.com/61443847/95320191-172f5900-08d4-11eb-83ed-7d09cee1d77c.png">

In the document of current version, clicking **successfully used** link (see above picture) does nothing, as the anchor has been removed (or replaced, I'm not really sure).

This PR updates links to actual **used by** section of `README.md`, instead of anchor tag, as currently this was the only one I can find.

Please note that this was my first open source contribution, so if there is any problem, please let me know! 😃