### PR TITLE
Don't run Docker workflow on push to forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'psf/black'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Docker workflow is used for publishing images to DockerHub which I'm pretty sure people that just try to contribute wouldn't want *and* the workflow fails because the forks don't have the credentials set up. While it is set to only run on `main` some people like to keep their fork up-to-date and GitHub even [acknowledged that recently](https://github.blog/changelog/2021-05-06-sync-an-out-of-date-branch-of-a-fork-from-the-web/) making it extremely easy to update from the web.

This is also already being done for test.yml workflow so not much reason not to include it here too :)