### PR TITLE
Update PyCharm integrations instructions to avoid running on external changes

### DIFF
--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -72,7 +72,9 @@ On Windows / Linux / BSD:
       - Output paths to refresh: `$FilePath$`
       - Working directory: `$ProjectFileDir$`
 
-   - Uncheck "Auto-save edited files to trigger the watcher" in Advanced Options
+   - In Advanced Options
+     - Uncheck "Auto-save edited files to trigger the watcher"
+     - Uncheck "Trigger the watcher on external changes"
 
 ## Wing IDE
 


### PR DESCRIPTION
As described [here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000151324-VCS-git-file-watchers?page=1#community_comment_360000095170), whenever PyCharm switches branches, it will run File Watchers on all of the changed files. What this leads to in practice is `black` getting fired off on many files when branches are switches, which is often not what the developer expects and can be quite slow.

This is especially bad if you are switching between branches where some of your files are not "black-ified" yet, as it will fire off on the files without the developer having control.

This change brings the setting in line with only running `black` when a developer opts-in and pressing `Ctrl-S`, which is what the docs were already pushing for by disabling Auto-save triggers.