### PR TITLE
primer: Add `--no-diff` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 #### _Black_
 
 - Set `--pyi` mode if `--stdin-filename` ends in `.pyi` (#2169)
+- Add `--no-diff` to black-primer to suppress formatting changes (#2187)
 
 ### 21.4b2
 

--- a/src/black_primer/cli.py
+++ b/src/black_primer/cli.py
@@ -39,6 +39,7 @@ async def async_main(
     debug: bool,
     keep: bool,
     long_checkouts: bool,
+    no_diff: bool,
     rebase: bool,
     workdir: str,
     workers: int,
@@ -54,7 +55,13 @@ async def async_main(
 
     try:
         ret_val = await lib.process_queue(
-            config, work_path, workers, keep, long_checkouts, rebase
+            config,
+            work_path,
+            workers,
+            keep,
+            long_checkouts,
+            rebase,
+            no_diff,
         )
         return int(ret_val)
     finally:
@@ -94,6 +101,12 @@ async def async_main(
     is_flag=True,
     show_default=True,
     help="Pull big projects to test",
+)
+@click.option(
+    "--no-diff",
+    is_flag=True,
+    show_default=True,
+    help="Disable showing source file changes in black output",
 )
 @click.option(
     "-R",

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -112,13 +112,20 @@ def analyze_results(project_count: int, results: Results) -> int:
 
 
 async def black_run(
-    repo_path: Path, project_config: Dict[str, Any], results: Results
+    repo_path: Path,
+    project_config: Dict[str, Any],
+    results: Results,
+    no_diff: bool,
 ) -> None:
     """Run Black and record failures"""
     cmd = [str(which(BLACK_BINARY))]
     if "cli_arguments" in project_config and project_config["cli_arguments"]:
         cmd.extend(*project_config["cli_arguments"])
-    cmd.extend(["--check", "--diff", "."])
+    cmd.append("--check")
+    if no_diff:
+        cmd.append(".")
+    else:
+        cmd.extend(["--diff", "."])
 
     with TemporaryDirectory() as tmp_path:
         # Prevent reading top-level user configs by manipulating envionment variables
@@ -246,6 +253,7 @@ async def project_runner(
     long_checkouts: bool = False,
     rebase: bool = False,
     keep: bool = False,
+    no_diff: bool = False,
 ) -> None:
     """Check out project and run Black on it + record result"""
     loop = asyncio.get_event_loop()
@@ -284,7 +292,7 @@ async def project_runner(
         repo_path = await git_checkout_or_rebase(work_path, project_config, rebase)
         if not repo_path:
             continue
-        await black_run(repo_path, project_config, results)
+        await black_run(repo_path, project_config, results, no_diff)
 
         if not keep:
             LOG.debug(f"Removing {repo_path}")
@@ -303,6 +311,7 @@ async def process_queue(
     keep: bool = False,
     long_checkouts: bool = False,
     rebase: bool = False,
+    no_diff: bool = False,
 ) -> int:
     """
     Process the queue with X workers and evaluate results
@@ -330,7 +339,15 @@ async def process_queue(
     await asyncio.gather(
         *[
             project_runner(
-                i, config, queue, work_path, results, long_checkouts, rebase, keep
+                i,
+                config,
+                queue,
+                work_path,
+                results,
+                long_checkouts,
+                rebase,
+                keep,
+                no_diff,
             )
             for i in range(workers)
         ]

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -115,7 +115,7 @@ async def black_run(
     repo_path: Path,
     project_config: Dict[str, Any],
     results: Results,
-    no_diff: bool,
+    no_diff: bool = False,
 ) -> None:
     """Run Black and record failures"""
     cmd = [str(which(BLACK_BINARY))]

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -198,6 +198,7 @@ class PrimerCLITests(unittest.TestCase):
             "rebase": False,
             "workdir": str(work_dir),
             "workers": 69,
+            "no_diff": False,
         }
         with patch("black_primer.cli.lib.process_queue", return_zero):
             return_val = loop.run_until_complete(cli.async_main(**args))


### PR DESCRIPTION
- Allow runs with no code diff output
- This is handy for reducing output to see which file is erroring

Test:
- Edit config for 'channels' to expect no changes and run with `--no-diff` and see no diff output
- Fix unittests to handle new argument