### PR TITLE
Removed adding a space into empty docstrings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### _Black_
 
+- A space is no longer inserted into empty docstrings (#2249)
 - Respect `.gitignore` files in all levels, not only `root/.gitignore` file (apply
   `.gitignore` rules like `git` does) (#2225)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -255,9 +255,6 @@ class LineGenerator(Visitor[Line]):
                         # Odd number of tailing backslashes, add some padding to
                         # avoid escaping the closing string quote.
                         docstring += " "
-            else:
-                # Add some padding if the docstring is empty.
-                docstring = " "
 
             # We could enforce triple quotes at this point.
             quote = quote_char * quote_len

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -236,6 +236,7 @@ class LineGenerator(Visitor[Line]):
             # characters but only if they are the same as the first.
             quote_len = 1 if docstring[1] != quote_char else 3
             docstring = docstring[quote_len:-quote_len]
+            docstring_started_empty = not docstring
 
             if is_multiline_string(leaf):
                 indent = " " * 4 * self.current_line.depth
@@ -255,6 +256,8 @@ class LineGenerator(Visitor[Line]):
                         # Odd number of tailing backslashes, add some padding to
                         # avoid escaping the closing string quote.
                         docstring += " "
+            elif not docstring_started_empty:
+                docstring = " "
 
             # We could enforce triple quotes at this point.
             quote = quote_char * quote_len

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -102,7 +102,7 @@ def and_this():
   "hey yah"'''
 
 
-def empty():
+def multiline_whitespace():
     '''
     
     
@@ -111,11 +111,11 @@ def empty():
     '''
 
 
-def oneline_empty():
+def oneline_whitespace():
     '''      '''
 
 
-def oneline_nothing():
+def empty():
     """"""
 
 
@@ -293,15 +293,15 @@ def and_this():
     "hey yah"'''
 
 
+def multiline_whitespace():
+    """ """
+
+
+def oneline_whitespace():
+    """ """
+
+
 def empty():
-    """"""
-
-
-def oneline_empty():
-    """"""
-
-
-def oneline_nothing():
     """"""
 
 

--- a/tests/data/docstring.py
+++ b/tests/data/docstring.py
@@ -294,15 +294,15 @@ def and_this():
 
 
 def empty():
-    """ """
+    """"""
 
 
 def oneline_empty():
-    """ """
+    """"""
 
 
 def oneline_nothing():
-    """ """
+    """"""
 
 
 def single_quotes():


### PR DESCRIPTION
Resolves #2168 by disabling the insertion of a " " when the docstring is entirely empty.

Note that this PR is focussed only on the case of empty docstrings. In particular this does not make any changes to the behaviour that a " " is inserted if a non-empty docstring begins with the quoting character. That is, black still prefers:

    """ "something" """

to:

    """"something" """

and that:

    """"Something""""

is not a legal docstring.
