### PR TITLE
Remove useless shebangs in non-executable files

### DIFF
--- a/src/black_primer/cli.py
+++ b/src/black_primer/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # coding=utf8
 
 import asyncio

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import asyncio
 import errno
 import json


### PR DESCRIPTION
Such shebangs are only ever used if the file is executed directly, i.e.:

    $ /usr/lib/python3.9/site-packages/black_primer/cli.py

But that doesn't work:

    $ /usr/lib/python3.9/site-packages/black_primer/cli.py
    bash: /usr/lib/python3.9/site-packages/black_primer/cli.py: Permission denied

The lib file even has: "lib is a library, funnily enough"

----

I consider this **trivial** change, no changelog entry required.