### PR TITLE
Go back to single core for test suite on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Unit tests
         run: |
-          tox -e py -- -v --color=yes
+          tox -e ci-py -- -v --color=yes
 
       - name: Publish coverage to Coveralls
         # If pushed / is a pull request against main repo AND

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,23 @@
 [tox]
-envlist = py{36,37,38,39},fuzz
+envlist = {,ci-}py{36,37,38,39},fuzz
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
 skip_install = True
 deps =
     -r{toxinidir}/test_requirements.txt
+; parallelization is disabled on CI because pytest-dev/pytest-xdist#620 occurs too frequently
+; local runs can stay parallelized since they aren't rolling the dice so many times as like on CI
 commands =
     pip install -e .[d]
     coverage erase
-    pytest tests --run-optional no_python2 --numprocesses auto --cov {posargs}
+    pytest tests --run-optional no_python2 \
+        !ci: --numprocesses auto \
+        --cov {posargs}
     pip install -e .[d,python2]
-    pytest tests --run-optional python2 --numprocesses auto --cov --cov-append {posargs}
+    pytest tests --run-optional python2 \
+        !ci: --numprocesses auto \
+        --cov --cov-append {posargs}
     coverage report
 
 [testenv:fuzz]


### PR DESCRIPTION
The random asyncio bug is just too frequent and annoying to be
worth the speed improvements. Our test suite is already quite fast.
Random test failures hurt for 3 reasons, 1) they are discouraging for
new contributors who won't understand it's out of their control, 2)
it's annoying and time consuming to rerun the workflow, and 3) it
makes single job failures feel less important.