### PR TITLE
Add option to require a specific version to be running

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Correct max string length calculation when there are string operators (#2292)
 - Fixed option usage when using the `--code` flag (#2259)
-- Add `--revision` option to require a specific version to be running (#2300)
+- Added `--required-version` option to require a specific version to be running (#2300)
 
 ## 21.5b2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Correct max string length calculation when there are string operators (#2292)
 - Fixed option usage when using the `--code` flag (#2259)
+- Add `--revision` option to require a specific version to be running (#2300)
 
 ## 21.5b2
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -176,18 +176,18 @@ $ black --version
 black, version 21.5b0
 ```
 
-An option to requiring a specific version to be running is also provided.
+An option to require a specific version to be running is also provided.
 
 ```console
-$ black --revision 21.5b2 -c "format = 'this'"
+$ black --required-version 21.5b2 -c "format = 'this'"
 format = "this"
-$ black --revision 31.5b2 -c "still = 'beta?!'"
-Oh no! 💥 💔 💥 The required revision does not match the running version!
+$ black --required-version 31.5b2 -c "still = 'beta?!'"
+Oh no! 💥 💔 💥 The required version does not match the running version!
 ```
 
 This is useful for example when running _Black_ in multiple environments that haven't
-necessarily installed the correct version. Setting this option can be done in a
-configuration file for consistent results across environments.
+necessarily installed the correct version. This option can be set in a configuration
+file for consistent results across environments.
 
 ## Configuration via a file
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -167,7 +167,7 @@ $ black src/ -q
 error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
 ```
 
-### Getting the version
+### Versions
 
 You can check the version of _Black_ you have installed using the `--version` flag.
 
@@ -175,6 +175,19 @@ You can check the version of _Black_ you have installed using the `--version` fl
 $ black --version
 black, version 21.5b0
 ```
+
+An option to requiring a specific version to be running is also provided.
+
+```console
+$ black --revision 21.5b2 -c "format = 'this'"
+format = "this"
+$ black --revision 31.5b2 -c "still = 'beta?!'"
+Oh no! 💥 💔 💥 The required revision does not match the running version!
+```
+
+This is useful for example when running _Black_ in multiple environments that haven't
+necessarily installed the correct version. Setting this option can be done in a
+configuration file for consistent results across environments.
 
 ## Configuration via a file
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -250,6 +250,14 @@ def validate_regex(
     help="If --fast given, skip temporary sanity checks. [default: --safe]",
 )
 @click.option(
+    "--revision",
+    type=str,
+    help=(
+        "Require a specific version of Black to be running (useful for unifying results"
+        " across many environments e.g. with a pyproject.toml file)."
+    ),
+)
+@click.option(
     "--include",
     type=str,
     default=DEFAULT_INCLUDES,
@@ -359,6 +367,7 @@ def main(
     experimental_string_processing: bool,
     quiet: bool,
     verbose: bool,
+    revision: str,
     include: Pattern,
     exclude: Optional[Pattern],
     extend_exclude: Optional[Pattern],
@@ -368,6 +377,17 @@ def main(
     config: Optional[str],
 ) -> None:
     """The uncompromising code formatter."""
+    error_msg = "Oh no! 💥 💔 💥"
+    if revision and revision != __version__:
+        msg = (
+            f"{error_msg} The required revision `{revision}` does not match"
+            f" the running version `{__version__}`!"
+        )
+        if ctx.default_map and revision == ctx.default_map.get("revision", None):
+            msg += f"\n(configuration read from `{config}`)"
+        err(msg)
+        ctx.exit(1)
+
     write_back = WriteBack.from_configuration(check=check, diff=diff, color=color)
     if target_version:
         versions = set(target_version)
@@ -436,9 +456,9 @@ def main(
             )
 
     if verbose or not quiet:
-        out("Oh no! 💥 💔 💥" if report.return_code else "All done! ✨ 🍰 ✨")
+        out(error_msg if report.return_code else "All done! ✨ 🍰 ✨")
         if code is None:
-            click.secho(str(report), err=True)
+            click.echo(str(report), err=True)
     ctx.exit(report.return_code)
 
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -250,7 +250,7 @@ def validate_regex(
     help="If --fast given, skip temporary sanity checks. [default: --safe]",
 )
 @click.option(
-    "--revision",
+    "--required-version",
     type=str,
     help=(
         "Require a specific version of Black to be running (useful for unifying results"
@@ -367,7 +367,7 @@ def main(
     experimental_string_processing: bool,
     quiet: bool,
     verbose: bool,
-    revision: str,
+    required_version: str,
     include: Pattern,
     exclude: Optional[Pattern],
     extend_exclude: Optional[Pattern],
@@ -377,15 +377,15 @@ def main(
     config: Optional[str],
 ) -> None:
     """The uncompromising code formatter."""
+    if config and verbose:
+        out(f"Using configuration from {config}.", bold=False, fg="blue")
+
     error_msg = "Oh no! 💥 💔 💥"
-    if revision and revision != __version__:
-        msg = (
-            f"{error_msg} The required revision `{revision}` does not match"
+    if required_version and required_version != __version__:
+        err(
+            f"{error_msg} The required version `{required_version}` does not match"
             f" the running version `{__version__}`!"
         )
-        if ctx.default_map and revision == ctx.default_map.get("revision", None):
-            msg += f"\n(configuration read from `{config}`)"
-        err(msg)
         ctx.exit(1)
 
     write_back = WriteBack.from_configuration(check=check, diff=diff, color=color)
@@ -402,8 +402,6 @@ def main(
         magic_trailing_comma=not skip_magic_trailing_comma,
         experimental_string_processing=experimental_string_processing,
     )
-    if config and verbose:
-        out(f"Using configuration from {config}.", bold=False, fg="blue")
 
     if code is not None:
         # Run in quiet mode by default with -c; the extra output isn't useful.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1796,6 +1796,14 @@ class BlackTestCase(BlackBaseTestCase):
         for option in ["--include", "--exclude", "--extend-exclude", "--force-exclude"]:
             self.invokeBlack(["-", option, "**()(!!*)"], exit_code=2)
 
+    def test_revision_matches_version(self) -> None:
+        self.invokeBlack(
+            ["--revision", black.__version__], exit_code=0, ignore_config=True
+        )
+
+    def test_revision_does_not_match_version(self) -> None:
+        self.invokeBlack(["--revision", "20.99b"], exit_code=1, ignore_config=True)
+
     def test_preserves_line_endings(self) -> None:
         with TemporaryDirectory() as workspace:
             test_file = Path(workspace) / "test.py"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1796,13 +1796,15 @@ class BlackTestCase(BlackBaseTestCase):
         for option in ["--include", "--exclude", "--extend-exclude", "--force-exclude"]:
             self.invokeBlack(["-", option, "**()(!!*)"], exit_code=2)
 
-    def test_revision_matches_version(self) -> None:
+    def test_required_version_matches_version(self) -> None:
         self.invokeBlack(
-            ["--revision", black.__version__], exit_code=0, ignore_config=True
+            ["--required-version", black.__version__], exit_code=0, ignore_config=True
         )
 
-    def test_revision_does_not_match_version(self) -> None:
-        self.invokeBlack(["--revision", "20.99b"], exit_code=1, ignore_config=True)
+    def test_required_version_does_not_match_version(self) -> None:
+        self.invokeBlack(
+            ["--required-version", "20.99b"], exit_code=1, ignore_config=True
+        )
 
     def test_preserves_line_endings(self) -> None:
         with TemporaryDirectory() as workspace:


### PR DESCRIPTION
Closes #1246: This PR adds a new option (and automatically a toml entry, hooray for existing configuration management 🎉) to require a specific version of Black to be running.

For example: `black --required-version 20.8b -c "format = 'this'"`

Execution fails straight away if it doesn't match `__version__`. Some points of contention:
- Option placement: higher or lower on the CLI and help
- Option name: <strike>revision was suggested in the issue, I agree that it's the most appropriate, but it isn't perfect. Other possibilities: `runtime-version`, `black-version`..?</strike> `required-version` was chosen
- Option shorthand: I don't think it's needed
- Error message: <strike>particularly printing the configuration location</strike>
- Documentation: new section name, placement, anything else