### PR TITLE
GHA: Use pre-commit/action to simplify CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pre-commit
           python -m pip install -e '.[d]'
 
       - name: Lint
-        run: pre-commit run --all-files --show-diff-on-failure
+        uses: pre-commit/action@v2.0.2


### PR DESCRIPTION
https://github.com/pre-commit/action takes care of at least caching pip dependencies and colouring the terminal output.

Takes about the same amount of time as before, ~41s.