### PR TITLE
Detect `'@' dotted_name '(' ')' NEWLINE` as a simple decorator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 
 - Set `--pyi` mode if `--stdin-filename` ends in `.pyi` (#2169)
 
+- Stop detecting target version as Python 3.9+ with pre-PEP-614 decorators that are
+  being called but with no arguments (#2182)
+
 ### 21.4b2
 
 #### _Black_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5761,6 +5761,13 @@ def is_simple_decorator_trailer(node: LN, last: bool = False) -> bool:
             and node.children[0].type == token.DOT
             and node.children[1].type == token.NAME
         )
+        # last trailer can be an argument-less parentheses pair
+        or (
+            last
+            and len(node.children) == 2
+            and node.children[0].type == token.LPAR
+            and node.children[1].type == token.RPAR
+        )
         # last trailer can be arguments
         or (
             last

--- a/tests/data/decorators.py
+++ b/tests/data/decorators.py
@@ -13,6 +13,12 @@ def f():
 
 ##
 
+@decorator()
+def f():
+    ...
+
+##
+
 @decorator(arg)
 def f():
     ...


### PR DESCRIPTION
Previously the RELAXED_DECORATOR detection would be falsely True on that
example. The problem was that an argument-less parentheses pair didn't
pass the `is_simple_decorator_trailer` check even it should. OTOH a
parentheses pair containing an argument or more passed as expected.

Fixes #2181

I whipped up this fix really quickly so apologies if this fix is garbage :)