### PR TITLE
Code Flag Options

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -68,6 +68,7 @@ Multiple contributions by:
 - Gustavo Camargo
 - hauntsaninja
 - [Hadi Alqattan](mailto:alqattanhadizaki@gmail.com)
+- [Hassan Abouelela](mailto:hassan@hassanamr.com)
 - [Heaford](mailto:dan@heaford.com)
 - [Hugo Barrera](mailto::hugo@barrera.io)
 - Hugo van Kemenade

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Fix typos discovered by codespell (#2228)
 - Fix Vim plugin installation instructions. (#2235)
 - Add new Frequently Asked Questions page (#2247)
+- Removed safety checks warning for the `--code` option (#2259)
 
 ## 21.5b1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Respect `.gitignore` files in all levels, not only `root/.gitignore` file (apply
   `.gitignore` rules like `git` does) (#2225)
 - Restored compatibility with Click 8.0 on Python 3.6 when LANG=C used (#2227)
+- Fixed option usage when using the `--code` flag (#2259)
 
 ### _Blackd_
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -68,13 +68,6 @@ $ black --code "print ( 'hello, world' )"
 print("hello, world")
 ```
 
-```{warning}
---check, --diff, and --safe / --fast have no effect when using -c / --code. Safety
-checks normally turned on by default that verify _Black_'s output are disabled as well.
-This is a bug which we intend to fix eventually. More details can be found in this [bug
-report](https://github.com/psf/black/issues/2104).
-```
-
 ### Writeback and reporting
 
 By default _Black_ reformats the files given and/or found in place. Sometimes you need

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -385,6 +385,11 @@ def main(
     if config and verbose:
         out(f"Using configuration from {config}.", bold=False, fg="blue")
 
+    if code is not None:
+        # Run in quiet mode by default with -c; the extra output isn't useful.
+        # You can still pass -v to get verbose output.
+        quiet = True
+
     report = Report(check=check, diff=diff, quiet=quiet, verbose=verbose)
 
     if code is not None:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -530,17 +530,18 @@ def reformat_code(
     `fast`, `write_back`, and `mode` options are passed to
     :func:`format_file_in_place` or :func:`format_stdin_to_stdout`.
     """
+    path = Path("<string>")
     try:
         changed = Changed.NO
         if format_stdin_to_stdout(
             content=content, fast=fast, write_back=write_back, mode=mode
         ):
             changed = Changed.YES
-        report.done(content, changed)
+        report.done(path, changed)
     except Exception as exc:
         if report.verbose:
             traceback.print_exc()
-        report.failed(content, str(exc))
+        report.failed(path, str(exc))
 
 
 def reformat_one(

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -38,7 +38,7 @@ def find_project_root(srcs: Sequence[str]) -> Path:
     project root, the root of the file system is returned.
     """
     if not srcs:
-        return Path(".").resolve()
+        srcs = [str(Path.cwd().resolve())]
 
     path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -38,7 +38,7 @@ def find_project_root(srcs: Sequence[str]) -> Path:
     project root, the root of the file system is returned.
     """
     if not srcs:
-        return Path("/").resolve()
+        return Path(".").resolve()
 
     path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
 

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -4,6 +4,7 @@ Summarize Black runs to users.
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+import typing
 
 from click import style
 
@@ -28,7 +29,7 @@ class Report:
     same_count: int = 0
     failure_count: int = 0
 
-    def done(self, src: Path, changed: Changed) -> None:
+    def done(self, src: typing.Union[Path, str], changed: Changed) -> None:
         """Increment the counter for successful reformatting. Write out a message."""
         if changed is Changed.YES:
             reformatted = "would reformat" if self.check or self.diff else "reformatted"
@@ -44,7 +45,7 @@ class Report:
                 out(msg, bold=False)
             self.same_count += 1
 
-    def failed(self, src: Path, message: str) -> None:
+    def failed(self, src: typing.Union[Path, str], message: str) -> None:
         """Increment the counter for failed reformatting. Write out a message."""
         err(f"error: cannot format {src}: {message}")
         self.failure_count += 1

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -4,7 +4,6 @@ Summarize Black runs to users.
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-import typing
 
 from click import style
 
@@ -29,7 +28,7 @@ class Report:
     same_count: int = 0
     failure_count: int = 0
 
-    def done(self, src: typing.Union[Path, str], changed: Changed) -> None:
+    def done(self, src: Path, changed: Changed) -> None:
         """Increment the counter for successful reformatting. Write out a message."""
         if changed is Changed.YES:
             reformatted = "would reformat" if self.check or self.diff else "reformatted"
@@ -45,7 +44,7 @@ class Report:
                 out(msg, bold=False)
             self.same_count += 1
 
-    def failed(self, src: typing.Union[Path, str], message: str) -> None:
+    def failed(self, src: Path, message: str) -> None:
         """Increment the counter for failed reformatting. Write out a message."""
         err(f"error: cannot format {src}: {message}")
         self.failure_count += 1

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2169,6 +2169,27 @@ class BlackTestCase(BlackBaseTestCase):
 
             self.compare_results(result, formatted, 0)
 
+    def test_code_option_config(self) -> None:
+        """
+        Test that the code option finds the pyproject.toml in the current directory.
+        """
+        with patch.object(black, "parse_pyproject_toml", return_value={}) as parse:
+            # Create a temporary pyproject in the current directory
+            config = Path("pyproject.toml")
+            assert (
+                not config.exists()
+            ), "Creating a temporary config would override an existing file."
+            config.write_text("")
+
+            try:
+                args = ["--code", "print"]
+                CliRunner().invoke(black.main, args)
+
+                parse.assert_called_once_with(str(config.absolute()))
+            finally:
+                # Delete the pyproject file
+                config.unlink()
+
 
 with open(black.__file__, "r", encoding="utf-8") as _bf:
     black_source_lines = _bf.readlines()

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2185,8 +2185,10 @@ class BlackTestCase(BlackBaseTestCase):
             assert (
                 len(parse.mock_calls) >= 1
             ), "Expected config parse to be called with the current directory."
+
+            _, call_args, _ = parse.mock_calls[0]
             assert (
-                parse.mock_calls[0].args[0].lower() == str(pyproject_path).lower()
+                call_args[0].lower() == str(pyproject_path).lower()
             ), "Incorrect config loaded."
 
     def test_code_option_parent_config(self) -> None:
@@ -2205,8 +2207,10 @@ class BlackTestCase(BlackBaseTestCase):
             assert (
                 len(parse.mock_calls) >= 1
             ), "Expected config parse to be called with the current directory."
+
+            _, call_args, _ = parse.mock_calls[0]
             assert (
-                parse.mock_calls[0].args[0].lower() == str(pyproject_path).lower()
+                call_args[0].lower() == str(pyproject_path).lower()
             ), "Incorrect config loaded."
 
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2073,51 +2073,51 @@ class BlackTestCase(BlackBaseTestCase):
         actual = result.output
         self.assertFormatEqual(actual, expected)
 
+    @staticmethod
+    def compare_results(
+        result: click.testing.Result, expected_value: str, expected_exit_code: int
+    ) -> None:
+        """Helper method to test the value and exit code of a click Result."""
+        assert (
+            result.output == expected_value
+        ), "The output did not match the expected value."
+        assert result.exit_code == expected_exit_code, "The exit code is incorrect."
+
     def test_code_option(self) -> None:
         """Test the code option with no changes."""
         code = 'print("Hello world")\n'
         args = ["--code", code]
         result = CliRunner().invoke(black.main, args)
 
-        # The CLI prints an extra linebreak when exiting.
-        self.assertEqual(result.output, code + "\n")
-        self.assertEqual(result.exit_code, 0)
+        self.compare_results(result, code, 0)
 
     def test_code_option_changed(self) -> None:
         """Test the code option when changes are required."""
         code = "print('hello world')"
-        # The CLI prints an extra linebreak when exiting.
-        formatted = black.format_str(code, mode=DEFAULT_MODE) + "\n"
+        formatted = black.format_str(code, mode=DEFAULT_MODE)
 
         args = ["--code", code]
         result = CliRunner().invoke(black.main, args)
 
-        self.assertEqual(result.output, formatted)
-        self.assertEqual(result.exit_code, 0)
+        self.compare_results(result, formatted, 0)
 
     def test_code_option_check(self) -> None:
         """Test the code option when check is passed."""
         args = ["--check", "--code", 'print("Hello world")\n']
         result = CliRunner().invoke(black.main, args)
-
-        self.assertEqual(result.output, "")
-        self.assertEqual(result.exit_code, 0)
+        self.compare_results(result, "", 0)
 
     def test_code_option_check_changed(self) -> None:
         """Test the code option when changes are required, and check is passed."""
         args = ["--check", "--code", "print('hello world')"]
         result = CliRunner().invoke(black.main, args)
-
-        self.assertEqual(result.output, "")
-        self.assertEqual(result.exit_code, 1)
+        self.compare_results(result, "", 1)
 
     def test_code_option_diff(self) -> None:
         """Test the code option when diff is passed."""
         code = "print('hello world')"
         formatted = black.format_str(code, mode=DEFAULT_MODE)
-
-        # The CLI prints an extraline break when exiting.
-        result_diff = diff(code, formatted, "STDIN", "STDOUT") + "\n"
+        result_diff = diff(code, formatted, "STDIN", "STDOUT")
 
         args = ["--diff", "--code", code]
         result = CliRunner().invoke(black.main, args)
@@ -2125,8 +2125,8 @@ class BlackTestCase(BlackBaseTestCase):
         # Remove time from diff
         output = DIFF_TIME.sub("", result.output)
 
-        self.assertEqual(output, result_diff)
-        self.assertEqual(result.exit_code, 0)
+        assert output == result_diff, "The output did not match the expected value."
+        assert result.exit_code == 0, "The exit code is incorrect."
 
     def test_code_option_color_diff(self) -> None:
         """Test the code option when color and diff are passed."""
@@ -2134,8 +2134,7 @@ class BlackTestCase(BlackBaseTestCase):
         formatted = black.format_str(code, mode=DEFAULT_MODE)
 
         result_diff = diff(code, formatted, "STDIN", "STDOUT")
-        # The CLI prints an extraline break when exiting.
-        result_diff = color_diff(result_diff) + "\n"
+        result_diff = color_diff(result_diff)
 
         args = ["--diff", "--color", "--code", code]
         result = CliRunner().invoke(black.main, args)
@@ -2143,8 +2142,8 @@ class BlackTestCase(BlackBaseTestCase):
         # Remove time from diff
         output = DIFF_TIME.sub("", result.output)
 
-        self.assertEqual(output, result_diff)
-        self.assertEqual(result.exit_code, 0)
+        assert output == result_diff, "The output did not match the expected value."
+        assert result.exit_code == 0, "The exit code is incorrect."
 
     def test_code_option_safe(self) -> None:
         """Test that the code option throws an error when the sanity checks fail."""
@@ -2153,21 +2152,19 @@ class BlackTestCase(BlackBaseTestCase):
             args = ["--safe", "--code", 'print("Hello world")']
             result = CliRunner().invoke(black.main, args)
 
-            self.assertEqual(result.output, "")
-            self.assertEqual(result.exit_code, 1)
+            self.compare_results(result, "", 1)
 
     def test_code_option_fast(self) -> None:
         """Test that the code option ignores errors when the sanity checks fail."""
         # Patch black.assert_equivalent to ensure the sanity checks fail
         with patch.object(black, "assert_equivalent", side_effect=AssertionError):
             code = 'print("Hello world")'
-            formatted = black.format_str(code, mode=DEFAULT_MODE) + "\n"
+            formatted = black.format_str(code, mode=DEFAULT_MODE)
 
             args = ["--fast", "--code", code]
             result = CliRunner().invoke(black.main, args)
 
-            self.assertEqual(result.output, formatted)
-            self.assertEqual(result.exit_code, 0)
+            self.compare_results(result, formatted, 0)
 
 
 with open(black.__file__, "r", encoding="utf-8") as _bf:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2150,7 +2150,7 @@ class BlackTestCase(BlackBaseTestCase):
         # Patch black.assert_equivalent to ensure the sanity checks fail
         with patch.object(black, "assert_equivalent", side_effect=AssertionError):
             code = 'print("Hello world")'
-            error_msg = f"{code}\nerror: cannot format {code}: \n"
+            error_msg = f"{code}\nerror: cannot format <string>: \n"
 
             args = ["--safe", "--quiet", "--code", code]
             result = CliRunner().invoke(black.main, args)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2086,7 +2086,7 @@ class BlackTestCase(BlackBaseTestCase):
     def test_code_option(self) -> None:
         """Test the code option with no changes."""
         code = 'print("Hello world")\n'
-        args = ["--quiet", "--code", code]
+        args = ["--code", code]
         result = CliRunner().invoke(black.main, args)
 
         self.compare_results(result, code, 0)
@@ -2096,20 +2096,20 @@ class BlackTestCase(BlackBaseTestCase):
         code = "print('hello world')"
         formatted = black.format_str(code, mode=DEFAULT_MODE)
 
-        args = ["--quiet", "--code", code]
+        args = ["--code", code]
         result = CliRunner().invoke(black.main, args)
 
         self.compare_results(result, formatted, 0)
 
     def test_code_option_check(self) -> None:
         """Test the code option when check is passed."""
-        args = ["--check", "--quiet", "--code", 'print("Hello world")\n']
+        args = ["--check", "--code", 'print("Hello world")\n']
         result = CliRunner().invoke(black.main, args)
         self.compare_results(result, "", 0)
 
     def test_code_option_check_changed(self) -> None:
         """Test the code option when changes are required, and check is passed."""
-        args = ["--check", "--quiet", "--code", "print('hello world')"]
+        args = ["--check", "--code", "print('hello world')"]
         result = CliRunner().invoke(black.main, args)
         self.compare_results(result, "", 1)
 
@@ -2119,7 +2119,7 @@ class BlackTestCase(BlackBaseTestCase):
         formatted = black.format_str(code, mode=DEFAULT_MODE)
         result_diff = diff(code, formatted, "STDIN", "STDOUT")
 
-        args = ["--diff", "--quiet", "--code", code]
+        args = ["--diff", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         # Remove time from diff
@@ -2136,7 +2136,7 @@ class BlackTestCase(BlackBaseTestCase):
         result_diff = diff(code, formatted, "STDIN", "STDOUT")
         result_diff = color_diff(result_diff)
 
-        args = ["--diff", "--quiet", "--color", "--code", code]
+        args = ["--diff", "--color", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         # Remove time from diff
@@ -2152,7 +2152,7 @@ class BlackTestCase(BlackBaseTestCase):
             code = 'print("Hello world")'
             error_msg = f"{code}\nerror: cannot format <string>: \n"
 
-            args = ["--safe", "--quiet", "--code", code]
+            args = ["--safe", "--code", code]
             result = CliRunner().invoke(black.main, args)
 
             self.compare_results(result, error_msg, 123)
@@ -2164,7 +2164,7 @@ class BlackTestCase(BlackBaseTestCase):
             code = 'print("Hello world")'
             formatted = black.format_str(code, mode=DEFAULT_MODE)
 
-            args = ["--fast", "--quiet", "--code", code]
+            args = ["--fast", "--code", code]
             result = CliRunner().invoke(black.main, args)
 
             self.compare_results(result, formatted, 0)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2086,7 +2086,7 @@ class BlackTestCase(BlackBaseTestCase):
     def test_code_option(self) -> None:
         """Test the code option with no changes."""
         code = 'print("Hello world")\n'
-        args = ["--code", code]
+        args = ["--quiet", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         self.compare_results(result, code, 0)
@@ -2096,20 +2096,20 @@ class BlackTestCase(BlackBaseTestCase):
         code = "print('hello world')"
         formatted = black.format_str(code, mode=DEFAULT_MODE)
 
-        args = ["--code", code]
+        args = ["--quiet", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         self.compare_results(result, formatted, 0)
 
     def test_code_option_check(self) -> None:
         """Test the code option when check is passed."""
-        args = ["--check", "--code", 'print("Hello world")\n']
+        args = ["--check", "--quiet", "--code", 'print("Hello world")\n']
         result = CliRunner().invoke(black.main, args)
         self.compare_results(result, "", 0)
 
     def test_code_option_check_changed(self) -> None:
         """Test the code option when changes are required, and check is passed."""
-        args = ["--check", "--code", "print('hello world')"]
+        args = ["--check", "--quiet", "--code", "print('hello world')"]
         result = CliRunner().invoke(black.main, args)
         self.compare_results(result, "", 1)
 
@@ -2119,7 +2119,7 @@ class BlackTestCase(BlackBaseTestCase):
         formatted = black.format_str(code, mode=DEFAULT_MODE)
         result_diff = diff(code, formatted, "STDIN", "STDOUT")
 
-        args = ["--diff", "--code", code]
+        args = ["--diff", "--quiet", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         # Remove time from diff
@@ -2136,7 +2136,7 @@ class BlackTestCase(BlackBaseTestCase):
         result_diff = diff(code, formatted, "STDIN", "STDOUT")
         result_diff = color_diff(result_diff)
 
-        args = ["--diff", "--color", "--code", code]
+        args = ["--diff", "--quiet", "--color", "--code", code]
         result = CliRunner().invoke(black.main, args)
 
         # Remove time from diff
@@ -2149,10 +2149,13 @@ class BlackTestCase(BlackBaseTestCase):
         """Test that the code option throws an error when the sanity checks fail."""
         # Patch black.assert_equivalent to ensure the sanity checks fail
         with patch.object(black, "assert_equivalent", side_effect=AssertionError):
-            args = ["--safe", "--code", 'print("Hello world")']
+            code = 'print("Hello world")'
+            error_msg = f"{code}\nerror: cannot format {code}: \n"
+
+            args = ["--safe", "--quiet", "--code", code]
             result = CliRunner().invoke(black.main, args)
 
-            self.compare_results(result, "", 1)
+            self.compare_results(result, error_msg, 123)
 
     def test_code_option_fast(self) -> None:
         """Test that the code option ignores errors when the sanity checks fail."""
@@ -2161,7 +2164,7 @@ class BlackTestCase(BlackBaseTestCase):
             code = 'print("Hello world")'
             formatted = black.format_str(code, mode=DEFAULT_MODE)
 
-            args = ["--fast", "--code", code]
+            args = ["--fast", "--quiet", "--code", code]
             result = CliRunner().invoke(black.main, args)
 
             self.compare_results(result, formatted, 0)


### PR DESCRIPTION
Closes #2104, closes #1801.

Fixes a bug in the `--code` flag which would ignore options such as `--diff`, `--check`, and `--fast`.

This PR implements the fix described in the issue. It also adds tests for this fix.