### PR TITLE
Speed up tests even more

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -171,8 +171,9 @@ class BlackTestCase(BlackBaseTestCase):
         )
         self.assertEqual(result.exit_code, 0)
         self.assertFormatEqual(expected, result.output)
-        black.assert_equivalent(source, result.output)
-        black.assert_stable(source, result.output, DEFAULT_MODE)
+        if source != result.output:
+            black.assert_equivalent(source, result.output)
+            black.assert_stable(source, result.output, DEFAULT_MODE)
 
     def test_piping_diff(self) -> None:
         diff_header = re.compile(
@@ -1900,7 +1901,7 @@ class BlackTestCase(BlackBaseTestCase):
             critical=fail,
             log=fail,
         ):
-            ff(THIS_FILE)
+            ff(THIS_DIR / "util.py")
 
     def test_invalid_config_return_code(self) -> None:
         tmp_file = Path(black.dump_to_file())

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -7,7 +7,6 @@ from parameterized import parameterized
 from tests.util import (
     BlackBaseTestCase,
     fs,
-    ff,
     DEFAULT_MODE,
     dump_to_stderr,
     read_data,
@@ -111,11 +110,11 @@ class TestSimpleFormat(BlackBaseTestCase):
     def test_source_is_formatted(self, filename: str) -> None:
         path = THIS_DIR.parent / filename
         self.check_file(str(path), DEFAULT_MODE, data=False)
-        self.assertFalse(ff(path))
 
     def check_file(self, filename: str, mode: black.Mode, *, data: bool = True) -> None:
         source, expected = read_data(filename, data=data)
         actual = fs(source, mode=mode)
         self.assertFormatEqual(expected, actual)
-        black.assert_equivalent(source, actual)
-        black.assert_stable(source, actual, mode)
+        if source != actual:
+            black.assert_equivalent(source, actual)
+            black.assert_stable(source, actual, mode)


### PR DESCRIPTION
There's three optimizations in this commit:

1. Don't check if Black's output is stable or equivalant if no changes
   were made in the first place. It's not like passing the same code
   (for both source and actual) through black.assert_equivalent or
   black.assert_stable is useful. It's not a big deal for the smaller
   tests, but it eats a lot of time in tests/test_format.py since
   its test cases are big. This is also closer to how Black works IRL.

2. Use a smaller file for `test_root_logger_not_used_directly` since
   the logging it's checking happens during blib2to3's startup so the
   file doesn't really matter.

3. If we're checking a file is formatting (i.e. test_source_is_formatted)
   don't run Black over it again with `black.format_file_in_place`.
   `tests/test_format.py::TestSimpleFormat.check_file` is good enough.