### PR TITLE
Use codespell to find typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### _Black_
 
+- Fix typos discovered by codespell (#2228)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)
 
 ## 21.5b1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Try it out now using the `Black Playground <https://black.vercel.app>`_.
    many projects, small and big. *Black* has a comprehensive test suite, with efficient
    parallel tests, our own auto  formatting and parallel Continuous Integration runner.
    However, *Black* is still beta. Things will probably be wonky for a while. This is
-   made explicit by the "Beta" trove classifier, as well as by the "b" in the versio
+   made explicit by the "Beta" trove classifier, as well as by the "b" in the version
    number. What this means for you is that **until the formatter becomes stable, you
    should expect some formatting to change in the future**. That being said, no drastic
    stylistic changes are planned, mostly responses to bug reports.

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -576,7 +576,7 @@ class StringParenStripper(StringTransformer):
             - The target string is NOT the only argument to a function call.
             - The target string is NOT a "pointless" string.
             - If the target string contains a PERCENT, the brackets are not
-              preceeded or followed by an operator with higher precedence than
+              preceded or followed by an operator with higher precedence than
               PERCENT.
 
     Transformations:

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -128,7 +128,7 @@ async def black_run(
         cmd.extend(["--diff", "."])
 
     with TemporaryDirectory() as tmp_path:
-        # Prevent reading top-level user configs by manipulating envionment variables
+        # Prevent reading top-level user configs by manipulating environment variables
         env = {
             **os.environ,
             "XDG_CONFIG_HOME": tmp_path,  # Unix-like

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -101,7 +101,7 @@ class FakeParameter(click.Parameter):
 
 
 class BlackRunner(CliRunner):
-    """Make sure STDOUT and STDERR are kept seperate when testing Black via its CLI."""
+    """Make sure STDOUT and STDERR are kept separate when testing Black via its CLI."""
 
     def __init__(self) -> None:
         super().__init__(mix_stderr=False)
@@ -1508,7 +1508,7 @@ class BlackTestCase(BlackBaseTestCase):
 
     @patch("black.find_project_root", lambda *args: THIS_DIR.resolve())
     def test_get_sources_with_stdin_filename_and_exclude(self) -> None:
-        # Exclude shouldn't exclude stdin_filename since it is mimicing the
+        # Exclude shouldn't exclude stdin_filename since it is mimicking the
         # file being passed directly. This is the same as
         # test_exclude_for_issue_1572
         path = THIS_DIR / "data" / "include_exclude_tests"


### PR DESCRIPTION
Fix typos discovered by https://github.com/codespell-project/codespell
```
codespell --ignore-words-list="ans,hart,ot,poit,reallllly,tring" .
```