### PR TITLE
Use latest Python in uploading binaries

### DIFF
--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
         os: [windows-2019, ubuntu-20.04, macos-latest]
         include:
           - os: windows-2019
@@ -29,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up latest Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.x"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up latest Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "*"
 
       - name: Install dependencies
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 ### _Packaging_
 
 - Release self-contained macOS binaries as part of the GitHub release pipeline (#2198)
+- Always build binaries with the latest available Python (#2260)
 
 ### Documentation
 


### PR DESCRIPTION
From #2252, here to claim my bonus points: I found [a way](https://docs.github.com/en/actions/guides/building-and-testing-python#using-a-specific-python-version) to always use the latest Python minor in GitHub Actions. It seemed easy enough to just drop in, although I'm not really sure how it could be verified without actually uploading.

I do trust the documentation, but if you're a bit scared (like I am too), we could just have the version be set to 3.9 for a guaranteed success. What do ya reckon?

---

`skip news`? I'm still not really sure what changes should end up in the changelog but I'm slowly getting there 😅