### PR TITLE
Use type_comments when parsing AST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### Unreleased
+
+#### _Black_
+
+- Parse type comments when using ast module (#2165)
+
 ### 21.4b2
 
 #### _Black_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -6416,7 +6416,12 @@ def parse_ast(src: str) -> Union[ast.AST, ast3.AST, ast27.AST]:
         # TODO: support Python 4+ ;)
         for minor_version in range(sys.version_info[1], 4, -1):
             try:
-                return ast.parse(src, filename, feature_version=(3, minor_version))
+                return ast.parse(
+                    src,
+                    filename,
+                    feature_version=(3, minor_version),
+                    type_comments=True,
+                )
             except SyntaxError:
                 continue
     else:


### PR DESCRIPTION
`ast.parse` doesn't parse type comments by default. This PR enables this option.

[reference](https://docs.python.org/3/library/ast.html#ast.parse)