### PR TITLE
Update example exclude to match only files in root

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,10 @@ line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
 exclude = '''
-
-(
-  /(
+# A regex preceded with ^/ will apply only to files in the root of
+# the project.
+^/(
+  (
       \.eggs         # exclude a few common directories in the
     | \.git          # root of the project
     | \.hg

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
 exclude = '''
-# A regex preceded with ^/ will apply only to files in the root of
-# the project.
+# A regex preceded with ^/ will apply only to files and directories
+# in the root of the project.
 ^/(
   (
       \.eggs         # exclude a few common directories in the


### PR DESCRIPTION
The `exclude` section of the example `pyproject.toml` file didn't work as expected. It claimed to exclude matched files only in the project root, but it actually excluded matched files at any directory level within the project. We can address this by prepending `^/` to the regex to ensure that it only matches files in the project root.

See https://github.com/psf/black/issues/1473#issuecomment-740008873 for explanation.