### PR TITLE
Push contributors to use Next PR Number

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,11 +69,10 @@ have a line in the following format:
 - `Black` is now more awesome (#X)
 ```
 
-To workout X, checkout the latest issue and PR number and add 1. This is not perfect but
-saves a lot of release overhead as now the releaser does not need to go back and workout
-what to add to the `CHANGES.md` for each release.
-
-_Suggestions welcome on how this could be a better less invasive flow._
+To workout X, please use
+[Next PR Number](https://ichard26.github.io/next-pr-number/?owner=psf&name=black). This
+is not perfect but saves a lot of release overhead as now the releaser does not need to
+go back and workout what to add to the `CHANGES.md` for each release.
 
 ### Docs Testing
 

--- a/docs/contributing_to_black.md
+++ b/docs/contributing_to_black.md
@@ -60,6 +60,22 @@ $ tox -e fuzz
 $ black-primer [-k -w /tmp/black_test_repos]
 ```
 
+### News / Changelog Requirement
+
+`Black` has CI that will check for an entry corresponding to your PR in `CHANGES.md`. If
+you feel this PR not require a changelog entry please state that in a comment and a
+maintainer can add a `skip news` label to make the CI pass. Otherwise, please ensure you
+have a line in the following format:
+
+```md
+- `Black` is now more awesome (#X)
+```
+
+To workout X, please use
+[Next PR Number](https://ichard26.github.io/next-pr-number/?owner=psf&name=black). This
+is not perfect but saves a lot of release overhead as now the releaser does not need to
+go back and workout what to add to the `CHANGES.md` for each release.
+
 ### Docs Testing
 
 If you make changes to docs, you can test they still build locally too.


### PR DESCRIPTION
This is a tool of my own making. Right now our requirement to have the
PR number in the changelog entry is pretty painful / annoying since
the contributor either has to guess or add the # retroactively after
the PR creation. This tool should make it way less painful by making
it simple to get your PR number beforehand.