### PR TITLE
Strip redundant parentheses from assignment exprs

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5540,17 +5540,19 @@ def maybe_make_parens_invisible_in_atom(node: LN, parent: LN) -> bool:
     Returns whether the node should itself be wrapped in invisible parentheses.
 
     """
+
     if (
         node.type != syms.atom
         or is_empty_tuple(node)
         or is_one_tuple(node)
         or (is_yield(node) and parent.type != syms.expr_stmt)
         or max_delimiter_priority_in_atom(node) >= COMMA_PRIORITY
-        or parent.type == syms.expr_stmt
-        and parent.children[1].type == token.EQUAL
-        and is_walrus_assignment(node)
     ):
         return False
+
+    if is_walrus_assignment(node):
+        if parent.type in [syms.annassign, syms.expr_stmt]:
+            return False
 
     first = node.children[0]
     last = node.children[-1]

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5368,10 +5368,7 @@ def normalize_invisible_parens(node: Node, parens_after: Set[str]) -> None:
             check_lpar = True
 
         if check_lpar:
-            if is_walrus_assignment(child):
-                pass
-
-            elif child.type == syms.atom:
+            if child.type == syms.atom:
                 if maybe_make_parens_invisible_in_atom(child, parent=node):
                     wrap_in_parentheses(node, child, visible=False)
             elif is_one_tuple(child):
@@ -5549,6 +5546,9 @@ def maybe_make_parens_invisible_in_atom(node: LN, parent: LN) -> bool:
         or is_one_tuple(node)
         or (is_yield(node) and parent.type != syms.expr_stmt)
         or max_delimiter_priority_in_atom(node) >= COMMA_PRIORITY
+        or parent.type == syms.expr_stmt
+        and parent.children[1].type == token.EQUAL
+        and is_walrus_assignment(node)
     ):
         return False
 

--- a/tests/data/pep_572.py
+++ b/tests/data/pep_572.py
@@ -2,7 +2,7 @@
 (a := a)
 if (match := pattern.search(data)) is None:
     pass
-if (match := pattern.search(data)):
+if match := pattern.search(data):
     pass
 [y := f(x), y ** 2, y ** 3]
 filtered_data = [y for x in data if (y := f(x)) is None]
@@ -43,5 +43,5 @@ foo(c=(b := 2), a=1)
 
 while x := f(x):
     pass
-while (x := f(x)):
+while x := f(x):
     pass

--- a/tests/data/pep_572_remove_parens.py
+++ b/tests/data/pep_572_remove_parens.py
@@ -1,0 +1,10 @@
+if (foo := 0):
+    pass
+
+y = (x := 0)
+
+# output
+if foo := 0:
+    pass
+
+y = (x := 0)

--- a/tests/data/pep_572_remove_parens.py
+++ b/tests/data/pep_572_remove_parens.py
@@ -1,10 +1,38 @@
 if (foo := 0):
     pass
 
+if (foo := 1):
+    pass
+
+if (y := 5 + 5):
+    pass
+
 y = (x := 0)
+
+y += (x := 0)
+
+(y := 5 + 5)
+
+test: int = (test2 := 2)
+
+a, b = (test := (1, 2))
 
 # output
 if foo := 0:
     pass
 
+if foo := 1:
+    pass
+
+if y := 5 + 5:
+    pass
+
 y = (x := 0)
+
+y += (x := 0)
+
+(y := 5 + 5)
+
+test: int = (test2 := 2)
+
+a, b = (test := (1, 2))

--- a/tests/data/remove_parens.py
+++ b/tests/data/remove_parens.py
@@ -54,6 +54,9 @@ def example7():
 def example8():
     return (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((None)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
+def example9():
+    if (foo := 0):
+        pass
 
 # output
 x = 1
@@ -142,3 +145,7 @@ def example7():
 def example8():
     return None
 
+
+def example9():
+    if foo := 0:
+        pass

--- a/tests/data/remove_parens.py
+++ b/tests/data/remove_parens.py
@@ -54,10 +54,6 @@ def example7():
 def example8():
     return (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((None)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
-def example9():
-    if (foo := 0):
-        pass
-
 # output
 x = 1
 x = 1.2
@@ -144,8 +140,3 @@ def example7():
 
 def example8():
     return None
-
-
-def example9():
-    if foo := 0:
-        pass

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -263,6 +263,15 @@ class BlackTestCase(BlackBaseTestCase):
         if sys.version_info >= (3, 8):
             black.assert_equivalent(source, actual)
 
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_pep_572_remove_parens(self) -> None:
+        source, expected = read_data("pep_572_remove_parens")
+        actual = fs(source)
+        self.assertFormatEqual(expected, actual)
+        black.assert_stable(source, actual, DEFAULT_MODE)
+        if sys.version_info >= (3, 8):
+            black.assert_equivalent(source, actual)
+
     def test_pep_572_version_detection(self) -> None:
         source, _ = read_data("pep_572")
         root = black.lib2to3_parse(source)


### PR DESCRIPTION
#1656 

This converts code of the form:

```
if (foo := 0):
    pass
```

into

```
if foo := 0:
    pass
```

which is consistent with how `if (foo):` is transformed into `if foo:` and also with examples in PEP 572. 

— 

Although all tests are passing, please review particularly this condition:
`and parent.children[1].type == token.EQUAL`

I am unsure if children[1] is always guaranteed to be the operator.