### PR TITLE
Start using Python 3.9 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
       python: 3.8
     - name: "3.9"
       python: 3.9
-  allow_failures:
-    - python: 3.9
 before_deploy:
   - pip install pyinstaller
   - pyinstaller --clean -F --add-data src/blib2to3/:blib2to3 src/black/__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
     - name: "3.8"
       python: 3.8
     - name: "3.9"
-      python: 3.9-dev
+      python: 3.9
   allow_failures:
-    - python: 3.9-dev
+    - python: 3.9
 before_deploy:
   - pip install pyinstaller
   - pyinstaller --clean -F --add-data src/blib2to3/:blib2to3 src/black/__init__.py


### PR DESCRIPTION
Travis-CI started giving support for Python 3.9 [https://travis-ci.community/t/python-3-9-0-build/10091](https://travis-ci.community/t/python-3-9-0-build/10091) so I thought it would be nice to use it.