### PR TITLE
[primer] Enable everything

### DIFF
--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -39,7 +39,7 @@ class Results(NamedTuple):
 
 async def _gen_check_output(
     cmd: Sequence[str],
-    timeout: float = 300,
+    timeout: float = 600,
     env: Optional[Dict[str, str]] = None,
     cwd: Optional[Path] = None,
 ) -> Tuple[bytes, bytes]:

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -30,8 +30,6 @@
       "py_versions": ["all"]
     },
     "django": {
-      "disabled_reason": "black --check --diff returned 123 on tests_syntax_error.py",
-      "disabled": true,
       "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/django/django.git",
@@ -53,8 +51,6 @@
       "py_versions": ["all"]
     },
     "pandas": {
-      "disabled_reason": "black-primer runs failing on Pandas - #2193",
-      "disabled": true,
       "cli_arguments": ["--experimental-string-processing"],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/pandas-dev/pandas.git",

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -32,6 +32,7 @@
     "django": {
       "cli_arguments": [
         "--experimental-string-processing",
+        "--skip-string-normalization",
         "--extend-exclude",
         "/((docs|scripts)/|django/forms/models.py|tests/gis_tests/test_spatialrefsys.py|tests/test_runner_apps/tagged/tests_syntax_error.py)"
       ],

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -39,7 +39,7 @@
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/django/django.git",
       "long_checkout": false,
-      "py_versions": ["all"]
+      "py_versions": ["3.8", "3.9"]
     },
     "flake8-bugbear": {
       "cli_arguments": ["--experimental-string-processing"],

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -30,7 +30,11 @@
       "py_versions": ["all"]
     },
     "django": {
-      "cli_arguments": ["--experimental-string-processing"],
+      "cli_arguments": [
+        "--experimental-string-processing",
+        "--extend-exclude",
+        "/((docs|scripts)/|django/forms/models.py|tests/gis_tests/test_spatialrefsys.py|tests/test_runner_apps/tagged/tests_syntax_error.py)"
+      ],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/django/django.git",
       "long_checkout": false,


### PR DESCRIPTION
- See if we pass all our repos with experimental string processing enabled.

Django probably needed:
- Ignores
- >= 3.8 only
  - We could support PEP440 version specifiers, but that would introduce the `packaging` module as a dependency that I'd like to avoid ... Or I could implement a poor persons version or vendor