### PR TITLE
Build macOS releases

### DIFF
--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [windows-2019, ubuntu-20.04, macos-latest]
+        os: [windows-2019, ubuntu-20.04, macos-11.0]
         include:
           - os: windows-2019
             pathsep: ";"
@@ -21,11 +21,12 @@ jobs:
             pathsep: ":"
             executable_suffix: ".elf"
             executable_mime: "application/x-executable"
-
-          - os: macos-latest
+          - os: macos-11.0
             pathsep: ":"
             executable_suffix: ""
             executable_mime: "application/x-mach-binary"
+            env:
+              CFLAGS: "-arch arm64 -arch x86_64"
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install .
-          python -m pip install pyinstaller
+          python -m pip install https://github.com/rokm/pyinstaller/archive/macos11-arm-support.zip
 
       - name: Build binary
         run: |

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [windows-2019, ubuntu-20.04, macos-11.0]
+        os: [windows-2019, ubuntu-20.04, macos-latest]
         include:
           - os: windows-2019
             pathsep: ";"
@@ -22,7 +22,7 @@ jobs:
             executable_suffix: ".elf"
             executable_mime: "application/x-executable"
 
-          - os: macos-11.0
+          - os: macos-latest
             pathsep: ":"
             executable_suffix: ""
             executable_mime: "application/x-mach-binary"

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [ubuntu-16.04, windows-2019]
+        os: [windows-2019, ubuntu-16.04, macos-11.0]
         include:
           - os: windows-2019
             pathsep: ";"
@@ -21,6 +21,11 @@ jobs:
             pathsep: ":"
             executable_suffix: ".elf"
             executable_mime: "application/x-executable"
+
+          - os: macos-11.0
+            pathsep: ":"
+            executable_suffix: ""
+            executable_mime: "application/x-mach-binary"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -11,13 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [windows-2019, ubuntu-16.04, macos-11.0]
+        os: [windows-2019, ubuntu-20.04, macos-11.0]
         include:
           - os: windows-2019
             pathsep: ";"
             executable_suffix: ".exe"
             executable_mime: "application/vnd.microsoft.portable-executable"
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             pathsep: ":"
             executable_suffix: ".elf"
             executable_mime: "application/x-executable"

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -37,18 +37,36 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        if: matrix.os != 'macos-11.0'
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install .
+          python -m pip install pyinstaller
+
+      - name: Build binary
+        if: matrix.os != 'macos-11.0'
+        run: |
+          python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+
+      - name: Install dependencies macOS
+        if: matrix.os == 'macos-11.0'
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install .
           git clone https://github.com/rokm/pyinstaller -b macos11-arm-support
           cd pyinstaller/bootloader
-          python ./waf all
+          mkdir -p build
+          clang -arch x86_64 -mmacos-version-min=10.7  `ls src/*.c` -o build/run-x86_64 -lm -lz
+          clang -isysroot /Applications/Xcode2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.*.sdk -arch arm64 -mmacos-version-min=11.0 -o build/run-arm64 `ls src/*.c` -lz -lc
+          lipo -create -o ../PyInstaller/bootloader/Darwin-64bit/run build/run-arm64 build/run-x86_64
+          lipo -archs ../PyInstaller/bootloader/Darwin-64bit/run
           cd ../..
-          python -m pip install https://github.com/rokm/pyinstaller/archive/macos11-arm-support.zip
+          python setup.py install
 
-      - name: Build binary
+      - name: Build binary macOS
+        if: matrix.os == 'macos-11.0'
         run: |
-          python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+          CFLAGS="-arch arm64 -arch x86_64" python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install .
+          git clone https://github.com/rokm/pyinstaller -b macos11-arm-support
+          cd pyinstaller/bootloader
+          python ./waf all
+          cd ../..
           python -m pip install https://github.com/rokm/pyinstaller/archive/macos11-arm-support.zip
 
       - name: Build binary

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -56,8 +56,8 @@ jobs:
           git clone https://github.com/rokm/pyinstaller -b macos11-arm-support
           cd pyinstaller/bootloader
           mkdir -p build
