### PR TITLE
Fix GitHub markdown links to work on RTD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ your PR. You may need to change
 configuration for it to pass.
 
 For more `black-primer` information visit the
-[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md#).
+[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md#black-primer).
 
 ## Hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ your PR. You may need to change
 configuration for it to pass.
 
 For more `black-primer` information visit the
-[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md).
+[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md#).
 
 ## Hygiene
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ about _Black_'s changes or will overwrite _Black_'s changes. A good example of t
 should be configured to neither warn about nor overwrite _Black_'s changes.
 
 Actual details on _Black_ compatible configurations for various tools can be found in
-[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md).
+[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md#).
 
 ### Migrating your code style without ruining git blame
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ about _Black_'s changes or will overwrite _Black_'s changes. A good example of t
 should be configured to neither warn about nor overwrite _Black_'s changes.
 
 Actual details on _Black_ compatible configurations for various tools can be found in
-[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md#).
+[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md#black-compatible-configurations).
 
 ### Migrating your code style without ruining git blame
 

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -132,6 +132,7 @@ Multiple contributions by:
 - [Paul Ganssle](mailto:p.ganssle@gmail.com)
 - [Paul Meinhardt](mailto:mnhrdt@gmail.com)
 - [Peter Bengtsson](mailto:mail@peterbe.com)
+- [Peter Grayson](mailto:pete@jpgrayson.net)
 - [Peter Stensmyr](mailto:peter.stensmyr@gmail.com)
 - pmacosta
 - [Quentin Pradet](mailto:quentin@pradet.me)

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -17,6 +17,12 @@
 
 - fixed a crash when PWD=/ on POSIX (#1631)
 
+- fixed "I/O operation on closed file" when using --diff (#1664)
+
+- Prevent coloured diff output being interleaved with multiple files (#1673)
+
+- Added support for PEP 614 relaxed decorator syntax on python 3.9 (#1711)
+
 ### 20.8b1
 
 #### _Packaging_

--- a/docs/contributing_to_black.md
+++ b/docs/contributing_to_black.md
@@ -54,7 +54,7 @@ your PR. You may need to change
 configuration for it to pass.
 
 For more `black-primer` information visit the
-[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md).
+[documentation](https://github.com/psf/black/blob/master/docs/black_primer.md#).
 
 ## Hygiene
 

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -119,7 +119,7 @@ about _Black_'s changes or will overwrite _Black_'s changes. A good example of t
 should be configured to neither warn about nor overwrite _Black_'s changes.
 
 Actual details on _Black_ compatible configurations for various tools can be found in
-[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md).
+[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md#).
 
 ## Migrating your code style without ruining git blame
 
@@ -167,12 +167,13 @@ know!)
 
 ## NOTE: This is a beta product
 
-_Black_ is already [successfully used](#used-by) by many projects, small and big. It
-also sports a decent test suite. However, it is still very new. Things will probably be
-wonky for a while. This is made explicit by the "Beta" trove classifier, as well as by
-the "b" in the version number. What this means for you is that **until the formatter
-becomes stable, you should expect some formatting to change in the future**. That being
-said, no drastic stylistic changes are planned, mostly responses to bug reports.
+_Black_ is already [successfully used](https://github.com/psf/black#used-by) by many
+projects, small and big. It also sports a decent test suite. However, it is still very
+new. Things will probably be wonky for a while. This is made explicit by the "Beta"
+trove classifier, as well as by the "b" in the version number. What this means for you
+is that **until the formatter becomes stable, you should expect some formatting to
+change in the future**. That being said, no drastic stylistic changes are planned,
+mostly responses to bug reports.
 
 Also, as a temporary safety measure, _Black_ will check that the reformatted code still
 produces a valid AST that is equivalent to the original. This slows it down. If you're


### PR DESCRIPTION
Links to Markdown files on readthedocs.io are swallowing the `.md` extension, causing 404s. Example: from README.md, the text

```markdown
[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md)
```

is creating a link to https://github.com/psf/black/blob/master/docs/compatible_configs, which does not exist. ([Here's the relevant paragraph on RTD.](https://black.readthedocs.io/en/stable/installation_and_usage.html#using-black-with-other-tools)) Pointing to a specific anchor seems to fix it, e.g.,

```markdown
[compatible_configs](https://github.com/psf/black/blob/master/docs/compatible_configs.md#black-compatible-configurations)
```

Note that these still lead to GitHub, instead of staying on RTD, which feels a little odd from the user side (but was needed to make links work on PyPI in #1397.)

EDIT: It looks like this has been fixed in https://github.com/readthedocs/recommonmark/pull/181, so next release of recommonmark would make these changes moot.