### PR TITLE
Handle Docstrings as bytes + strip all whitespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@
 
 - Lines ending with `fmt: skip` will now be not formatted (#1800)
 
+- Fixed "Black produced code that is not equivalent to the source" when formatting
+  Python2 docstrings
+
 #### _Packaging_
 
 - Self-contained native _Black_ binaries are now provided for releases via GitHub

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1886,6 +1886,26 @@ class BlackTestCase(BlackBaseTestCase):
         actual = diff_header.sub(DETERMINISTIC_HEADER, actual)
         self.assertEqual(actual, expected)
 
+    def test_docstring_reformat_for_py27(self) -> None:
+        """
+        Check that stripping trailing whitespace from Python 2 docstrings
+        doesn't trigger a "not equivalent to source" error
+        """
+        source = (
+            b'def foo():\r\n    """Testing\r\n    Testing """\r\n    print "Foo"\r\n'
+        )
+        expected = 'def foo():\n    """Testing\n    Testing"""\n    print "Foo"\n'
+
+        result = CliRunner().invoke(
+            black.main,
+            ["-", "-q", "--target-version=py27"],
+            input=BytesIO(source),
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        actual = result.output
+        self.assertFormatEqual(actual, expected)
+
 
 with open(black.__file__, "r", encoding="utf-8") as _bf:
     black_source_lines = _bf.readlines()


### PR DESCRIPTION
(Eventually) reproduced with a test and 'fixed'.

Successfully ran:
* `tox -e py`
* `tox -e fuzz`
* `black-primer`

(fixes #1844, fixes #1923, fixes #1851, fixes #2002, fixes #2103)
