### PR TITLE
Make Prettier preserve line ending type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,3 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
-        args: [--prose-wrap=always, --print-width=88, --end-of-line=auto]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
-        args: [--prose-wrap=always, --print-width=88]
+        args: [--prose-wrap=always, --print-width=88, --end-of-line=auto]

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,3 @@
+proseWrap: always
+printWidth: 88
+endOfLine: auto


### PR DESCRIPTION
Hi! This PR, should you choose to accept it, makes Prettier preserve the line ending types of files it touches.

Why? The default in Prettier 2.0 was [changed](https://prettier.io/docs/en/options.html#end-of-line) from `auto` to `LF`. This makes development on Windows awkward, because every file is marked with changes both by Prettier and then by Git regardless of repository line ending settings, making committing harder than it should be.

As discussed in #1741, line ending settings can be configured, and there are other tools for enforcing line ending consistency. I don't know whether they have the same effect of converting all files regardless of settings though.

Suggested: `skip-news`. If this is not to your liking, feel free to close. This PR will self-destruct in five years.

---

Aside from that: I noticed that runnin pre-commit manually seems to add line endings to symlink files, but they disappear when actually committing. Don't know if that's a known.. quirk..(?) or not.