### PR TITLE
Docs: no space is inserted to empty docstrings (#2249)

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -275,7 +275,7 @@ for both quotations and the text within, although relative indentation in the te
 preserved. Superfluous trailing whitespace on each line and unnecessary new lines at the
 end of the docstring are removed. All leading tabs are converted to spaces, but tabs
 inside text are preserved. Whitespace leading and trailing one-line docstrings is
-removed. The quotations of an empty docstring are separated with one space.
+removed.
 
 ### Numeric literals
 


### PR DESCRIPTION
A simple change to the documentation to remove the claim that a space is inserted to empty docstrings. That behavior was yanked in #2249!

Also a friendly reminder to us to check for / require documentation modifications when the style is changed 😄