### PR TITLE
docs(README): Update dead ReadTheDocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python -m black {source_file_or_directory}
 
 Further information can be found in our docs:
 
-- [Usage and Configuration](https://black.readthedocs.io/en/stable/usage_and_configuration/index.html)
+- [Usage and Configuration](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 
 ### NOTE: This is a beta product
 
@@ -122,7 +122,7 @@ You can find more details in our documentation:
 
 And if you're looking for more general configuration documentation:
 
-- [Usage and Configuration](https://black.readthedocs.io/en/stable/usage_and_configuration/index.html)
+- [Usage and Configuration](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 
 **Pro-tip**: If you're asking yourself "Do I need to configure anything?" the answer is
 "No". _Black_ is all about sensible defaults. Applying those defaults will have your

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ planned, mostly responses to bug reports.
 Also, as a safety measure which slows down processing, _Black_ will check that the
 reformatted code still produces a valid AST that is effectively equivalent to the
 original (see the
-[Pragmatism](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#ast-before-and-after-formatting)
+[AST Before and After Formatting](https://black.readthedocs.io/en/stable/the_black_code_style.html#ast-before-and-after-formatting)
 section for details). If you're feeling confident, use `--fast`.
 
 ## The _Black_ code style

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ project.
 
 You can find more details in our documentation:
 
-- [The basics: Configuration via a file](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file)
+- [The basics: Configuration via a file](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)
 
 And if you're looking for more general configuration documentation:
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ initial author. This was fine at the time as it made the implementation simpler 
 there were not many users anyway. Not many edge cases were reported. As a mature tool,
 _Black_ does make some exceptions to rules it otherwise holds.
 
-- [The _Black_ code style: Pragmatism](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#pragmatism)
+- [The _Black_ code style: Pragmatism](https://black.readthedocs.io/en/stable/the_black_code_style.html#pragmatism)
 
 Please refer to this document before submitting an issue just like with the document
 above. What seems like a bug might be intended behaviour.


### PR DESCRIPTION
I found some dead ReadTheDocs links in the README and fixed them. Each link fix is in a separate commit - please let me know if any should be pointing to a different page in RTD altogether and I'll modify my changes.