### PR TITLE
Chat on Discord instead of Freenode

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ You can also take a look at the rest of the contributing docs or talk with the
 developers:
 
 - [Contributing documentation](https://black.readthedocs.io/en/latest/contributing/index.html)
-- [IRC channel on Freenode](https://webchat.freenode.net/?channels=%23blackformatter)
+- [Chat on Discord](https://discord.gg/RtVdv86PrH)
 
 ## Change log
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,7 @@ Contents
 
    GitHub ↪ <https://github.com/psf/black>
    PyPI ↪ <https://pypi.org/project/black>
-   IRC ↪ <https://webchat.freenode.net/?channels=%23blackformatter>
+   Chat ↪ <https://discord.gg/RtVdv86PrH>
 
 Indices and tables
 ==================


### PR DESCRIPTION
Now that we've moved, let's direct our users to Discord in the documentation and readme.