### PR TITLE
[src/black/__init__.py] Drop `typed_ast` on Python 3.10+

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -49,7 +49,11 @@ from appdirs import user_cache_dir
 from dataclasses import dataclass, field, replace
 import click
 import toml
-from typed_ast import ast3, ast27
+
+if sys.version_info >= (3, 10):
+    ast3 = ast27 = ast
+else:
+    from typed_ast import ast3, ast27
 from pathspec import PathSpec
 
 # lib2to3 fork


### PR DESCRIPTION
Tracking issue for Python 3.10 support in `typed_ast`: https://github.com/python/typed_ast/issues/150

In the meantime, this makes `black` somewhat usable in 3.10

(maybe keep open and not merge? - Your call…)