### PR TITLE
respect .gitignore files in all levels.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 #### _Black_
 
+- `Black` now respects `.gitignore` files in all levels, not only `root/.gitignore` file
+  (#1750).
+
 - `Black` now respects `--skip-string-normalization` when normalizing multiline
   docstring quotes (#1637)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 #### _Black_
 
 - `Black` now respects `.gitignore` files in all levels, not only `root/.gitignore` file
-  (#1750).
+  (like `git` does) (#1750).
 
 - `Black` now respects `--skip-string-normalization` when normalizing multiline
   docstring quotes (#1637)

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5915,14 +5915,23 @@ def get_future_imports(node: Node) -> Set[str]:
     return imports
 
 
+def get_gitignore_files(root: Path) -> Iterator[Path]:
+    """Yields list of `.gitignore` files paths."""
+    for path in root.iterdir():
+        gitignore = root / ".gitignore"
+        if gitignore.is_file():
+            yield gitignore
+        if path.is_dir():
+            yield from get_gitignore_files(path)
+
+
 @lru_cache()
 def get_gitignore(root: Path) -> PathSpec:
-    """ Return a PathSpec matching gitignore content if present."""
-    gitignore = root / ".gitignore"
-    lines: List[str] = []
-    if gitignore.is_file():
-        with gitignore.open() as gf:
-            lines = gf.readlines()
+    """Return a PathSpec matching gitignore content if present."""
+    lines: Set[str] = set()
+    for path in get_gitignore_files(root):
+        with path.open() as gf:
+            lines |= set(gf.readlines())
     return PathSpec.from_lines("gitwildmatch", lines)
 
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5917,10 +5917,10 @@ def get_future_imports(node: Node) -> Set[str]:
 
 def get_gitignore_files(root: Path) -> Iterator[Path]:
     """Yields list of `.gitignore` files paths."""
+    gitignore = root / ".gitignore"
+    if gitignore.is_file():
+        yield gitignore
     for path in root.iterdir():
-        gitignore = root / ".gitignore"
-        if gitignore.is_file():
-            yield gitignore
         if path.is_dir():
             yield from get_gitignore_files(path)
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -67,8 +67,9 @@ def cache_dir(exists: bool = True) -> Iterator[Path]:
         cache_dir = Path(workspace)
         if not exists:
             cache_dir = cache_dir / "new"
-        with patch("black.CACHE_DIR", cache_dir):
-            yield cache_dir
+        with patch("black.get_gitignore_files"):
+            with patch("black.CACHE_DIR", cache_dir):
+                yield cache_dir
 
 
 @contextmanager


### PR DESCRIPTION
`Black` now respects `.gitignore` files in all levels, not only `root/.gitignore` file (apply `.gitignore` rules like `git` does).

Fix: #1730 

