### PR TITLE
Update vim plugin manual installation instructions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fix typos discovered by codespell (#2228)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)
+- Fix vim plugin installation instructions. (#2235)
 
 ### _Blackd_
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -147,8 +147,7 @@ $ git checkout origin/stable -b stable
 ```
 
 or you can copy the plugin files from
-[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim)
-and
+[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim) and
 [autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim).
 
 ```

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -146,12 +146,16 @@ $ cd ~/.vim/bundle/black
 $ git checkout origin/stable -b stable
 ```
 
-or you can copy the plugin from
-[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim).
+or you can copy the plugin files from
+[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim)
+and
+[autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim).
 
 ```
 mkdir -p ~/.vim/pack/python/start/black/plugin
+mkdir -p ~/.vim/pack/python/start/black/autoload
 curl https://raw.githubusercontent.com/psf/black/stable/plugin/black.vim -o ~/.vim/pack/python/start/black/plugin/black.vim
+curl https://raw.githubusercontent.com/psf/black/stable/autoload/black.vim -o ~/.vim/pack/python/start/black/autoload/black.vim
 ```
 
 Let me know if this requires any changes to work with Vim 8's builtin `packadd`, or


### PR DESCRIPTION
Closes #2234 

Since the vim.plugin was updated to v1.2 in #1157 , the installation procedure has changed.

This PR updates the manual installation instructions for the new vim plugin to include BOTH `plugin/black.vim` and `autoload/black.vim`.