### PR TITLE
Fix Github action failing due to syntax error in entrypoint.sh

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # If no arguments are given use current working directory


### PR DESCRIPTION
# Problem

Running `- uses: psf/black@master` Github action step throws the following error:

`/entrypoint.sh: 5: /entrypoint.sh: Syntax error: "(" unexpected`

Bug seems to be introduced in https://github.com/psf/black/pull/1909

# Steps to reproduce

The following examples reproduce the issue + logs

### Example 1

```yaml
name: Lint in python container

on:
  push

jobs:
  lint:
    runs-on: ubuntu-latest
    container: python:3.8
    steps:
      - uses: actions/checkout@v2
      - uses: psf/black@master
```
See [logs](https://github.com/ThomasHagebols/BlackActionFailDemo/runs/1680786909?check_suite_focus=true)

### Example 2

```yaml
name: Lint setup-python

on:
  push

jobs:
  lint:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-python@v2
      - uses: psf/black@master
```
See [logs](https://github.com/ThomasHagebols/BlackActionFailDemo/runs/1680786900?check_suite_focus=true)

# Proposed solution

Currently, entrypoint.sh starts with the `#!/bin/sh` shebang. This causes an error since some parts of the script are non compliant to POSIX. Switching to a bash interpreter fixes the issue.

# Other references
@rickstaa @cooperlees 