### PR TITLE
Fix flake8 configuration by switching from extend-ignore to ignore

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501
+ignore = E203, E266, E501, W503
 # line length is intentionally set to 80 here because black uses Bugbear
 # See https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length for more details
 max-line-length = 80

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E203, E266, E501
+ignore = E203, E266, E501
 # line length is intentionally set to 80 here because black uses Bugbear
 # See https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length for more details
 max-line-length = 80

--- a/src/black/output.py
+++ b/src/black/output.py
@@ -45,7 +45,8 @@ def diff(a: str, b: str, a_name: str, b_name: str) -> str:
         a_lines, b_lines, fromfile=a_name, tofile=b_name, n=5
     ):
         # Work around https://bugs.python.org/issue2142
-        # See https://www.gnu.org/software/diffutils/manual/html_node/Incomplete-Lines.html
+        # See:
+        # https://www.gnu.org/software/diffutils/manual/html_node/Incomplete-Lines.html
         if line[-1] == "\n":
             diff_lines.append(line)
         else:


### PR DESCRIPTION
Basically, bugbear's B9 checks (and possibly other checks that you possibly want to run) weren't actually running due to the use of `extend-ignore` which *extends* default ignores that actually include B9 checks (among the others).