### PR TITLE
Use 'args' to Avoid GH workflow warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          black_args: ". --check"
+          args: ". --check"
 ```
 
 ### Inputs


### PR DESCRIPTION
Unexpected input(s) 'black_args', valid inputs are ['entryPoint', 'args']

![image](https://user-images.githubusercontent.com/17945/108110767-95e98f00-7048-11eb-9989-4497055816b2.png)
