### PR TITLE
OSS-Fuzz integration for Black's fuzz tests

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -56,4 +56,17 @@ def test_idempotent_any_syntatically_valid_python(
 
 
 if __name__ == "__main__":
+    # Run tests, including shrinking and reporting any known failures.
     test_idempotent_any_syntatically_valid_python()
+
+    # If Atheris is available, run coverage-guided fuzzing.
+    # (if you want only bounded fuzzing, just use `pytest fuzz.py`)
+    try:
+        import sys
+        import atheris
+    except ImportError:
+        pass
+    else:
+        test = test_idempotent_any_syntatically_valid_python
+        atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)
+        atheris.Fuzz()


### PR DESCRIPTION
[OSS-Fuzz](https://google.github.io/oss-fuzz/) is a service provided by Google and the Core Infrastructure Initiative, where critical or widely used projects can have their fuzzers run full-time.  So far they've found around 25,000 (!!) bugs in hundreds of open source projects.

Since I've recently [been asked](https://github.com/google/oss-fuzz/issues/4121) to [show how to use Hypothesis on OSS-Fuzz](https://github.com/google/oss-fuzz/pull/4975), and [Black is considered a critical project](https://github.com/ossf/criticality_score#public-data), I thought it would make sense to integrate Black with OSS-Fuzz directly.

As a bonus, OSS-Fuzz also provides a CI action to run fuzzing briefly on each PR (anywhere from six minutes up to the Actions timeout at six hours!) - this is *almost* a duplicate of the existing fuzz job, but integrates with the constant fuzzing so it can replay all known examples first off.  If you think that sounds a lot like vanilla Hypothesis, no coincidence - we've stolen a lot of features from cutting-edge fuzzing workflows, when we didn't independently invent them first!  (and our shrinking is still way better 😤)

-------------

If interested: merge this, and comment on https://github.com/google/oss-fuzz/pull/4977 to confirm that Black maintainers approve.  I'd also welcome Black maintainers to join the email list for bug reports, since it's otherwise just me 😅 