### PR TITLE
Add optional uvloop import

### DIFF
--- a/.github/workflows/uvloop_test.yml
+++ b/.github/workflows/uvloop_test.yml
@@ -1,0 +1,46 @@
+name: test uvloop
+
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+jobs:
+  build:
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. Without this if check, checks are duplicated since
+    # internal PRs match both the push and pull_request events.
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Test uvloop Extra Install
+        run: |
+          python -m pip install -e ".[uvloop]"
+
+      - name: Primer uvloop run
+        run: |
+          black-primer

--- a/.github/workflows/uvloop_test.yml
+++ b/.github/workflows/uvloop_test.yml
@@ -32,10 +32,9 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
 
-      - name: Install dependencies
+      - name: Install latest pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade tox
 
       - name: Test uvloop Extra Install
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Respect `.gitignore` files in all levels, not only `root/.gitignore` file (apply
   `.gitignore` rules like `git` does) (#2225)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)
+- Add extra uvloop install + import support if in python env (#2258)
 
 ### _Blackd_
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "d": ["aiohttp>=3.6.0", "aiohttp-cors>=0.4.0"],
         "colorama": ["colorama>=0.4.3"],
         "python2": ["typed-ast>=1.4.2"],
+        "uvloop": ["uvloop>=0.15.2"],
     },
     test_suite="tests.test_black",
     classifiers=[

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -54,6 +54,13 @@ from blib2to3.pgen2 import token
 
 from _black_version import version as __version__
 
+# If our environment has uvloop installed lets use it
+try:
+    import uvloop
+
+    uvloop.install()
+except ImportError:
+    pass
 
 # types
 FileContent = str

--- a/src/black_primer/cli.py
+++ b/src/black_primer/cli.py
@@ -13,6 +13,14 @@ import click
 
 from black_primer import lib
 
+# If our environment has uvloop installed lets use it
+try:
+    import uvloop
+
+    uvloop.install()
+except ImportError:
+    pass
+
 
 DEFAULT_CONFIG = Path(__file__).parent / "primer.json"
 _timestamp = datetime.now().strftime("%Y%m%d%H%M%S")

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -22,6 +22,14 @@ except ImportError as ie:
 import black
 import click
 
+# If our environment has uvloop installed lets use it
+try:
+    import uvloop
+
+    uvloop.install()
+except ImportError:
+    pass
+
 from _black_version import version as __version__
 
 # This is used internally by tests to shut down the server prematurely


### PR DESCRIPTION
- If we find `uvloop` in the env for black, blackd or black-primer lets try and use it
- Add a uvloop extra install

Fixes #2257

Test:
- Add ci job to install black[uvloop] and run a primer run with uvloop
  - Only with latest python (3.9)
  - Will be handy to compare runtimes as a very unoffical benchmark