### PR TITLE
Extend use of optional parentheses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+#### _Black_
+
+- Adjusted line wrapping by inserting optional parentheses more often to
+  improve readability and make the code style more consistent.
+  **Almost every project will be affected by it!** (#2163)
+
 ### 21.5b0
 
 #### _Black_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6776,6 +6776,13 @@ def can_omit_invisible_parens(
         # With more than one delimiter of a kind the optional parentheses read better.
         return False
 
+    if (
+        max_priority >= LOGIC_PRIORITY
+        and bt.delimiter_count_with_priority(max_priority) > 0
+    ):
+        # With at least one delimiter of kind LOGIC or above, optional parentheses are beter
+        return False
+
     if max_priority == DOT_PRIORITY:
         # A single stranded method call doesn't require optional parentheses.
         return True

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -772,12 +772,16 @@ def reformat_one(
                 res_src_s = str(res_src)
                 if res_src_s in cache and cache[res_src_s] == get_cache_info(res_src):
                     changed = Changed.CACHED
-            if changed is not Changed.CACHED and format_file_in_place(
-                src, fast=fast, write_back=write_back, mode=mode
+            if (
+                changed is not Changed.CACHED
+                and format_file_in_place(
+                    src, fast=fast, write_back=write_back, mode=mode
+                )
             ):
                 changed = Changed.YES
-            if (write_back is WriteBack.YES and changed is not Changed.CACHED) or (
-                write_back is WriteBack.CHECK and changed is Changed.NO
+            if (
+                (write_back is WriteBack.YES and changed is not Changed.CACHED)
+                or (write_back is WriteBack.CHECK and changed is Changed.NO)
             ):
                 write_cache(cache, [src], mode)
         report.done(src, changed)
@@ -884,8 +888,9 @@ async def schedule_formatting(
                 changed = Changed.YES if task.result() else Changed.NO
                 # If the file was written back or was successfully checked as
                 # well-formatted, store this information in the cache.
-                if write_back is WriteBack.YES or (
-                    write_back is WriteBack.CHECK and changed is Changed.NO
+                if (
+                    write_back is WriteBack.YES
+                    or (write_back is WriteBack.CHECK and changed is Changed.NO)
                 ):
                     sources_to_cache.append(src)
                 report.done(src, changed)
@@ -1614,9 +1619,10 @@ class Line:
     @property
     def is_stub_class(self) -> bool:
         """Is this line a class definition with a body consisting only of "..."?"""
-        return self.is_class and self.leaves[-3:] == [
-            Leaf(token.DOT, ".") for _ in range(3)
-        ]
+        return (
+            self.is_class
+            and self.leaves[-3:] == [Leaf(token.DOT, ".") for _ in range(3)]
+        )
 
     @property
     def is_def(self) -> bool:
@@ -1630,11 +1636,14 @@ class Line:
             second_leaf: Optional[Leaf] = self.leaves[1]
         except IndexError:
             second_leaf = None
-        return (first_leaf.type == token.NAME and first_leaf.value == "def") or (
-            first_leaf.type == token.ASYNC
-            and second_leaf is not None
-            and second_leaf.type == token.NAME
-            and second_leaf.value == "def"
+        return (
+            (first_leaf.type == token.NAME and first_leaf.value == "def")
+            or (
+                first_leaf.type == token.ASYNC
+                and second_leaf is not None
+                and second_leaf.type == token.NAME
+                and second_leaf.value == "def"
+            )
         )
 
     @property
@@ -1675,8 +1684,9 @@ class Line:
         try:
             last_leaf = self.leaves[-1]
             ignored_ids.add(id(last_leaf))
-            if last_leaf.type == token.COMMA or (
-                last_leaf.type == token.RPAR and not last_leaf.value
+            if (
+                last_leaf.type == token.COMMA
+                or (last_leaf.type == token.RPAR and not last_leaf.value)
             ):
                 # When trailing commas or optional parens are inserted by Black for
                 # consistency, comments after the previous last element are not moved
@@ -1696,9 +1706,12 @@ class Line:
         for leaf_id, comments in self.comments.items():
             for comment in comments:
                 if is_type_comment(comment):
-                    if comment_seen or (
-                        not is_type_comment(comment, " ignore")
-                        and leaf_id not in ignored_ids
+                    if (
+                        comment_seen
+                        or (
+                            not is_type_comment(comment, " ignore")
+                            and leaf_id not in ignored_ids
+                        )
                     ):
                         return True
 
@@ -1838,8 +1851,9 @@ class Line:
 
             if subscript_start.type == syms.subscriptlist:
                 subscript_start = child_towards(subscript_start, leaf)
-        return subscript_start is not None and any(
-            n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
+        return (
+            subscript_start is not None
+            and any(n.type in TEST_DESCENDANTS for n in subscript_start.pre_order())
         )
 
     def clone(self) -> "Line":
@@ -1960,8 +1974,9 @@ class EmptyLineTracker:
 
             return 0, 0
 
-        if self.previous_line.depth < current_line.depth and (
-            self.previous_line.is_class or self.previous_line.is_def
+        if (
+            self.previous_line.depth < current_line.depth
+            and (self.previous_line.is_class or self.previous_line.is_def)
         ):
             return 0, 0
 
@@ -1982,8 +1997,9 @@ class EmptyLineTracker:
                 else:
                     newlines = 1
             elif (
-                current_line.is_def or current_line.is_decorator
-            ) and not self.previous_line.is_def:
+                (current_line.is_def or current_line.is_decorator)
+                and not self.previous_line.is_def
+            ):
                 # Blank line between a block of functions (maybe with preceding
                 # decorators) and a block of non-functions
                 newlines = 1
@@ -2273,11 +2289,15 @@ def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
         return DOUBLESPACE
 
     assert p is not None, f"INTERNAL ERROR: hand-made leaf without parent: {leaf!r}"
-    if t == token.COLON and p.type not in {
-        syms.subscript,
-        syms.subscriptlist,
-        syms.sliceop,
-    }:
+    if (
+        t == token.COLON
+        and p.type
+        not in {
+            syms.subscript,
+            syms.subscriptlist,
+            syms.sliceop,
+        }
+    ):
         return NO
 
     prev = leaf.prev_sibling
@@ -2457,10 +2477,14 @@ def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
 
             prevp_parent = prevp.parent
             assert prevp_parent is not None
-            if prevp.type == token.COLON and prevp_parent.type in {
-                syms.subscript,
-                syms.sliceop,
-            }:
+            if (
+                prevp.type == token.COLON
+                and prevp_parent.type
+                in {
+                    syms.subscript,
+                    syms.sliceop,
+                }
+            ):
                 return NO
 
             elif prevp.type == token.EQUAL and prevp_parent.type == syms.argument:
@@ -3336,10 +3360,14 @@ class StringMerger(CustomSplitMapMixin, StringTransformer):
             i = string_idx
             found_sa_comment = False
             is_valid_index = is_valid_index_factory(line.leaves)
-            while is_valid_index(i) and line.leaves[i].type in [
-                token.STRING,
-                STANDALONE_COMMENT,
-            ]:
+            while (
+                is_valid_index(i)
+                and line.leaves[i].type
+                in [
+                    token.STRING,
+                    STANDALONE_COMMENT,
+                ]
+            ):
                 if line.leaves[i].type == STANDALONE_COMMENT:
                     found_sa_comment = True
                 elif found_sa_comment:
@@ -3442,8 +3470,12 @@ class StringParenStripper(StringTransformer):
             # That LPAR should NOT be preceded by a function name or a closing
             # bracket (which could be a function which returns a function or a
             # list/dictionary that contains a function)...
-            if is_valid_index(idx - 2) and (
-                LL[idx - 2].type == token.NAME or LL[idx - 2].type in CLOSING_BRACKETS
+            if (
+                is_valid_index(idx - 2)
+                and (
+                    LL[idx - 2].type == token.NAME
+                    or LL[idx - 2].type in CLOSING_BRACKETS
+                )
             ):
                 continue
 
@@ -3459,27 +3491,30 @@ class StringParenStripper(StringTransformer):
             if is_valid_index(idx - 2):
                 # mypy can't quite follow unless we name this
                 before_lpar = LL[idx - 2]
-                if token.PERCENT in {leaf.type for leaf in LL[idx - 1 : next_idx]} and (
-                    (
-                        before_lpar.type
-                        in {
-                            token.STAR,
-                            token.AT,
-                            token.SLASH,
-                            token.DOUBLESLASH,
-                            token.PERCENT,
-                            token.TILDE,
-                            token.DOUBLESTAR,
-                            token.AWAIT,
-                            token.LSQB,
-                            token.LPAR,
-                        }
-                    )
-                    or (
-                        # only unary PLUS/MINUS
-                        before_lpar.parent
-                        and before_lpar.parent.type == syms.factor
-                        and (before_lpar.type in {token.PLUS, token.MINUS})
+                if (
+                    token.PERCENT in {leaf.type for leaf in LL[idx - 1 : next_idx]}
+                    and (
+                        (
+                            before_lpar.type
+                            in {
+                                token.STAR,
+                                token.AT,
+                                token.SLASH,
+                                token.DOUBLESLASH,
+                                token.PERCENT,
+                                token.TILDE,
+                                token.DOUBLESTAR,
+                                token.AWAIT,
+                                token.LSQB,
+                                token.LPAR,
+                            }
+                        )
+                        or (
+                            # only unary PLUS/MINUS
+                            before_lpar.parent
+                            and before_lpar.parent.type == syms.factor
+                            and (before_lpar.type in {token.PLUS, token.MINUS})
+                        )
                     )
                 ):
                     continue
@@ -3492,12 +3527,16 @@ class StringParenStripper(StringTransformer):
             ):
                 # That RPAR should NOT be followed by anything with higher
                 # precedence than PERCENT
-                if is_valid_index(next_idx + 1) and LL[next_idx + 1].type in {
-                    token.DOUBLESTAR,
-                    token.LSQB,
-                    token.LPAR,
-                    token.DOT,
-                }:
+                if (
+                    is_valid_index(next_idx + 1)
+                    and LL[next_idx + 1].type
+                    in {
+                        token.DOUBLESTAR,
+                        token.LSQB,
+                        token.LPAR,
+                        token.DOT,
+                    }
+                ):
                     continue
 
                 return Ok(string_idx)
@@ -3607,17 +3646,22 @@ class BaseStringSplitter(StringTransformer):
                 "The string itself is not what is causing this line to be too long."
             )
 
-        if not string_leaf.parent or [L.type for L in string_leaf.parent.children] == [
-            token.STRING,
-            token.NEWLINE,
-        ]:
+        if (
+            not string_leaf.parent
+            or [L.type for L in string_leaf.parent.children]
+            == [
+                token.STRING,
+                token.NEWLINE,
+            ]
+        ):
             return TErr(
                 f"This string ({string_leaf.value}) appears to be pointless (i.e. has"
                 " no parent)."
             )
 
-        if id(line.leaves[string_idx]) in line.comments and contains_pragma_comment(
-            line.comments[id(line.leaves[string_idx])]
+        if (
+            id(line.leaves[string_idx]) in line.comments
+            and contains_pragma_comment(line.comments[id(line.leaves[string_idx])])
         ):
             return TErr(
                 "Line appears to end with an inline pragma comment. Splitting the line"
@@ -3843,8 +3887,9 @@ class StringSplitter(CustomSplitMapMixin, BaseStringSplitter):
         # contain any f-expressions, but ONLY if the original f-string
         # contains at least one f-expression. Otherwise, we will alter the AST
         # of the program.
-        drop_pointless_f_prefix = ("f" in prefix) and re.search(
-            self.RE_FEXPR, LL[string_idx].value, re.VERBOSE
+        drop_pointless_f_prefix = (
+            ("f" in prefix)
+            and re.search(self.RE_FEXPR, LL[string_idx].value, re.VERBOSE)
         )
 
         first_string_line = True
@@ -4263,9 +4308,10 @@ class StringParenWrapper(CustomSplitMapMixin, BaseStringSplitter):
         """
         # If this line is apart of a return/yield statement and the first leaf
         # contains either the "return" or "yield" keywords...
-        if parent_type(LL[0]) in [syms.return_stmt, syms.yield_expr] and LL[
-            0
-        ].value in ["return", "yield"]:
+        if (
+            parent_type(LL[0]) in [syms.return_stmt, syms.yield_expr]
+            and LL[0].value in ["return", "yield"]
+        ):
             is_valid_index = is_valid_index_factory(LL)
 
             idx = 2 if is_valid_index(1) and is_empty_par(LL[1]) else 1
@@ -5760,26 +5806,29 @@ def is_walrus_assignment(node: LN) -> bool:
 
 def is_simple_decorator_trailer(node: LN, last: bool = False) -> bool:
     """Return True iff `node` is a trailer valid in a simple decorator"""
-    return node.type == syms.trailer and (
-        (
-            len(node.children) == 2
-            and node.children[0].type == token.DOT
-            and node.children[1].type == token.NAME
-        )
-        # last trailer can be an argument-less parentheses pair
-        or (
-            last
-            and len(node.children) == 2
-            and node.children[0].type == token.LPAR
-            and node.children[1].type == token.RPAR
-        )
-        # last trailer can be arguments
-        or (
-            last
-            and len(node.children) == 3
-            and node.children[0].type == token.LPAR
-            # and node.children[1].type == syms.argument
-            and node.children[2].type == token.RPAR
+    return (
+        node.type == syms.trailer
+        and (
+            (
+                len(node.children) == 2
+                and node.children[0].type == token.DOT
+                and node.children[1].type == token.NAME
+            )
+            # last trailer can be an argument-less parentheses pair
+            or (
+                last
+                and len(node.children) == 2
+                and node.children[0].type == token.LPAR
+                and node.children[1].type == token.RPAR
+            )
+            # last trailer can be arguments
+            or (
+                last
+                and len(node.children) == 3
+                and node.children[0].type == token.LPAR
+                # and node.children[1].type == syms.argument
+                and node.children[2].type == token.RPAR
+            )
         )
     )
 
@@ -5946,10 +5995,13 @@ def should_split_line(line: Line, opening_bracket: Leaf) -> bool:
     except (IndexError, ValueError):
         return False
 
-    return max_priority == COMMA_PRIORITY and (
-        (line.mode.magic_trailing_comma and trailing_comma)
-        # always explode imports
-        or opening_bracket.parent.type in {syms.atom, syms.import_from}
+    return (
+        max_priority == COMMA_PRIORITY
+        and (
+            (line.mode.magic_trailing_comma and trailing_comma)
+            # always explode imports
+            or opening_bracket.parent.type in {syms.atom, syms.import_from}
+        )
     )
 
 
@@ -5975,10 +6027,14 @@ def is_one_tuple_between(opening: Leaf, closing: Leaf, leaves: List[Leaf]) -> bo
         bracket_depth = leaf.bracket_depth
         if bracket_depth == depth and leaf.type == token.COMMA:
             commas += 1
-            if leaf.parent and leaf.parent.type in {
-                syms.arglist,
-                syms.typedargslist,
-            }:
+            if (
+                leaf.parent
+                and leaf.parent.type
+                in {
+                    syms.arglist,
+                    syms.typedargslist,
+                }
+            ):
                 commas += 1
                 break
 
@@ -6015,8 +6071,9 @@ def get_features_used(node: Node) -> Set[Feature]:
             features.add(Feature.ASSIGNMENT_EXPRESSIONS)
 
         elif n.type == syms.decorator:
-            if len(n.children) > 1 and not is_simple_decorator_expression(
-                n.children[1]
+            if (
+                len(n.children) > 1
+                and not is_simple_decorator_expression(n.children[1])
             ):
                 features.add(Feature.RELAXED_DECORATORS)
 

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -3,7 +3,7 @@
   "projects": {
     "aioexabgp": {
       "cli_arguments": ["--experimental-string-processing"],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/cooperlees/aioexabgp.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -40,7 +40,7 @@
     },
     "flake8-bugbear": {
       "cli_arguments": ["--experimental-string-processing"],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/PyCQA/flake8-bugbear.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -77,7 +77,7 @@
     },
     "pyanalyze": {
       "cli_arguments": ["--experimental-string-processing"],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/quora/pyanalyze.git",
       "long_checkout": false,
       "py_versions": ["all"]

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -295,8 +295,9 @@ def _get_normal_name(orig_enc: str) -> str:
     enc = orig_enc[:12].lower().replace("_", "-")
     if enc == "utf-8" or enc.startswith("utf-8-"):
         return "utf-8"
-    if enc in ("latin-1", "iso-8859-1", "iso-latin-1") or enc.startswith(
-        ("latin-1-", "iso-8859-1-", "iso-latin-1-")
+    if (
+        enc in ("latin-1", "iso-8859-1", "iso-latin-1")
+        or enc.startswith(("latin-1-", "iso-8859-1-", "iso-latin-1-"))
     ):
         return "iso-8859-1"
     return orig_enc
@@ -549,8 +550,8 @@ def generate_tokens(
                 spos, epos, pos = (lnum, start), (lnum, end), end
                 token, initial = line[start:end], line[start]
 
-                if initial in numchars or (
-                    initial == "." and token != "."
+                if (
+                    initial in numchars or (initial == "." and token != ".")
                 ):  # ordinary number
                     yield (NUMBER, token, spos, epos, line)
                 elif initial in "\r\n":

--- a/tests/data/empty_lines.py
+++ b/tests/data/empty_lines.py
@@ -123,23 +123,31 @@ def f():
             return NO
 
         if prevp.type == token.EQUAL:
-            if prevp.parent and prevp.parent.type in {
-                syms.typedargslist,
-                syms.varargslist,
-                syms.parameters,
-                syms.arglist,
-                syms.argument,
-            }:
+            if (
+                prevp.parent
+                and prevp.parent.type
+                in {
+                    syms.typedargslist,
+                    syms.varargslist,
+                    syms.parameters,
+                    syms.arglist,
+                    syms.argument,
+                }
+            ):
                 return NO
 
         elif prevp.type == token.DOUBLESTAR:
-            if prevp.parent and prevp.parent.type in {
-                syms.typedargslist,
-                syms.varargslist,
-                syms.parameters,
-                syms.arglist,
-                syms.dictsetmaker,
-            }:
+            if (
+                prevp.parent
+                and prevp.parent.type
+                in {
+                    syms.typedargslist,
+                    syms.varargslist,
+                    syms.parameters,
+                    syms.arglist,
+                    syms.dictsetmaker,
+                }
+            ):
                 return NO
 
 
@@ -177,11 +185,15 @@ def g():
             return NO
 
         if prevp.type == token.EQUAL:
-            if prevp.parent and prevp.parent.type in {
-                syms.typedargslist,
-                syms.varargslist,
-                syms.parameters,
-                syms.arglist,
-                syms.argument,
-            }:
+            if (
+                prevp.parent
+                and prevp.parent.type
+                in {
+                    syms.typedargslist,
+                    syms.varargslist,
+                    syms.parameters,
+                    syms.arglist,
+                    syms.argument,
+                }
+            ):
                 return NO

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -272,8 +272,8 @@
 -for addr_family, addr_type, addr_proto, addr_canonname, addr_sockaddr in socket.getaddrinfo('google.com', 'http'):
 +print(*lambda x: x)
 +assert not Test, "Short message"
-+assert this is ComplexTest and not requirements.fit_in_a_single_line(
-+    force=False
++assert (
++    this is ComplexTest and not requirements.fit_in_a_single_line(force=False)
 +), "Short message"
 +assert parens is TooMany
 +for (x,) in (1,), (2,), (3,):

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -510,8 +510,8 @@ print(*[] or [1])
 print(**{1: 3} if False else {x: x for x in range(3)})
 print(*lambda x: x)
 assert not Test, "Short message"
-assert this is ComplexTest and not requirements.fit_in_a_single_line(
-    force=False
+assert (
+    this is ComplexTest and not requirements.fit_in_a_single_line(force=False)
 ), "Short message"
 assert parens is TooMany
 for (x,) in (1,), (2,), (3,):

--- a/tests/data/expression_skip_magic_trailing_comma.diff
+++ b/tests/data/expression_skip_magic_trailing_comma.diff
@@ -253,8 +253,8 @@
 -for addr_family, addr_type, addr_proto, addr_canonname, addr_sockaddr in socket.getaddrinfo('google.com', 'http'):
 +print(*lambda x: x)
 +assert not Test, "Short message"
-+assert this is ComplexTest and not requirements.fit_in_a_single_line(
-+    force=False
++assert (
++    this is ComplexTest and not requirements.fit_in_a_single_line(force=False)
 +), "Short message"
 +assert parens is TooMany
 +for (x,) in (1,), (2,), (3,):

--- a/tests/optional.py
+++ b/tests/optional.py
@@ -98,8 +98,9 @@ def pytest_collection_modifyitems(config: "Config", items: "List[Node]") -> None
     for item in items:
         all_markers_on_test = set(m.name for m in item.iter_markers())
         optional_markers_on_test = all_markers_on_test & all_possible_optional_markers
-        if not optional_markers_on_test or (
-            optional_markers_on_test & enabled_optional_markers
+        if (
+            not optional_markers_on_test
+            or (optional_markers_on_test & enabled_optional_markers)
         ):
             continue
         log.info("skipping non-requested optional", item)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -234,14 +234,12 @@ class BlackTestCase(BlackBaseTestCase):
         black.assert_equivalent(source, actual)
         black.assert_stable(source, actual, black.FileMode())
 
-    @unittest.expectedFailure
     @patch("black.dump_to_file", dump_to_stderr)
     def test_trailing_comma_optional_parens_stability1(self) -> None:
         source, _expected = read_data("trailing_comma_optional_parens1")
         actual = fs(source)
         black.assert_stable(source, actual, DEFAULT_MODE)
 
-    @unittest.expectedFailure
     @patch("black.dump_to_file", dump_to_stderr)
     def test_trailing_comma_optional_parens_stability2(self) -> None:
         source, _expected = read_data("trailing_comma_optional_parens2")


### PR DESCRIPTION
For statements with just one priority delimiter it's often better / easier to read if optional parentheses are inserted. Some examples (from black itself):

```py
        return subscript_start is not None and any(
            n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
        )

# new
        return (
            subscript_start is not None
            and any(n.type in TEST_DESCENDANTS for n in subscript_start.pre_order())
        )
```

```py
        if id(line.leaves[string_idx]) in line.comments and contains_pragma_comment(
            line.comments[id(line.leaves[string_idx])]
        )

# new
        if (
            id(line.leaves[string_idx]) in line.comments
            and contains_pragma_comment(line.comments[id(line.leaves[string_idx])])
        ):
```

Additional examples can be seen here: https://github.com/psf/black/commit/74b47c1d8e02e71ea7ba1d1637c73f25aa905589

This is already the default if at least two delimiters with the same max priority are present:
https://github.com/psf/black/blob/b39999da7f451c285befac217f1f9a685774b34d/src/black/__init__.py#L6760-L6763
```py
# example formatting
return (
    is_postponed_evaluation_enabled(node)
    and value.qname() in SUBSCRIPTABLE_CLASSES_PEP585
    and is_node_in_type_annotation_context(node)
)
```

### Notes

The only code change is the first commit: https://github.com/psf/black/commit/4a4a3bc58a395680d53b94307bfa2e283249f4c8

Closes #2156

### Remaining Todo's
- [x] Fix broken tests
- [x] Write changelog entry