### PR TITLE
Switch back to Python 3.8 for ReadTheDocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: setuptools


### PR DESCRIPTION
ReadTheDocs doesn't support Python 3.9 yet.

![Screenshot from 2020-11-25 18-28-56](https://user-images.githubusercontent.com/63936253/100291714-862c4400-2f4c-11eb-8729-e9de2e09d5c7.png)
