### PR TITLE
Remove placeholder exit code in unreachable 'black-primer' subprocess handler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.800
     hooks:
       - id: mypy
         exclude: ^docs/conf.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v0.780
     hooks:
       - id: mypy
         exclude: ^docs/conf.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.780
+    rev: v0.770
     hooks:
       - id: mypy
         exclude: ^docs/conf.py

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -58,6 +58,11 @@ async def _gen_check_output(
         await process.wait()
         raise
 
+    # A non-optional timeout was supplied to asyncio.wait_for, guaranteeing
+    # a timeout or completed process.  A terminated Python process will have a
+    # non-empty returncode value.
+    assert process.returncode is not None
+
     if process.returncode != 0:
         cmd_str = " ".join(cmd)
         raise CalledProcessError(

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -59,12 +59,10 @@ async def _gen_check_output(
         raise
 
     if process.returncode != 0:
-        returncode = process.returncode
-        if returncode is None:
-            returncode = 69
-
         cmd_str = " ".join(cmd)
-        raise CalledProcessError(returncode, cmd_str, output=stdout, stderr=stderr)
+        raise CalledProcessError(
+            process.returncode, cmd_str, output=stdout, stderr=stderr
+        )
 
     return (stdout, stderr)
 


### PR DESCRIPTION
During investigation into `black-primer` test failures in #1949, the lines at https://github.com/psf/black/blob/71117e730c4f62458b30af820f51890487b458e4/src/black_primer/lib.py#L63-L64 stood out as a workaround that it may be possible to remove.

It's probably harmless to assign a placeholder exit code in these circumstances, but it seems better not to if we can avoid it; it's less confusing for future readers, and less likely to introduce unexpected bugs if the surrounding code changes in future.

The reason the lines were originally added was to allow `mypy` type checks to pass by guaranteeing an integer `process.returncode` value.

It _should_ already be true that an integer return code is guaranteed by the point we reach this code path, as far as I can tell, but `mypy` is not able to determine that without some additional context.  An `assert` statement is introduced here to provide `mypy` with a suitable hint. 

Builds upon #1887 and further resolves #1886.