### PR TITLE
Correctly handle inline tabs in docstrings

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6744,14 +6744,33 @@ def is_docstring(leaf: Leaf) -> bool:
     return False
 
 
+def lines_with_leading_tabs_expanded(s: str) -> List[str]:
+    """
+    Splits string into lines and expands only leading tabs (following the normal
+    Python rules)
+    """
+    lines = []
+    for line in s.splitlines():
+        # Find the index of the first non-whitespace character after a string of
+        # whitespace that includes at least one tab
+        match = re.match(r"\s*\t+\s*(\S)", line)
+        if match:
+            first_non_whitespace_idx = match.start(1)
+
+            lines.append(
+                line[:first_non_whitespace_idx].expandtabs()
+                + line[first_non_whitespace_idx:]
+            )
+        else:
+            lines.append(line)
+    return lines
+
+
 def fix_docstring(docstring: str, prefix: str) -> str:
     # https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
     if not docstring:
         return ""
-    # Convert leading tabs to spaces (following the normal Python rules)
-    # and split into a list of lines:
-    docstring_expanded = re.sub(r"^\t+", "\t".expandtabs(), docstring, flags=re.M)
-    lines = docstring_expanded.splitlines()
+    lines = lines_with_leading_tabs_expanded(docstring)
     # Determine minimum indentation (first line doesn't count):
     indent = sys.maxsize
     for line in lines[1:]:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6748,9 +6748,10 @@ def fix_docstring(docstring: str, prefix: str) -> str:
     # https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
     if not docstring:
         return ""
-    # Convert tabs to spaces (following the normal Python rules)
+    # Convert leading tabs to spaces (following the normal Python rules)
     # and split into a list of lines:
-    lines = docstring.expandtabs().splitlines()
+    docstring_expanded = re.sub(r"^\t+", "\t".expandtabs(), docstring, flags=re.M)
+    lines = docstring_expanded.splitlines()
     # Determine minimum indentation (first line doesn't count):
     indent = sys.maxsize
     for line in lines[1:]:

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -111,12 +111,30 @@ def ignored_docstring():
 b"""  
 
 
-def docstring_with_inline_tabs():
+def docstring_with_inline_tabs_and_space_indentation():
     """hey
 
     tab	separated	value
-    	tab at a start of line and then a tab	separated	value
+    	tab at start of line and then a tab	separated	value
+    				multiple tabs at the beginning	and	inline
+    	 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+    			 	  		
+    line ends with some tabs		
     """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+	"""hey
+
+	tab	separated	value
+		tab at start of line and then a tab	separated	value
+					multiple tabs at the beginning	and	inline
+		 	  	mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+				 	  		
+	line ends with some tabs		
+	"""
+	pass
+        
 
 # output
 
@@ -233,9 +251,26 @@ def ignored_docstring():
 b"""
 
 
-def docstring_with_inline_tabs():
+def docstring_with_inline_tabs_and_space_indentation():
     """hey
 
     tab	separated	value
-    	tab at a start of line and then a tab	separated	value
+        tab at start of line and then a tab	separated	value
+                                multiple tabs at the beginning	and	inline
+                        mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
     """
+
+
+def docstring_with_inline_tabs_and_tab_indentation():
+    """hey
+
+    tab	separated	value
+            tab at start of line and then a tab	separated	value
+                                    multiple tabs at the beginning	and	inline
+                            mixed tabs and spaces at beginning. next line has mixed tabs and spaces only.
+
+    line ends with some tabs
+    """
+    pass

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -110,6 +110,14 @@ def ignored_docstring():
     """a => \
 b"""  
 
+
+def docstring_with_inline_tabs():
+    """hey
+
+    tab	separated	value
+    	tab at a start of line and then a tab	separated	value
+    """
+
 # output
 
 class MyClass:
@@ -223,3 +231,11 @@ def believe_it_or_not_this_is_in_the_py_stdlib():
 def ignored_docstring():
     """a => \
 b"""
+
+
+def docstring_with_inline_tabs():
+    """hey
+
+    tab	separated	value
+    	tab at a start of line and then a tab	separated	value
+    """


### PR DESCRIPTION
The `fix_docstring` function expanded all tabs, which caused a
difference in the AST representation when those tabs were inline and not
leading. This changes the function to only expand leading tabs so inline
tabs are preserved.

Fixes #1601.