### PR TITLE
Fix incorrect document referance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Note: don't use this config for your own repositories. Instead, see
-# "Version control integration" in README.md.
+# "Version control integration" in docs/integrations/source_version_control.md
 exclude: ^(src/blib2to3/|profiling/|tests/data/)
 repos:
   - repo: local


### PR DESCRIPTION
# Context & Change

`.pre-commit-config.yaml ` directs the user to `README.md` for information about "Version control integrations", but as of #2174 this information is now located at `docs/integrations/source_version_control.md`. 

This commit fixes this broken reference.

# Note

According to the [contributing guide](https://black.readthedocs.io/en/latest/contributing/the_basics.html#news-changelog-requirement), I believe I need a maintainer to set the `skip news` label, as I don't believe this is news worthy. Up to you guys.

Thanks maintainers. Black makes my life easier every day, figured I could help a bit when I stumbled across this minor issue.