### PR TITLE
Correct max string length calculation when there are string operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### _Black_
+
+- Correct max string length calculation when there are string operators (#2292)
+
 ## 21.5b2
 
 ### _Black_

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -739,14 +739,15 @@ class BaseStringSplitter(StringTransformer):
     """
 
     STRING_OPERATORS = [
-        token.PLUS,
-        token.STAR,
         token.EQEQUAL,
-        token.NOTEQUAL,
-        token.LESS,
-        token.LESSEQUAL,
         token.GREATER,
         token.GREATEREQUAL,
+        token.LESS,
+        token.LESSEQUAL,
+        token.NOTEQUAL,
+        token.PERCENT,
+        token.PLUS,
+        token.STAR,
     ]
 
     @abstractmethod

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -738,6 +738,17 @@ class BaseStringSplitter(StringTransformer):
         * The target string is not a multiline (i.e. triple-quote) string.
     """
 
+    STRING_OPERATORS = [
+        token.PLUS,
+        token.STAR,
+        token.EQEQUAL,
+        token.NOTEQUAL,
+        token.LESS,
+        token.LESSEQUAL,
+        token.GREATER,
+        token.GREATEREQUAL,
+    ]
+
     @abstractmethod
     def do_splitter_match(self, line: Line) -> TMatchResult:
         """
@@ -847,9 +858,9 @@ class BaseStringSplitter(StringTransformer):
                 p_idx -= 1
 
             P = LL[p_idx]
-            if P.type == token.PLUS:
-                # WMA4 a space and a '+' character (e.g. `+ STRING`).
-                offset += 2
+            if P.type in self.STRING_OPERATORS:
+                # WMA4 a space and a string operator (e.g. `+ STRING` or `== STRING`).
+                offset += len(str(P)) + 1
 
             if P.type == token.COMMA:
                 # WMA4 a space, a comma, and a closing bracket [e.g. `), STRING`].
@@ -952,16 +963,6 @@ class StringSplitter(CustomSplitMapMixin, BaseStringSplitter):
         CustomSplit objects and add them to the custom split map.
     """
 
-    STRING_OPERATORS = [
-        token.PLUS,
-        token.STAR,
-        token.EQEQUAL,
-        token.NOTEQUAL,
-        token.LESS,
-        token.LESSEQUAL,
-        token.GREATER,
-        token.GREATEREQUAL,
-    ]
     MIN_SUBSTR_SIZE = 6
     # Matches an "f-expression" (e.g. {var}) that might be found in an f-string.
     RE_FEXPR = r"""

--- a/tests/data/long_strings__edge_case.py
+++ b/tests/data/long_strings__edge_case.py
@@ -29,6 +29,8 @@ ternary_expression = (
 )
 return f'{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoajaaaaaaaaaaa'
 return f'{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoajaaaaaaaaaaaa'
+assert str(result) == "This long string should be split at some point right close to or around hereeeeeee"
+assert str(result) < "This long string should be split at some point right close to or around hereeeeee"
 
 
 # output
@@ -108,3 +110,13 @@ return (
     f"{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoajaaaaaaaaaaa"
 )
 return f"{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoajaaaaaaaaaaaa"
+assert (
+    str(result)
+    == "This long string should be split at some point right close to or around"
+    " hereeeeeee"
+)
+assert (
+    str(result)
+    < "This long string should be split at some point right close to or around"
+    " hereeeeee"
+)

--- a/tests/data/long_strings__edge_case.py
+++ b/tests/data/long_strings__edge_case.py
@@ -31,6 +31,7 @@ return f'{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoaja
 return f'{x}/b/c/d/d/d/dadfjsadjsaidoaisjdsfjaofjdfijaidfjaodfjaoifjodjafojdoajaaaaaaaaaaaa'
 assert str(result) == "This long string should be split at some point right close to or around hereeeeeee"
 assert str(result) < "This long string should be split at some point right close to or around hereeeeee"
+assert "A format string: %s" % "This long string should be split at some point right close to or around hereeeeeee" != result
 
 
 # output
@@ -119,4 +120,10 @@ assert (
     str(result)
     < "This long string should be split at some point right close to or around"
     " hereeeeee"
+)
+assert (
+    "A format string: %s"
+    % "This long string should be split at some point right close to or around"
+    " hereeeeeee"
+    != result
 )


### PR DESCRIPTION
PR #2286 did not fix the edge-cases (e.g. when the string is just long
enough to cause a line to be 89 characters long). This PR corrects that
mistake.

I also forgot to list the percent symbol as a "string operator".