### PR TITLE
Fix Primer: Tox has been formatted with Black 21.4b0

### DIFF
--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -112,7 +112,7 @@
     },
     "tox": {
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/tox-dev/tox.git",
       "long_checkout": false,
       "py_versions": ["all"]


### PR DESCRIPTION
Tox was formatted with Black 21.4b0 in https://github.com/tox-dev/tox/pull/2046 and there are now no expected formatting changes.

I don't think this needs a changelog entry, please add a `skip news` label.