### PR TITLE
Simplify GitHub Action entrypoint (#1909)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,15 +424,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
-        with:
-          args: ". --check"
 ```
 
-### Inputs
+You may use `options` (Default is `'--check --diff'`) and `src` (Default is `'.'`) as follows:
 
-#### `black_args`
-
-**optional**: Black input arguments. Defaults to `. --check --diff`.
+```yaml
+      - uses: psf/black@stable
+        with:
+            options: '--check --verbose'
+            src: './src'
+```
 
 ## Ignoring unmodified files
 

--- a/README.md
+++ b/README.md
@@ -426,13 +426,14 @@ jobs:
       - uses: psf/black@stable
 ```
 
-You may use `options` (Default is `'--check --diff'`) and `src` (Default is `'.'`) as follows:
+You may use `options` (Default is `'--check --diff'`) and `src` (Default is `'.'`) as
+follows:
 
 ```yaml
-      - uses: psf/black@stable
-        with:
-            options: '--check --verbose'
-            src: './src'
+- uses: psf/black@stable
+  with:
+    options: "--check --verbose"
+    src: "./src"
 ```
 
 ## Ignoring unmodified files

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,9 @@ description: "The uncompromising Python code formatter."
 author: "Łukasz Langa and contributors to Black"
 inputs:
   options:
-    description: "Options passed to black. Use `black --help` to see available options. Default: '--check'"
+    description:
+      "Options passed to black. Use `black --help` to see available options. Default:
+      '--check'"
     required: false
     default: "--check --diff"
   src:

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,16 @@ name: "Black"
 description: "The uncompromising Python code formatter."
 author: "Łukasz Langa and contributors to Black"
 inputs:
+  options:
+    description: "Options passed to black. Use `black --help` to see available options. Default: '--check'"
+    required: false
+    default: "--check --diff"
+  src:
+    description: "Source to run black. Default: '.'"
+    required: false
+    default: "."
   black_args:
-    description: "Black input arguments."
+    description: "[DEPRECATED] Black input arguments."
     required: false
     default: ""
 branding:

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,17 +1,8 @@
-#!/bin/bash
-set -e
+#!/bin/bash -e
 
-# If no arguments are given use current working directory
-black_args=(".")
-if [ "$#" -eq 0 ] && [ "${INPUT_BLACK_ARGS}" != "" ]; then
-  black_args+=(${INPUT_BLACK_ARGS})
-elif [ "$#" -ne 0 ] && [ "${INPUT_BLACK_ARGS}" != "" ]; then
-  black_args+=($* ${INPUT_BLACK_ARGS})
-elif [ "$#" -ne 0 ] && [ "${INPUT_BLACK_ARGS}" == "" ]; then
-  black_args+=($*)
-else
-  # Default (if no args provided).
-  black_args+=("--check" "--diff")
-fi
+if [ -n $INPUT_BLACK_ARGS ]; then
+  echo 'WARNING: input `with.black_args` is deprecated. Use `with.options` and `with.src` instead.'
+  black $INPUT_BLACK_ARGS
+  exit $?
 
-sh -c "black . ${black_args[*]}"
+black $INPUT_OPTIONS $INPUT_SRC

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 if [ -n $INPUT_BLACK_ARGS ]; then
-  echo 'WARNING: input `with.black_args` is deprecated. Use `with.options` and `with.src` instead.'
+  echo '::warning::Input `with.black_args` is deprecated. Use `with.options` and `with.src` instead.'
   black $INPUT_BLACK_ARGS
   exit $?
 


### PR DESCRIPTION
This PR simplifies `entrypoint.sh` for GitHub Actions by removing duplication of `args` and `black_args` (cf. #1909).

The reason why #1909 uses the input id `black_args` is to avoid an overlap with `args`, but this naming seems redundant.
So let me suggest `option` and `src`, which are consistent with CLI. Backward compatibility is guaranteed; Users can still use `black_args` as well.

Any suggestions for improvements are more than welcome. Thanks!

This PR may not require a changelog entry.