### PR TITLE
Fix for enum changes in 3.10

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -883,7 +883,7 @@ def format_file_in_place(
         dst_name = f"{src}\t{now} +0000"
         diff_contents = diff(src_contents, dst_contents, src_name, dst_name)
 
-        if write_back == write_back.COLOR_DIFF:
+        if write_back == WriteBack.COLOR_DIFF:
             diff_contents = color_diff(diff_contents)
 
         with lock or nullcontext():


### PR DESCRIPTION
Enum member access was changed in https://github.com/python/cpython/commit/c314e60388282d9829762fb6c30b12e2807caa19.

This now raises
```py
Traceback (most recent call last):
  File "/Users/gobot1234/PycharmProjects/lint-action/venv/lib/python3.10/site-packages/black/__init__.py", line 670, in reformat_one
    if changed is not Changed.CACHED and format_file_in_place(
  File "/Users/gobot1234/PycharmProjects/lint-action/venv/lib/python3.10/site-packages/black/__init__.py", line 826, in format_file_in_place
    if write_back == write_back.COLOR_DIFF:
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/enum.py", line 146, in __get__
    raise AttributeError(
AttributeError: WriteBack: no attribute 'COLOR_DIFF'
```