### PR TITLE
Use Prettier pre-commit mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
       - id: mypy
         exclude: ^docs/conf.py
 
-  - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v1.19.1
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]


### PR DESCRIPTION
This fixes Prettier install failures similar to those seen in https://github.com/prettier/prettier/issues/9459, and is the solution recommended there.