### PR TITLE
Add blackd to nicely exit if missing aiohttp deps

### DIFF
--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -15,7 +15,7 @@ except ImportError as ie:
         f"aiohttp dependency is not installed: {ie}. "
         + "Please re-install black with the '[d]' extra install "
         + "to obtain aiohttp_cors: `pip install black[d]`",
-        file=sys.stderr
+        file=sys.stderr,
     )
     sys.exit(-1)
 

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -1,13 +1,24 @@
 import asyncio
+import logging
+import sys
 from concurrent.futures import Executor, ProcessPoolExecutor
 from datetime import datetime
 from functools import partial
-import logging
 from multiprocessing import freeze_support
 from typing import Set, Tuple
 
-from aiohttp import web
-import aiohttp_cors
+try:
+    from aiohttp import web
+    import aiohttp_cors
+except ImportError as ie:
+    print(
+        f"aiohttp dependency is not installed: {ie}. "
+        + "Please re-install black with the '[d]' extra install "
+        + "to obtain aiohttp_cors: `pip install black[d]`",
+        file=sys.stderr
+    )
+    sys.exit(-1)
+
 import black
 import click
 


### PR DESCRIPTION
- If no aiohttp* deps exist nicely print a helpful message and exit
- There seems to be no nice way to optionally install the entry point, so lets make the entry point nicer

Test:
```
cooper-mbp1:black cooper$ /tmp/tb/bin/pip install .
cooper-mbp1:black cooper$ /tmp/tb/bin/blackd
aiohttp dependency is not installed: No module named 'aiohttp'. Please re-install black with the '[d]' extra install to obtain aiohttp_cors: `pip install black[d]`
cooper-mbp1:black cooper$ /tmp/tb/bin/pip install .[d]
...
Successfully installed aiohttp-3.6.3 aiohttp-cors-0.7.0 black
cooper-mbp1:black cooper$ /tmp/tb/bin/blackd
blackd version 20.8b2.dev31+gdd2f86a.d20201013 listening on localhost port 45484
```

Fixes #1688