### PR TITLE
Bump mypy to 0.780 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.780
     hooks:
       - id: mypy
         exclude: ^docs/conf.py

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -59,10 +59,12 @@ async def _gen_check_output(
         raise
 
     if process.returncode != 0:
+        returncode = process.returncode
+        if returncode is None:
+            returncode = 69
+
         cmd_str = " ".join(cmd)
-        raise CalledProcessError(
-            process.returncode, cmd_str, output=stdout, stderr=stderr
-        )
+        raise CalledProcessError(returncode, cmd_str, output=stdout, stderr=stderr)
 
     return (stdout, stderr)
 


### PR DESCRIPTION
Resolves #1886.

To avoid hitting a mypy bug causes pre-commit to always fail on CPython
3.9. Even though it's still an outdated version, the bug effectively
blocks development on CPython 3.9 so that's why this commit exists
instead of waiting for cooperlees to finish his bump to 0.790 PR.

Also this fixes primer to ensure it always raises CalledProcessError
with an int error code. I stole the patch from cooperlees's mypy bump
PR.

It's funny how mypy 0.790 is already asked for in our
Pipfile.lock file, but oh well mypy is probably more commonly run
through pre-commit than standalone I guess.

Oh and if you're curious why the bug doesn't up on CPython 3.8 or lower:
there was some subscription AST changes in CPython 3.9.