### PR TITLE
Fix path_empty()

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -506,8 +506,9 @@ def path_empty(
     """
     Exit if there is no `src` provided for formatting
     """
-    if not src and (verbose or not quiet):
-        out(msg)
+    if not src:
+        if verbose or not quiet:
+            out(msg)
         ctx.exit(0)
 
 


### PR DESCRIPTION
Behavior other than output shouldn't depend on the verbose/quiet option. As far as I can tell this currently has no visible effect, since code after this function is called handles an empty list gracefully.