### PR TITLE
Keep user inserted optional parentheses

### DIFF
--- a/src/black/const.py
+++ b/src/black/const.py
@@ -1,4 +1,10 @@
+from enum import Enum
+
 DEFAULT_LINE_LENGTH = 88
 DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist)/"  # noqa: B950
 DEFAULT_INCLUDES = r"\.pyi?$"
 STDIN_PLACEHOLDER = "__BLACK_STDIN_FILENAME__"
+
+
+class Fixer(Enum):
+    HIDE_PARENTHESES = 1

--- a/tests/data/trailing_comma_optional_parens2.py
+++ b/tests/data/trailing_comma_optional_parens2.py
@@ -1,3 +1,3 @@
-if (e123456.get_tk_patchlevel() >= (8, 6, 0, 'final') or
-    (8, 5, 8) <= get_tk_patchlevel() < (8, 6)):
+if e123456.get_tk_patchlevel() >= (8, 6, 0, 'final') or \
+    (8, 5, 8) <= get_tk_patchlevel() < (8, 6):
     pass


### PR DESCRIPTION
This is the followup to #2163 as it was seen as a noticeable improvement but rejected due to the large impact on existing codebases.

With this PR, `black` will now keep user-inserted optional parentheses if at least `1` delimiter with `LOGIC_PRIORITY` or higher is present. This would allow developers the option to actively choose the improved style while not changing existing codebases.

_If the idea itself is excepted, we could also discuss if this change should apply to all delimiters._

Example style
```py
        return subscript_start is not None and any(
            n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
        )

# OR
        return (
            subscript_start is not None
            and any(n.type in TEST_DESCENDANTS for n in subscript_start.pre_order())
        )
```
For more examples, please refer to the original PR #2163 or the issue #2156 

Closes: #2156

/CC: @ambv, @JelleZijlstra, @cooperlees, @felix-hilden As you all have in some form participated in the original discussion, I'm especially interested in your thoughts.

### Remaining tasks
- [ ] Decide if the PR should move forward
- [ ] _[Decide if change should apply to all delimiters]_
- [ ] Fix failing tests (if any)
- [ ] Add new test case
- [ ] Add changelog entry