### PR TITLE
Create grammar tables directory

### DIFF
--- a/src/blib2to3/pgen2/driver.py
+++ b/src/blib2to3/pgen2/driver.py
@@ -20,6 +20,7 @@ import codecs
 import io
 import os
 import logging
+import pathlib
 import pkgutil
 import sys
 from typing import (
@@ -191,6 +192,8 @@ def load_grammar(
     if logger is None:
         logger = logging.getLogger(__name__)
     gp = _generate_pickle_name(gt) if gp is None else gp
+    pickle_directory = pathlib.Path(gp).parent
+    pickle_directory.mkdir(exist_ok=True, parents=True)
     if force or not _newer(gp, gt):
         logger.info("Generating grammar tables from %s", gt)
         g: grammar.Grammar = pgen.generate_grammar(gt)


### PR DESCRIPTION
When importing black as a Python dependency I have been getting the following logging messages:

```
2021-02-02 09:46:38.074 Generating grammar tables from C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\blib2to3\Grammar.txt
2021-02-02 09:46:38.104 Writing grammar tables to C:\Users\sbiggs\AppData\Local\black\black\Cache\20.8b1\Grammar3.7.9.final.0.pickle
2021-02-02 09:46:38.105 Writing failed: [Errno 2] No such file or directory: 'C:\\Users\\sbiggs\\AppData\\Local\\black\\black\\Cache\\20.8b1\\tmpd9fht2r6'
2021-02-02 09:46:38.106 Generating grammar tables from C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\blib2to3\PatternGrammar.txt
2021-02-02 09:46:38.108 Writing grammar tables to C:\Users\sbiggs\AppData\Local\black\black\Cache\20.8b1\PatternGrammar3.7.9.final.0.pickle
2021-02-02 09:46:38.109 Writing failed: [Errno 2] No such file or directory: 'C:\\Users\\sbiggs\\AppData\\Local\\black\\black\\Cache\\20.8b1\\tmp9jp7c60o'
```

I made the changes to the black repo as within this PR, and those messages changed to the following for the first run:

```
2021-02-02 09:56:35.847 Generating grammar tables from C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\blib2to3\Grammar.txt
2021-02-02 09:56:35.879 Writing grammar tables to C:\Users\sbiggs\AppData\Local\black\black\Cache\20.8b2.dev73+g988c686.d20210201\Grammar3.7.9.final.0.pickle
2021-02-02 09:56:35.884 Generating grammar tables from C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\blib2to3\PatternGrammar.txt
2021-02-02 09:56:35.888 Writing grammar tables to C:\Users\sbiggs\AppData\Local\black\black\Cache\20.8b2.dev73+g988c686.d20210201\PatternGrammar3.7.9.final.0.pickle
```

And then subsequently they were gone.

---

I suspected the issue was that the parent directory for that file didn't exist, so I created it.