### PR TITLE
Mark blackd tests with the `blackd` optional marker

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ wheel = ">=0.31.1"
 black = {editable = true, extras = ["d"], path = "."}
 
 [packages]
-aiohttp = ">=3.3.2"
+aiohttp = ">=3.6.0"
 aiohttp-cors = "*"
 appdirs = "*"
 click = ">=7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ build-backend = "setuptools.build_meta"
 # Option below requires `tests/optional.py`
 optional-tests = [
   "no_python2: run when `python2` extra NOT installed",
+  "no_blackd: run when `d` extra NOT installed",
 ]

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "mypy_extensions>=0.4.3",
     ],
     extras_require={
-        "d": ["aiohttp>=3.3.2", "aiohttp-cors"],
+        "d": ["aiohttp>=3.6.0", "aiohttp-cors"],
         "colorama": ["colorama>=0.4.3"],
         "python2": ["typed-ast>=1.4.2"],
     },

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,10 +1,10 @@
 import re
-import unittest
 from unittest.mock import patch
 
 from click.testing import CliRunner
+import pytest
 
-from tests.util import read_data, DETERMINISTIC_HEADER, skip_if_exception
+from tests.util import read_data, DETERMINISTIC_HEADER
 
 try:
     import blackd
@@ -16,8 +16,8 @@ else:
     has_blackd_deps = True
 
 
+@pytest.mark.blackd
 class BlackDTestCase(AioHTTPTestCase):
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     def test_blackd_main(self) -> None:
         with patch("blackd.web.run_app"):
             result = CliRunner().invoke(blackd.main, [])
@@ -28,10 +28,6 @@ class BlackDTestCase(AioHTTPTestCase):
     async def get_application(self) -> web.Application:
         return blackd.make_app()
 
-    # TODO: remove these decorators once the below is released
-    # https://github.com/aio-libs/aiohttp/pull/3727
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_request_needs_formatting(self) -> None:
         response = await self.client.post("/", data=b"print('hello world')")
@@ -39,16 +35,12 @@ class BlackDTestCase(AioHTTPTestCase):
         self.assertEqual(response.charset, "utf8")
         self.assertEqual(await response.read(), b'print("hello world")\n')
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_request_no_change(self) -> None:
         response = await self.client.post("/", data=b'print("hello world")\n')
         self.assertEqual(response.status, 204)
         self.assertEqual(await response.read(), b"")
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_request_syntax_error(self) -> None:
         response = await self.client.post("/", data=b"what even ( is")
@@ -59,8 +51,6 @@ class BlackDTestCase(AioHTTPTestCase):
             msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
         )
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_unsupported_version(self) -> None:
         response = await self.client.post(
@@ -68,8 +58,6 @@ class BlackDTestCase(AioHTTPTestCase):
         )
         self.assertEqual(response.status, 501)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_supported_version(self) -> None:
         response = await self.client.post(
@@ -77,8 +65,6 @@ class BlackDTestCase(AioHTTPTestCase):
         )
         self.assertEqual(response.status, 200)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_invalid_python_variant(self) -> None:
         async def check(header_value: str, expected_status: int = 400) -> None:
@@ -97,8 +83,6 @@ class BlackDTestCase(AioHTTPTestCase):
         await check("pypy3.0")
         await check("jython3.4")
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_pyi(self) -> None:
         source, expected = read_data("stub.pyi")
@@ -108,8 +92,6 @@ class BlackDTestCase(AioHTTPTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(await response.text(), expected)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_diff(self) -> None:
         diff_header = re.compile(
@@ -128,8 +110,6 @@ class BlackDTestCase(AioHTTPTestCase):
         actual = diff_header.sub(DETERMINISTIC_HEADER, actual)
         self.assertEqual(actual, expected)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_python_variant(self) -> None:
         code = (
@@ -166,8 +146,6 @@ class BlackDTestCase(AioHTTPTestCase):
         await check("py34,py36", 204)
         await check("34", 204)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_line_length(self) -> None:
         response = await self.client.post(
@@ -175,8 +153,6 @@ class BlackDTestCase(AioHTTPTestCase):
         )
         self.assertEqual(response.status, 200)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_invalid_line_length(self) -> None:
         response = await self.client.post(
@@ -184,8 +160,6 @@ class BlackDTestCase(AioHTTPTestCase):
         )
         self.assertEqual(response.status, 400)
 
-    @skip_if_exception("ClientOSError")
-    @unittest.skipUnless(has_blackd_deps, "blackd's dependencies are not installed")
     @unittest_run_loop
     async def test_blackd_response_black_version_header(self) -> None:
         response = await self.client.post("/")

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,7 @@
 import os
 import unittest
-from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Tuple, Iterator, Any
+from typing import List, Tuple, Any
 import black
 from functools import partial
 
@@ -43,17 +42,6 @@ class BlackBaseTestCase(unittest.TestCase):
             except Exception as ve:
                 black.err(str(ve))
         self.assertMultiLineEqual(expected, actual)
-
-
-@contextmanager
-def skip_if_exception(e: str) -> Iterator[None]:
-    try:
-        yield
-    except Exception as exc:
-        if exc.__class__.__name__ == e:
-            unittest.skip(f"Encountered expected exception {exc}, skipping")
-        else:
-            raise
 
 
 def read_data(name: str, data: bool = True) -> Tuple[str, str]:


### PR DESCRIPTION
This is a follow-up of #2203 that uses a pytest marker instead of a bunch of `skipUnless`.  Similarly to the Python 2 tests, they are running by default and will crash on an unsuspecting contributor with missing dependencies.  This is by design, we WANT contributors to test everything.  Unless we actually don't
and then we can run:

```
pytest --run-optional=no_blackd
```

Relatedly, bump required aiohttp to 3.6.0 at least to get rid of expected failures on Python 3.8 (see 6b5eb7d4651c7333cc3f5df4bf7aa7a1f1ffb45b).