### PR TITLE
Modify when Test, Primer, and Documentation Build run

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ assignees: ""
    - clone this repository;
    - run `pip install -e .[d,python2]`;
    - run `pip install -r test_requirements.txt`
-   - make sure it's sane by running `python -m unittest`; and
+   - make sure it's sane by running `python -m pytest`; and
    - run `black` like you did last time.
 
 **Additional context** Add any other context about the problem here.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,20 +1,6 @@
 name: Documentation Build
 
-on:
-  push:
-    paths:
-      - "docs/**"
-      - "README.md"
-      - "CHANGES.md"
-      - "CONTRIBUTING.md"
-      - "AUTHORS.md"
-  pull_request:
-    paths:
-      - "docs/**"
-      - "README.md"
-      - "CHANGES.md"
-      - "CONTRIBUTING.md"
-      - "AUTHORS.md"
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/primer.yml
+++ b/.github/workflows/primer.yml
@@ -1,6 +1,15 @@
 name: Primer
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 jobs:
   build:


### PR DESCRIPTION
- Test and Primer don't run for documentation only changes since it's
  unnecessary, eating unnecessary cycles and slowing down CI since these
  workflows eat up the 20 max workers limit quite easily!

- Documentation Build runs all of the time now since quite a bit of the
  content depends on Black's code so even a simple 1-file change in
  src/black/__init__.py may break the docs build. It's not like this is
  a costly workflow anyway.

Fuzz is still running on all changes because with fuzzing, the more the
better in general. 6 or 7 jobs on a documentation only commit is much
better than 27/28 jobs anyway :p

I also found an error in our bug report issue template :)