### PR TITLE
Add ability to pass posargs to pytest run in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 commands =
     pip install -e .[d,python2]
     coverage erase
-    coverage run -m pytest tests
+    coverage run -m pytest tests {posargs}
     coverage report
 
 [testenv:fuzz]


### PR DESCRIPTION
I found it useful with #2170 be to able to specify `-k test_im_interested_in`, `--trace`, or `--pdb`.