### PR TITLE
Consistency: bring default line length in-line with PEP8

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -68,7 +68,7 @@ else:
 if TYPE_CHECKING:
     import colorama  # noqa: F401
 
-DEFAULT_LINE_LENGTH = 88
+DEFAULT_LINE_LENGTH = 79
 DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
 DEFAULT_INCLUDES = r"\.pyi?$"
 CACHE_DIR = Path(user_cache_dir("black", version=__version__))

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -3,7 +3,7 @@
   "projects": {
     "aioexabgp": {
       "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/cooperlees/aioexabgp.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -17,7 +17,7 @@
     },
     "bandersnatch": {
       "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pypa/bandersnatch.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -40,7 +40,7 @@
     },
     "flake8-bugbear": {
       "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/PyCQA/flake8-bugbear.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -84,7 +84,7 @@
     },
     "ptr": {
       "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/facebookincubator/ptr.git",
       "long_checkout": false,
       "py_versions": ["all"]

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -172,7 +172,7 @@ class BlackTestCase(BlackBaseTestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertFormatEqual(expected, result.output)
         black.assert_equivalent(source, result.output)
-        black.assert_stable(source, result.output, mode=LEGACY_MODE)
+        black.assert_stable(source, result.output, LEGACY_MODE)
 
     def test_piping_diff(self) -> None:
         diff_header = re.compile(
@@ -253,7 +253,7 @@ class BlackTestCase(BlackBaseTestCase):
     def test_trailing_comma_optional_parens_stability3(self) -> None:
         source, _expected = read_data("trailing_comma_optional_parens3")
         actual = fs(source, mode=LEGACY_MODE)
-        black.assert_stable(source, actual, mode=LEGACY_MODE)
+        black.assert_stable(source, actual, LEGACY_MODE)
 
     @patch("black.dump_to_file", dump_to_stderr)
     def test_pep_572(self) -> None:
@@ -286,7 +286,7 @@ class BlackTestCase(BlackBaseTestCase):
         self.assertFormatEqual(expected, actual)
         with patch("black.dump_to_file", dump_to_stderr):
             black.assert_equivalent(source, actual)
-            black.assert_stable(source, actual, mode=LEGACY_MODE)
+            black.assert_stable(source, actual, LEGACY_MODE)
 
     def test_expression_diff(self) -> None:
         source, _ = read_data("expression.py")

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -303,7 +303,7 @@ class BlackTestCase(BlackBaseTestCase):
                     "--diff",
                     str(tmp_file),
                     "--line-length",
-                    "88",
+                    LEGACY_MODE.line_length,
                 ],
             )
             self.assertEqual(result.exit_code, 0)
@@ -1203,7 +1203,15 @@ class BlackTestCase(BlackBaseTestCase):
             self.invokeBlack([str(src1), "--diff", "--check"], exit_code=1)
             # Files which will not be reformatted.
             src2 = (THIS_DIR / "data" / "composition.py").resolve()
-            self.invokeBlack([str(src2), "--diff", "--check", "--line-length", "88"])
+            self.invokeBlack(
+                [
+                    str(src2),
+                    "--diff",
+                    "--check",
+                    "--line-length",
+                    LEGACY_MODE.line_length,
+                ]
+            )
             # Multi file command.
             self.invokeBlack([str(src1), str(src2), "--diff", "--check"], exit_code=1)
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -303,7 +303,7 @@ class BlackTestCase(BlackBaseTestCase):
                     "--diff",
                     str(tmp_file),
                     "--line-length",
-                    LEGACY_MODE.line_length,
+                    str(LEGACY_MODE.line_length),
                 ],
             )
             self.assertEqual(result.exit_code, 0)
@@ -1209,7 +1209,7 @@ class BlackTestCase(BlackBaseTestCase):
                     "--diff",
                     "--check",
                     "--line-length",
-                    LEGACY_MODE.line_length,
+                    str(LEGACY_MODE.line_length),
                 ]
             )
             # Multi file command.

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from unittest.mock import patch
 
 import black
@@ -81,18 +82,20 @@ class TestSimpleFormat(BlackBaseTestCase):
     @patch("black.dump_to_file", dump_to_stderr)
     def test_simple_format(self, filename: str) -> None:
         source, expected = read_data(filename)
