### PR TITLE
Docker CI: Add missed Checkout step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 


### PR DESCRIPTION
- Reading my error others hit it by forgetting this Checkoutstep too so trying the fix
  - e.g. https://github.com/docker/build-push-action/issues/179
- Makes sense it's needed