### PR TITLE
Add `black` Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-slim
+
+RUN pip install --upgrade pip setuptools wheel
+RUN apt update && apt install -y git
+RUN mkdir /src
+COPY . /src/
+RUN cd /src && pip install --no-cache-dir .
+RUN rm -rf /src && apt remove -y git && apt autoremove -y
+
+CMD ["black"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip install --upgrade pip setuptools wheel
 RUN apt update && apt install -y git
 RUN mkdir /src
 COPY . /src/
-RUN cd /src && pip install --no-cache-dir .
+RUN cd /src && pip install --no-cache-dir .[colorama,d]
 RUN rm -rf /src && apt remove -y git && apt autoremove -y
 
 CMD ["black"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir .[colorama,d] \
     && rm -rf /src \
     && apt remove -y git \
-    && apt autoremove -y
+    && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 CMD ["black"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3-slim
 
-RUN pip install --upgrade pip setuptools wheel
-RUN apt update && apt install -y git
 RUN mkdir /src
 COPY . /src/
-RUN cd /src && pip install --no-cache-dir .[colorama,d]
-RUN rm -rf /src && apt remove -y git && apt autoremove -y
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && apt update && apt install -y git \
+    && cd /src \
+    && pip install --no-cache-dir .[colorama,d] \
+    && rm -rf /src \
+    && apt remove -y git \
+    && apt autoremove -y
 
 CMD ["black"]


### PR DESCRIPTION
- Build a `black` container based on python3-slim
- Test: `docker build --network-host --tag black .`
```console
cooper-mbp1:black cooper$ docker image ls
REPOSITORY                                         TAG            IMAGE ID       CREATED              SIZE
black                                              latest         0c7636402ac2   4 seconds ago        332MB
```

Addresses part of #1914