-        actual = fs(source)
+        legacy_mode = replace(DEFAULT_MODE, line_length=88)
+        actual = fs(source, mode=legacy_mode)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, DEFAULT_MODE)
+        black.assert_stable(source, actual, mode=legacy_mode)
 
     @parameterized.expand(SOURCES)
     @patch("black.dump_to_file", dump_to_stderr)
     def test_source_is_formatted(self, filename: str) -> None:
         path = THIS_DIR.parent / filename
         source, expected = read_data(str(path), data=False)
-        actual = fs(source, mode=DEFAULT_MODE)
+        legacy_mode = replace(DEFAULT_MODE, line_length=88)
+        actual = fs(source, mode=legacy_mode)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, DEFAULT_MODE)
-        self.assertFalse(ff(path))
+        black.assert_stable(source, actual, mode=legacy_mode)
+        self.assertFalse(ff(path, mode=legacy_mode))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -86,7 +86,7 @@ class TestSimpleFormat(BlackBaseTestCase):
         actual = fs(source, mode=LEGACY_MODE)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, mode=LEGACY_MODE)
+        black.assert_stable(source, actual, LEGACY_MODE)
 
     @parameterized.expand(SOURCES)
     @patch("black.dump_to_file", dump_to_stderr)
@@ -96,5 +96,5 @@ class TestSimpleFormat(BlackBaseTestCase):
         actual = fs(source, mode=LEGACY_MODE)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, mode=LEGACY_MODE)
+        black.assert_stable(source, actual, LEGACY_MODE)
         self.assertFalse(ff(path, mode=LEGACY_MODE))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,4 +1,3 @@
-from dataclasses import replace
 from unittest.mock import patch
 
 import black
@@ -8,7 +7,6 @@ from tests.util import (
     BlackBaseTestCase,
     fs,
     ff,
-    DEFAULT_MODE,
     LEGACY_MODE,
     dump_to_stderr,
     read_data,

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -9,6 +9,7 @@ from tests.util import (
     fs,
     ff,
     DEFAULT_MODE,
+    LEGACY_MODE,
     dump_to_stderr,
     read_data,
     THIS_DIR,
@@ -82,20 +83,18 @@ class TestSimpleFormat(BlackBaseTestCase):
     @patch("black.dump_to_file", dump_to_stderr)
     def test_simple_format(self, filename: str) -> None:
         source, expected = read_data(filename)
-        legacy_mode = replace(DEFAULT_MODE, line_length=88)
-        actual = fs(source, mode=legacy_mode)
+        actual = fs(source, mode=LEGACY_MODE)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, mode=legacy_mode)
+        black.assert_stable(source, actual, mode=LEGACY_MODE)
 
     @parameterized.expand(SOURCES)
     @patch("black.dump_to_file", dump_to_stderr)
     def test_source_is_formatted(self, filename: str) -> None:
         path = THIS_DIR.parent / filename
         source, expected = read_data(str(path), data=False)
-        legacy_mode = replace(DEFAULT_MODE, line_length=88)
-        actual = fs(source, mode=legacy_mode)
+        actual = fs(source, mode=LEGACY_MODE)
         self.assertFormatEqual(expected, actual)
         black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, mode=legacy_mode)
-        self.assertFalse(ff(path, mode=legacy_mode))
+        black.assert_stable(source, actual, mode=LEGACY_MODE)
+        self.assertFalse(ff(path, mode=LEGACY_MODE))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 import os
 import unittest
 from contextlib import contextmanager
@@ -13,6 +14,7 @@ DETERMINISTIC_HEADER = "[Deterministic header]"
 
 
 DEFAULT_MODE = black.FileMode(experimental_string_processing=True)
+LEGACY_MODE = replace(DEFAULT_MODE, line_length=88)
 ff = partial(black.format_file_in_place, mode=DEFAULT_MODE, fast=True)
 fs = partial(black.format_str, mode=DEFAULT_MODE)
 


### PR DESCRIPTION
Update [`DEFAULT_LINE_LENGTH`](https://github.com/psf/black/blob/71117e730c4f62458b30af820f51890487b458e4/src/black/__init__.py#L71) to 79, bringing it in-line with PEP8.

As far as possible, existing test logic and test data is left as-is; only tests where new failures are introduced by the migration are updated.

Resolves #498