### PR TITLE
Document experimental string processing and docstring indentation

### DIFF
--- a/docs/the_black_code_style.md
+++ b/docs/the_black_code_style.md
@@ -289,6 +289,14 @@ If you are adopting _Black_ in a large project with pre-existing string conventi
 you can pass `--skip-string-normalization` on the command line. This is meant as an
 adoption helper, avoid using this for new projects.
 
+As an experimental option, _Black_ splits long strings (using parentheses where
+appropriate) and merges short ones. When split, parts of f-strings that don't need
+formatting are converted to plain strings. User-made splits are respected when they do
+not exceed the line length limit. Line continuation backslashes are converted into
+parenthesized strings. Unnecessary parentheses are stripped. To enable experimental
+string processing, pass `--experimental-string-processing` on the command line. Because
+the functionality is experimental, feedback and issue reports are highly encouraged!
+
 ### Numeric literals
 
 _Black_ standardizes most numeric literals to use lowercase letters for the syntactic

--- a/docs/the_black_code_style.md
+++ b/docs/the_black_code_style.md
@@ -297,6 +297,13 @@ parenthesized strings. Unnecessary parentheses are stripped. To enable experimen
 string processing, pass `--experimental-string-processing` on the command line. Because
 the functionality is experimental, feedback and issue reports are highly encouraged!
 
+_Black_ also processes docstrings. Firstly the indentation of docstrings is corrected
+for both quotations and the text within, although relative indentation in the text is
+preserved. Superfluous trailing whitespace on each line and unnecessary new lines at the
+end of the docstring are removed. All leading tabs are converted to spaces, but tabs
+inside text are preserved. Whitespace leading and trailing one-line docstrings is
+removed. The quotations of an empty docstring are separated with one space.
+
 ### Numeric literals
 
 _Black_ standardizes most numeric literals to use lowercase letters for the syntactic

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -115,6 +115,10 @@ def oneline_empty():
     '''      '''
 
 
+def oneline_nothing():
+    """"""
+
+
 def single_quotes():
     'testing'
 
@@ -264,6 +268,10 @@ def empty():
 
 
 def oneline_empty():
+    """ """
+
+
+def oneline_nothing():
     """ """
 
 


### PR DESCRIPTION
From #53: this PR adds short descriptions of #1053 and #1132 to the Black code style document.

Possible points of review/contention:
- Has the processing changed since? Reading the changelog I don't think it has, but I haven't been around.
- Doc placement: I think the "Strings" section is appropriate for both, unless another section for indentation is created. I appended the text to the section by default, and because "experimental" hints that maybe it shouldn't be the first thing to be introduced to the reader. I'm not sure about the docstring paragraph though. It is quite short, so maybe it ought to be merged with some other paragraph.

I don't think any of the checks apply, and `skip news` could also be added. Pre-commit did line up the text though.

Happy to make any changes you suggest!

---

Also, while running the install stuff, there was some sort of process pool termination when formatting the repository. Is that something that is expected to happen on Windows?