### PR TITLE
Speed up test suite via distributed testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ omit =
   src/blib2to3/*
   tests/data/*
   */site-packages/*
+  .tox/*
 
 [run]
 relative_files = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Unit tests
         run: |
-          tox -e py
+          tox -e py -- -v --color=yes
 
       - name: Publish coverage to Coveralls
         # If pushed / is a pull request against main repo AND

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,7 @@ pre-commit
 pytest >= 6.1.1
 pytest-mock >= 3.3.1
 pytest-cases >= 2.3.0
+pytest-xdist >= 2.2.1
+pytest-cov >= 2.11.1
 parameterized >= 0.7.4
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ deps =
 commands =
     pip install -e .[d]
     coverage erase
-    pytest tests --run-optional=no_python2 --numprocesses auto --cov {{posargs}
+    pytest tests --run-optional no_python2 --numprocesses auto --cov {posargs}
     pip install -e .[d,python2]
-    pytest tests --run-optional=python2 --numprocesses auto --cov --cov-append {posargs}
+    pytest tests --run-optional python2 --numprocesses auto --cov --cov-append {posargs}
     coverage report
 
 [testenv:fuzz]

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ deps =
 commands =
     pip install -e .[d]
     coverage erase
-    coverage run -m pytest tests -m "not python2" {posargs}
+    pytest tests -m "not python2" --numprocesses auto --cov {posargs}
     pip install -e .[d,python2]
-    coverage run -m pytest tests -m "not without_python2" {posargs}
+    pytest tests -m "not without_python2" --numprocesses auto --cov --cov-append {posargs}
     coverage report
 
 [testenv:fuzz]


### PR DESCRIPTION
Since we now run the test suite twice, one with Python 2 and another
without, full test runs are getting pretty slow. Let's try to
fix that with parallization.

Also use verbose mode on CI since more logs is usually better since
getting more is quite literally impossible.

The main issue we'll face with this is we'll hit
pytest-dev/pytest-xdist#620 sometimes
(although pretty rarely). I suppose we can test this and see if how bad
this bug is for us, and revert if necessary down the line.

Also let's have some colours :tada:

---

Comparison:

After PR:

![Screenshot from 2021-05-04 16-10-44](https://user-images.githubusercontent.com/63936253/117063798-551e1f80-acf3-11eb-8e82-5cce5f9d1acc.png)
https://github.com/psf/black/actions/runs/811254652

Before PR:

![Screenshot from 2021-05-04 16-12-25](https://user-images.githubusercontent.com/63936253/117063973-8eef2600-acf3-11eb-8eb5-35e5c63f029f.png)
https://github.com/psf/black/actions/runs/811220250