### PR TITLE
Stop stripping parens in even more illegal spots

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5624,6 +5624,9 @@ def maybe_make_parens_invisible_in_atom(node: LN, parent: LN) -> bool:
             syms.expr_stmt,
             syms.assert_stmt,
             syms.return_stmt,
+            # these ones aren't useful to end users, but they do please fuzzers
+            syms.for_stmt,
+            syms.del_stmt,
         ]:
             return False
 

--- a/tests/data/pep_572_do_not_remove_parens.py
+++ b/tests/data/pep_572_do_not_remove_parens.py
@@ -1,0 +1,21 @@
+# Most of the following examples are really dumb, some of them aren't even accepted by Python,
+# we're fixing them only so fuzzers (which follow the grammar which actually allows these
+# examples matter of fact!) don't yell at us :p
+
+del (a := [1])
+
+try:
+    pass
+except (a := 1) as (b := why_does_this_exist):
+    pass
+
+for (z := 124) in (x := -124):
+    pass
+
+with (y := [3, 2, 1]) as (funfunfun := indeed):
+    pass
+
+
+@(please := stop)
+def sigh():
+    pass

--- a/tests/data/pep_572_remove_parens.py
+++ b/tests/data/pep_572_remove_parens.py
@@ -33,6 +33,9 @@ def foo2(answer: (p := 42) = 5):
 
 lambda: (x := 1)
 
+a[(x := 12)]
+a[:(x := 13)]
+
 # we don't touch expressions in f-strings but if we do one day, don't break 'em
 f'{(x:=10)}'
 
@@ -42,6 +45,10 @@ def a():
     await (b := 1)
     yield (a := 2)
     raise (c := 3)
+
+def this_is_so_dumb() -> (please := no):
+    pass
+
 
 # output
 if foo := 0:
@@ -79,6 +86,9 @@ def foo2(answer: (p := 42) = 5):
 
 lambda: (x := 1)
 
+a[(x := 12)]
+a[:(x := 13)]
+
 # we don't touch expressions in f-strings but if we do one day, don't break 'em
 f"{(x:=10)}"
 
@@ -88,3 +98,8 @@ def a():
     await (b := 1)
     yield (a := 2)
     raise (c := 3)
+
+
+def this_is_so_dumb() -> (please := no):
+    pass
+

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -290,6 +290,14 @@ class BlackTestCase(BlackBaseTestCase):
         if sys.version_info >= (3, 8):
             black.assert_equivalent(source, actual)
 
+    @patch("black.dump_to_file", dump_to_stderr)
+    def test_pep_572_do_not_remove_parens(self) -> None:
+        source, expected = read_data("pep_572_do_not_remove_parens")
+        # the AST safety checks will fail, but that's expected, just make sure no
+        # parentheses are touched
+        actual = black.format_str(source, mode=DEFAULT_MODE)
+        self.assertFormatEqual(expected, actual)
+
     def test_pep_572_version_detection(self) -> None:
         source, _ = read_data("pep_572")
         root = black.lib2to3_parse(source)


### PR DESCRIPTION
We're only fixing them so fuzzers don't yell at us when we break "valid" code. I mean "valid" because some of the examples aren't even accepted by Python.

I'm assuming since this has no effect whatsoever to end users, this won't need a changelog entry.