### PR TITLE
Add automatic version tagging to Docker CI Pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "master"
+  release:
+    types: created
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,13 +24,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Check + set version tag
+        run: echo "GIT_TAG=$(git describe --candidates=0 --tags 2> /dev/null || echo latest_non_release)" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: pyfound/black:latest
+          tags: pyfound/black:latest,pyfound/black:${{ env.GIT_TAG }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Check + set version tag
-        run: echo "GIT_TAG=$(git describe --candidates=0 --tags 2> /dev/null || echo latest_non_release)" >> $GITHUB_ENV
+        run:
+          echo "GIT_TAG=$(git describe --candidates=0 --tags 2> /dev/null || echo
+          latest_non_release)" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
- If the git comment has a tag, set that on the docker images pushed
- If we don't have a tag, we just set `latest_non_release`