### PR TITLE
GREP for PR reference accepts references that are split over a line

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Grep CHANGES.md for PR number
         if: contains(github.event.pull_request.labels.*.name, 'skip news') != true
         run: |
-          grep -P "PR #${{ github.event.pull_request.number }}[^0-9]" CHANGES.md || \
+          grep -Pz "PR( |\n\s*)#${{ github.event.pull_request.number }}[^0-9]" CHANGES.md || \
           (echo "Please add 'PR #${{ github.event.pull_request.number }}' change line to CHANGES.md" && \
           exit 1)


### PR DESCRIPTION
Fixes https://github.com/psf/black/issues/2070 by changing grep pattern used to search for the reference PR number in the github changelog workflow to be 
```
PR( |\n\s*)#${{ github.event.pull_request.number }}[^0-9]
```
This matches `PR #1234` or 
```
xxxxxxxxxxx xxxxxxxxx xxxxxxxxx PR
   #1234 xxxxxxxxx xxxxxxxxxx
```
so CHANGES.md is still acceptable even if prettify requires that the PR reference be formatted to be split across two lines.
