### PR TITLE
Fixed multiprocessing issue on win64 with more than 60 cores

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -741,7 +741,7 @@ def reformat_many(
     worker_count = os.cpu_count()
     if sys.platform == "win32":
         # Work around https://bugs.python.org/issue26903
-        worker_count = min(worker_count, 61)
+        worker_count = min(worker_count, 60)
     try:
         executor = ProcessPoolExecutor(max_workers=worker_count)
     except (ImportError, OSError):


### PR DESCRIPTION
#564 I was getting this issue on my machine (24 cores, 48 logical processors, `os.cpu_count()` returns 64)

Reducing the number of max workers from 61 to 60 fixed this issue for me.