### PR TITLE
Bump minimum_pre_commit_version per recommendation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         name: black
         language: system
         entry: black
-        minimum_pre_commit_version: 2.9.0
+        minimum_pre_commit_version: 2.9.2
         require_serial: true
         types_or: [python, pyi]
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,6 @@
   entry: black
   language: python
   language_version: python3
-  minimum_pre_commit_version: 2.9.0
+  minimum_pre_commit_version: 2.9.2
   require_serial: true
   types_or: [python, pyi]


### PR DESCRIPTION
Recommended by @asottile, the pre-commit author and maintainer, to avoid
some breakages in version 2.9.0.