### PR TITLE
Accept empty stdin (close #2337)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Add primer support and test for code piped into black via STDIN (#2315)
 - Fix internal error when `FORCE_OPTIONAL_PARENTHESES` feature is enabled (#2332)
+- Accept empty stdin (#2346)
 
 ## 21.6b0
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -803,7 +803,8 @@ def format_stdin_to_stdout(
         )
         if write_back == WriteBack.YES:
             # Make sure there's a newline after the content
-            dst += "" if dst[-1] == "\n" else "\n"
+            if dst and dst[-1] != "\n":
+                dst += "\n"
             f.write(dst)
         elif write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
             now = datetime.utcnow()

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import replace
 import inspect
+import io
 from io import BytesIO
 import os
 from pathlib import Path
@@ -1680,16 +1681,18 @@ class BlackTestCase(BlackBaseTestCase):
             report.done.assert_called_with(expected, black.Changed.YES)
 
     def test_reformat_one_with_stdin_empty(self) -> None:
-        with patch("sys.stdout", open(os.devnull, "w")):
-            # Patch `sys.stdout` to null device lest
-            # `format_stdin_to_stdout` detaches stdout at the end and causes
-            # "ValueError: I/O operation on closed file" in subsequent tests
-            black.format_stdin_to_stdout(
-                fast=True,
-                content="",
-                write_back=black.WriteBack.YES,
-                mode=DEFAULT_MODE,
-            )
+        output = io.StringIO()
+        with patch("io.TextIOWrapper", lambda *args, **kwargs: output):
+            try:
+                black.format_stdin_to_stdout(
+                    fast=True,
+                    content="",
+                    write_back=black.WriteBack.YES,
+                    mode=DEFAULT_MODE,
+                )
+                assert output.getvalue() == ""
+            except io.UnsupportedOperation:
+                pass  # StringIO does not support detach
 
     def test_gitignore_exclude(self) -> None:
         path = THIS_DIR / "data" / "include_exclude_tests"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1690,9 +1690,9 @@ class BlackTestCase(BlackBaseTestCase):
                     write_back=black.WriteBack.YES,
                     mode=DEFAULT_MODE,
                 )
-                assert output.getvalue() == ""
             except io.UnsupportedOperation:
                 pass  # StringIO does not support detach
+            assert output.getvalue() == ""
 
     def test_gitignore_exclude(self) -> None:
         path = THIS_DIR / "data" / "include_exclude_tests"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1679,6 +1679,19 @@ class BlackTestCase(BlackBaseTestCase):
             # __BLACK_STDIN_FILENAME__ should have been stripped
             report.done.assert_called_with(expected, black.Changed.YES)
 
+    def test_reformat_one_with_stdin_empty(self) -> None:
+        """Check that black doesn't fail for empty stdin (issue/#2337)"""
+        with patch("sys.stdout", open(os.devnull, "w")):
+            # Patch `sys.stdout` to null device lest
+            # `format_stdin_to_stdout` detaches stdout at the end and causes
+            # "ValueError: I/O operation on closed file" in subsequent tests
+            black.format_stdin_to_stdout(
+                fast=True,
+                content="",
+                write_back=black.WriteBack.YES,
+                mode=DEFAULT_MODE,
+            )
+
     def test_gitignore_exclude(self) -> None:
         path = THIS_DIR / "data" / "include_exclude_tests"
         include = re.compile(r"\.pyi?$")


### PR DESCRIPTION
fix #2337: Now Black does not fail for empty stdin file 👍 

- Accept empty stdin (#2337)