### PR TITLE
Add entry for `--extend-exclude` in the right place

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 
 - use lowercase hex strings (#1692)
 
+- added `--extend-exclude` argument (PR #2005)
+
 - speed up caching by avoiding pathlib (#1950)
 
 - `--diff` correctly indicates when a file doesn't end in a newline (#1662)


### PR DESCRIPTION
The PR author added the changelog entry for their `extend-exclude` addition
in `docs/change_log.md` which is understandable but incorrect as it will be
overwritten since it's autogenerated from the readme.