-          clang -arch x86_64 -mmacos-version-min=10.7  `ls src/*.c` -o build/run-x86_64 -lm -lz
-          clang -isysroot /Applications/Xcode2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.*.sdk -arch arm64 -mmacos-version-min=11.0 -o build/run-arm64 `ls src/*.c` -lz -lc
+          clang -arch x86_64 -mmacos-version-min=10.7 `ls src/*.c` -o build/run-x86_64 -lm -lz
+          clang -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.*.sdk -arch arm64 -mmacos-version-min=11.0 -o build/run-arm64 `ls src/*.c` -lz -lc
           lipo -create -o ../PyInstaller/bootloader/Darwin-64bit/run build/run-arm64 build/run-x86_64
           lipo -archs ../PyInstaller/bootloader/Darwin-64bit/run
           cd ../..

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build binary
         run: |
-          python -m PyInstaller -F --name ${{ asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1
@@ -50,6 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ asset_name }}
-          asset_name: ${{ asset_name }}
+          asset_path: dist/${{ matrix.asset_name }}
+          asset_name: ${{ matrix.asset_name }}
           asset_content_type: ${{ matrix.executable_mime }}

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -15,16 +15,15 @@ jobs:
         include:
           - os: windows-2019
             pathsep: ";"
-            executable_suffix: ".exe"
+            asset_name: black_windows.exe
             executable_mime: "application/vnd.microsoft.portable-executable"
           - os: ubuntu-20.04
             pathsep: ":"
-            executable_suffix: ".elf"
+            asset_name: black_linux
             executable_mime: "application/x-executable"
-
           - os: macos-latest
             pathsep: ":"
-            executable_suffix: ""
+            asset_name: black_macos
             executable_mime: "application/x-mach-binary"
 
     steps:
@@ -43,7 +42,7 @@ jobs:
 
       - name: Build binary
         run: |
-          python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+          python -m PyInstaller -F --name ${{ asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1
@@ -51,6 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/black${{ matrix.executable_suffix }}
-          asset_name: black${{ matrix.executable_suffix }}
+          asset_path: dist/${{ asset_name }}
+          asset_name: ${{ asset_name }}
           asset_content_type: ${{ matrix.executable_mime }}

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [windows-2019, ubuntu-20.04, macos-11.0]
+        os: [windows-2019, ubuntu-20.04, macos-latest]
         include:
           - os: windows-2019
             pathsep: ";"
@@ -21,12 +21,11 @@ jobs:
             pathsep: ":"
             executable_suffix: ".elf"
             executable_mime: "application/x-executable"
-          - os: macos-11.0
+
+          - os: macos-latest
             pathsep: ":"
             executable_suffix: ""
             executable_mime: "application/x-mach-binary"
-            env:
-              CFLAGS: "-arch arm64 -arch x86_64"
 
     steps:
       - uses: actions/checkout@v2
@@ -37,36 +36,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        if: matrix.os != 'macos-11.0'
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install .
           python -m pip install pyinstaller
 
       - name: Build binary
-        if: matrix.os != 'macos-11.0'
         run: |
           python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
-
-      - name: Install dependencies macOS
-        if: matrix.os == 'macos-11.0'
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install .
-          git clone https://github.com/rokm/pyinstaller -b macos11-arm-support
-          cd pyinstaller/bootloader
-          mkdir -p build
-          clang -arch x86_64 -mmacos-version-min=10.7 `ls src/*.c` -o build/run-x86_64 -lm -lz
-          clang -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.*.sdk -arch arm64 -mmacos-version-min=11.0 -o build/run-arm64 `ls src/*.c` -lz -lc
-          lipo -create -o ../PyInstaller/bootloader/Darwin-64bit/run build/run-arm64 build/run-x86_64
-          lipo -archs ../PyInstaller/bootloader/Darwin-64bit/run
-          cd ../..
-          python setup.py install
-
-      - name: Build binary macOS
-        if: matrix.os == 'macos-11.0'
-        run: |
-          CFLAGS="-arch arm64 -arch x86_64" python -m PyInstaller -F --name black${{ matrix.executable_suffix }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 - Add a lower bound for the `aiohttp-cors` dependency. Only 0.4.0 or higher is
   supported. (#2231)
 
+### _Packaging_
+
+- Release self-contained macOS binaries as part of the GitHub release pipeline (#2198)
+
 ### Documentation
 
 - Fix typos discovered by codespell (#2228)


### PR DESCRIPTION
This is an addition to the existing CI releases for Linux and Windows, adding support for self-contained macOS builds.

The pipeline run can be inspected here: https://github.com/disrupted/black/runs/2504846870

The result was uploaded here: https://github.com/disrupted/black/releases/tag/21.5b2

With those three targets in place I believe it would make sense to add the target names to the binaries to avoid ambiguity. I was thinking something like this:

- `black_macos`
- `black_ubuntu.elf`
- `black_windows.exe`