### PR TITLE
Fuzz on Python 3.9 too

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8] # Python3.9 should be added after fixing [https://github.com/Zac-HD/hypothesmith/issues/11].
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fuzzing on Python 3.9 used to cause errors but now they [have disappeared
on more modern Python 3.9 and Hypothesmith](https://github.com/ichard26/black/runs/1607360235?check_suite_focus=true).

See also #1749
