### PR TITLE
Add pyi file support to .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,9 @@ repos:
         name: black
         language: system
         entry: black
+        minimum_pre_commit_version: 2.9.0
         require_serial: true
-        types: [python]
+        types_or: [python, pyi]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.1

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,6 @@
   entry: black
   language: python
   language_version: python3
+  minimum_pre_commit_version: 2.9.0
   require_serial: true
-  types: [python]
+  types_or: [python, pyi]


### PR DESCRIPTION
Since pre-commit 2.9.0 (2020-11-21), the types_or key can be used to
match multiple disparate file types. For more upstream details, see:
https://github.com/pre-commit/pre-commit/issues/607

Fixes #402