### PR TITLE
Fuzzer testing: less strict special-case regex match passthrough for multi-line EOF exceptions

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -50,7 +50,7 @@ def test_idempotent_any_syntatically_valid_python(
         # TODO: remove this try-except block when issues are resolved.
         return
     except TokenError as e:
-        if (
+        if (  # Special-case logic for backslashes followed by newlines or end-of-input
             e.args[0] == "EOF in multi-line statement"
             and re.search(r"\\($|\r?\n)", src_contents) is not None
         ):

--- a/fuzz.py
+++ b/fuzz.py
@@ -52,7 +52,7 @@ def test_idempotent_any_syntatically_valid_python(
     except TokenError as e:
         if (
             e.args[0] == "EOF in multi-line statement"
-            and re.search(r"\\\r?\n", src_contents) is not None
+            and re.search(r"\\($|\r?\n)", src_contents) is not None
         ):
             # This is a bug - if it's valid Python code, as above, Black should be
             # able to cope with it.  See issue #1012.

--- a/fuzz.py
+++ b/fuzz.py
@@ -52,7 +52,7 @@ def test_idempotent_any_syntatically_valid_python(
     except TokenError as e:
         if (
             e.args[0] == "EOF in multi-line statement"
-            and re.search(r"\r?\n\\\r?\n", src_contents) is not None
+            and re.search(r"\\\r?\n", src_contents) is not None
         ):
             # This is a bug - if it's valid Python code, as above, Black should be
             # able to cope with it.  See issue #1012.


### PR DESCRIPTION
Relates to #1012, and in particular aims to address https://github.com/psf/black/issues/1012#issuecomment-782852915, https://github.com/psf/black/issues/1012#issuecomment-782952852.