### PR TITLE
Possible fix for issue with indentation and fmt: skip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### _Black_
 
+- Fix failure caused by `fmt: skip` and indentation (#2281)
 - Correct max string length calculation when there are string operators (#2292)
 
 ## 21.5b2

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -159,7 +159,10 @@ def convert_one_fmt_off_pair(node: Node) -> bool:
             first = ignored_nodes[0]  # Can be a container node with the `leaf`.
             parent = first.parent
             prefix = first.prefix
-            first.prefix = prefix[comment.consumed :]
+            if comment.value in FMT_OFF:
+                first.prefix = prefix[comment.consumed :]
+            if comment.value in FMT_SKIP:
+                first.prefix = ""
             hidden_value = "".join(str(n) for n in ignored_nodes)
             if comment.value in FMT_OFF:
                 hidden_value = comment.value + "\n" + hidden_value

--- a/tests/data/fmtskip6.py
+++ b/tests/data/fmtskip6.py
@@ -1,0 +1,5 @@
+class A:
+    def f(self):
+        for line in range(10):
+            if True:
+                pass  # fmt: skip

--- a/tests/data/fmtskip6.py
+++ b/tests/data/fmtskip6.py
@@ -3,3 +3,11 @@ class A:
         for line in range(10):
             if True:
                 pass  # fmt: skip
+
+# output
+
+class A:
+    def f(self):
+        for line in range(10):
+            if True:
+                pass  # fmt: skip

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -41,6 +41,7 @@ SIMPLE_CASES = [
     "fmtskip3",
     "fmtskip4",
     "fmtskip5",
+    "fmtskip6",
     "fstring",
     "function",
     "function2",


### PR DESCRIPTION
Possible fix for #2254 

Not sure the fix is right.  Here is what I found: the issue is connected with the line

```python    
first.prefix = prefix[comment.consumed :]
```
    
in `comments.py`.  `first.prefix` is a prefix of the line, that ends with `# fmt: skip`, but `comment.consumed` is the length of the `"  # fmt: skip"` string.  If prefix length is greater than 14, `first.prefix` will grow every time we apply formatting.