### PR TITLE
Fix test requirements file name in documentation

### DIFF
--- a/docs/contributing/the_basics.md
+++ b/docs/contributing/the_basics.md
@@ -22,7 +22,7 @@ from the cloned _Black_ repo. It will do the correct thing.
 Non pipenv install works too:
 
 ```console
-$ pip install -r test_requirements
+$ pip install -r test_requirements.txt
 $ pip install -e .[d]
 ```
 


### PR DESCRIPTION
No mountain too high to climb, no fix too small to shoot a PR and write a description that's a hundred times longer than the diff. Right?

A no-brainer, really. Another `skip-news`, if you'd be so kind!