### PR TITLE
Issue templates: use HTML comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,22 +6,31 @@ labels: bug
 assignees: ""
 ---
 
-**Describe the bug** A clear and concise description of what the bug is.
+**Describe the bug**
 
-**To Reproduce** Steps to reproduce the behavior:
+<!-- A clear and concise description of what the bug is. -->
 
+**To Reproduce**
+
+<!-- Steps to reproduce the behavior:
+
+For example:
 1. Take this file '...'
-1. Run _Black_ on it with these arguments '....'
-1. See error
+1. Run _Black_ on it with these arguments '...'
+1. See error -->
 
-**Expected behavior** A clear and concise description of what you expected to happen.
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Environment (please complete the following information):**
 
-- Version: \[e.g. main\]
-- OS and Python version: \[e.g. Linux/Python 3.7.4rc1\]
+- Version: <!-- e.g. [main] -->
+- OS and Python version: <!-- e.g. [Linux/Python 3.7.4rc1] -->
 
-**Does this bug also happen on main?** To answer this, you have two options:
+**Does this bug also happen on main?**
+
+<!-- To answer this, you have two options:
 
 1. Use the online formatter at <https://black.vercel.app/?version=main>, which will use
    the latest main branch.
@@ -31,6 +40,8 @@ assignees: ""
    - run `pip install -e .[d,python2]`;
    - run `pip install -r test_requirements.txt`
    - make sure it's sane by running `python -m pytest`; and
-   - run `black` like you did last time.
+   - run `black` like you did last time. -->
 
-**Additional context** Add any other context about the problem here.
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,14 +6,22 @@ labels: enhancement
 assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.** A clear and concise
-description of what the problem is. Ex. I'm always frustrated when \[...\]
+**Is your feature request related to a problem? Please describe.**
 
-**Describe the solution you'd like** A clear and concise description of what you want to
-happen.
+<!-- A clear and concise description of what the problem is.
+e.g. I'm always frustrated when [...] -->
 
-**Describe alternatives you've considered** A clear and concise description of any
-alternative solutions or features you've considered.
+**Describe the solution you'd like**
 
-**Additional context** Add any other context or screenshots about the feature request
-here.
+<!-- A clear and concise description of what you want to
+happen. -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any
+alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request
+here. -->

--- a/.github/ISSUE_TEMPLATE/style_issue.md
+++ b/.github/ISSUE_TEMPLATE/style_issue.md
@@ -6,11 +6,15 @@ labels: design
 assignees: ""
 ---
 
-**Describe the style change** A clear and concise description of how the style can be
-improved.
+**Describe the style change**
 
-**Examples in the current _Black_ style** Think of some short code snippets that show
-how the current _Black_ style is not great:
+<!-- A clear and concise description of how the style can be
+improved. -->
+
+**Examples in the current _Black_ style**
+
+<!-- Think of some short code snippets that show
+how the current _Black_ style is not great: -->
 
 ```python
 def f():
@@ -18,7 +22,9 @@ def f():
     pass
 ```
 
-**Desired style** How do you think _Black_ should format the above snippets:
+**Desired style**
+
+<!-- How do you think _Black_ should format the above snippets: -->
 
 ```python
 def f(
@@ -26,4 +32,6 @@ def f(
     pass
 ```
 
-**Additional context** Add any other context about the problem here.
+**Additional context**
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
This commit makes use of HTML comments inside GitHub issue templates
to make sure that even if they aren't removed by the issue author they won't be shown
in the rendered output.

The goal is to simply make the issues less noisy by removing template messages.

You can try them out [on my fork](https://github.com/Akarys42/black/issues). I haven’t added a news entry as this doesn’t seem to fit, let me know if it needs one! 😁 