### PR TITLE
Remove useless flake8 config + test support code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,3 @@ extend-ignore = E203, E266, E501
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-# We need to configure the mypy.ini because the flake8-mypy's default
-# options don't properly override it, so if we don't specify it we get
-# half of the config from mypy.ini and half from flake8-mypy.
-mypy_config = mypy.ini


### PR DESCRIPTION
Also remove the primer tests import in tests/test_black.py because it's
annoying when just trying to actually target tests/test_black.py tests.
`pytest -k test_black.py` doesn't do what you expect due to that import.