### PR TITLE
Add lower bound for aiohttp-cors + fix primer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 - Fix typos discovered by codespell (#2228)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)
 
+### _Blackd_
+
+- Add a lower bound for the `aiohttp-cors` dependency. Only 0.4.0 or higher is
+  supported. (#2231)
+
 ## 21.5b1
 
 ### _Black_

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "mypy_extensions>=0.4.3",
     ],
     extras_require={
-        "d": ["aiohttp>=3.6.0", "aiohttp-cors"],
+        "d": ["aiohttp>=3.6.0", "aiohttp-cors>=0.4.0"],
         "colorama": ["colorama>=0.4.3"],
         "python2": ["typed-ast>=1.4.2"],
     },

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -106,7 +106,7 @@
     "sqlalchemy": {
       "no_cli_args_reason": "breaks black with new string parsing - #2188",
       "cli_arguments": [],
-      "expect_formatting_changes": true,
+      "expect_formatting_changes": false,
       "git_clone_url": "https://github.com/sqlalchemy/sqlalchemy.git",
       "long_checkout": false,
       "py_versions": ["all"]


### PR DESCRIPTION
It appears sqlalchemy has recently reformatted their project with
Black 21.5b1.

Most of our dependencies have a lower bound and creating a test
environment with the oldest acceptable dependencies runs the full
Black test suite just fine. The only exception to this is aiohttp-cors.
It's unbounded and the oldest version 0.1.0 until 0.4.0 breaks the
test suite in such an old environment.

Failure with 0.1.0:

```
tests/test_blackd.py:10: in <module>
    import blackd
testenv/lib/python3.8/site-packages/blackd/__init__.py:12: in <module>
    import aiohttp_cors
testenv/lib/python3.8/site-packages/aiohttp_cors/__init__.py:29: in <module>
    from .urldispatcher_router_adapter import UrlDistatcherRouterAdapter
testenv/lib/python3.8/site-packages/aiohttp_cors/urldispatcher_router_adapter.py:27: in <module>
    class UrlDistatcherRouterAdapter(RouterAdapter):
testenv/lib/python3.8/site-packages/aiohttp_cors/urldispatcher_router_adapter.py:32: in UrlDistatcherRouterAdapter
    def route_methods(self, route: web.Route):
E   AttributeError: module 'aiohttp.web' has no attribute 'Route'
```

For 0.2.0:

```
tests/test_blackd.py:10: in <module>
    import blackd
testenv/lib/python3.8/site-packages/blackd/__init__.py:12: in <module>
    import aiohttp_cors
testenv/lib/python3.8/site-packages/aiohttp_cors/__init__.py:27: in <module>
    from .cors_config import CorsConfig
testenv/lib/python3.8/site-packages/aiohttp_cors/cors_config.py:24: in <module>
    from .urldispatcher_router_adapter import UrlDistatcherRouterAdapter
testenv/lib/python3.8/site-packages/aiohttp_cors/urldispatcher_router_adapter.py:27: in <module>
    class UrlDistatcherRouterAdapter(AbstractRouterAdapter):
testenv/lib/python3.8/site-packages/aiohttp_cors/urldispatcher_router_adapter.py:32: in UrlDistatcherRouterAdapter
    def route_methods(self, route: web.Route):
E   AttributeError: module 'aiohttp.web' has no attribute 'Route'
```

For 0.3.0:

```
ERROR: Cannot install aiohttp-cors==0.3.0 and aiohttp==3.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested aiohttp==3.6.0
    aiohttp-cors 0.3.0 depends on aiohttp<=0.20.2 and >=0.18.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```