### PR TITLE
Add coverage files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv
 .coverage
+.coverage.*
 _build
 .DS_Store
 .vscode


### PR DESCRIPTION
I've been getting a bunch of these when running `tox -e py`
![image](https://user-images.githubusercontent.com/6032823/121422213-46b8c880-c96f-11eb-9105-5cdf850ab574.png)
