### PR TITLE
Update readme.md with current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Use [pre-commit](https://pre-commit.com/). Once you
 ```yaml
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/docs/version_control_integration.md
+++ b/docs/version_control_integration.md
@@ -9,7 +9,7 @@ Use [pre-commit](https://pre-commit.com/). Once you
 ```yaml
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+


### PR DESCRIPTION
Update suggested pre-commit config with current version of black, so anyone who will copy-paste the config will already have the newest version without having to manually fix the version number.