### PR TITLE
Mention comment non-processing in documentation

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -203,10 +203,11 @@ required due to an inner function starting immediately after.
 ### Comments
 
 _Black_ does not format comment contents, but it enforces two spaces between code and a
-comment on the same line, and a space after the comment text begins. Some comments that
-are known to require contradictory spacing rules, like doc comments, are respected.
-Comments may sometimes be moved because of formatting changes though, which can break
-tools that assign special meaning to them. See
+comment on the same line, and a space before the comment text begins. Some types of
+comments that require specific spacing rules are respected: doc comments (`#: comment`),
+section comments with long runs of hashes, and Spyder cells. Non-breaking spaces after
+hashes are also preserved. Comments may sometimes be moved because of formatting
+changes, which can break tools that assign special meaning to them. See
 [AST before and after formatting](#ast-before-and-after-formatting) for more discussion.
 
 ### Trailing commas

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -200,6 +200,14 @@ following field or method. This conforms to
 _Black_ won't insert empty lines after function docstrings unless that empty line is
 required due to an inner function starting immediately after.
 
+### Comments
+
+_Black_ does not format comment contents, but two spaces between code and a comment on
+the same line, and a space after the comment text begins is enforced. Comments may
+sometimes be moved because of formatting changes though, which can break tools that
+assign special meaning to comments. See
+[AST before and after formatting](#ast-before-and-after-formatting) for more discussion.
+
 ### Trailing commas
 
 _Black_ will add trailing commas to expressions that are split by comma where each

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -202,10 +202,11 @@ required due to an inner function starting immediately after.
 
 ### Comments
 
-_Black_ does not format comment contents, but two spaces between code and a comment on
-the same line, and a space after the comment text begins is enforced. Comments may
-sometimes be moved because of formatting changes though, which can break tools that
-assign special meaning to comments. See
+_Black_ does not format comment contents, but it enforces two spaces between code and a
+comment on the same line, and a space after the comment text begins. Some comments that
+are known to require contradictory spacing rules, like doc comments, are respected.
+Comments may sometimes be moved because of formatting changes though, which can break
+tools that assign special meaning to them. See
 [AST before and after formatting](#ast-before-and-after-formatting) for more discussion.
 
 ### Trailing commas

--- a/tests/data/comments2.py
+++ b/tests/data/comments2.py
@@ -159,7 +159,7 @@ class Test:
 #######################
 
 
-instruction()
+instruction()#comment with bad spacing
 
 # END COMMENTS
 # MORE END COMMENTS
@@ -336,7 +336,7 @@ class Test:
 #######################
 
 
-instruction()
+instruction()  # comment with bad spacing
 
 # END COMMENTS
 # MORE END COMMENTS


### PR DESCRIPTION
Closes #1017: This PR adds a short section discussing the non-processing of docstrings besides spacing improvements, mentions comment moving and links to the AST equivalence discussion. I also added a simple spacing test for good measure.

`skip news`? Anything to add or improve?