### PR TITLE
Enable ` --experimental-string-processing` on most primer projects

### DIFF
--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -120,7 +120,7 @@ async def black_run(
     """Run Black and record failures"""
     cmd = [str(which(BLACK_BINARY))]
     if "cli_arguments" in project_config and project_config["cli_arguments"]:
-        cmd.extend(*project_config["cli_arguments"])
+        cmd.extend(project_config["cli_arguments"])
     cmd.append("--check")
     if no_diff:
         cmd.append(".")

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -104,7 +104,8 @@
       "py_versions": ["all"]
     },
     "sqlalchemy": {
-      "cli_arguments": ["--experimental-string-processing"],
+      "no_cli_args_reason": "breaks black with new string parsing - #2188",
+      "cli_arguments": [],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/sqlalchemy/sqlalchemy.git",
       "long_checkout": false,

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -2,28 +2,28 @@
   "configuration_format_version": 20200509,
   "projects": {
     "aioexabgp": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/cooperlees/aioexabgp.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "attrs": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/python-attrs/attrs.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "bandersnatch": {
-      "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "cli_arguments": ["--experimental-string-processing"],
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pypa/bandersnatch.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "channels": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/django/channels.git",
       "long_checkout": false,
@@ -32,22 +32,22 @@
     "django": {
       "disabled_reason": "black --check --diff returned 123 on tests_syntax_error.py",
       "disabled": true,
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/django/django.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "flake8-bugbear": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/PyCQA/flake8-bugbear.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "hypothesis": {
-      "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "cli_arguments": ["--experimental-string-processing"],
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/HypothesisWorks/hypothesis.git",
       "long_checkout": false,
       "py_versions": ["all"]
@@ -55,84 +55,84 @@
     "pandas": {
       "disabled_reason": "black-primer runs failing on Pandas - #2193",
       "disabled": true,
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pandas-dev/pandas.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "pillow": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/python-pillow/Pillow.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "poetry": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/python-poetry/poetry.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "pyanalyze": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/quora/pyanalyze.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "pyramid": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/Pylons/pyramid.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "ptr": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/facebookincubator/ptr.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "pytest": {
-      "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "cli_arguments": ["--experimental-string-processing"],
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pytest-dev/pytest.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "sqlalchemy": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/sqlalchemy/sqlalchemy.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "tox": {
-      "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "cli_arguments": ["--experimental-string-processing"],
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/tox-dev/tox.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "typeshed": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/python/typeshed.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "virtualenv": {
-      "cli_arguments": [],
-      "expect_formatting_changes": false,
+      "cli_arguments": ["--experimental-string-processing"],
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pypa/virtualenv.git",
       "long_checkout": false,
       "py_versions": ["all"]
     },
     "warehouse": {
-      "cli_arguments": [],
+      "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pypa/warehouse.git",
       "long_checkout": false,


### PR DESCRIPTION
- We want to make this default so need to test it more
- Fixed splat/star bug in extending black args for each project

Helps pave way for #2188