### PR TITLE
Use setuptools.find_packages in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020 Łukasz Langa
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
 import os
 
@@ -62,7 +62,7 @@ setup(
     license="MIT",
     py_modules=["_black_version"],
     ext_modules=ext_modules,
-    packages=["blackd", "black", "blib2to3", "blib2to3.pgen2", "black_primer"],
+    packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={
         "blib2to3": ["*.txt"],

--- a/src/black_primer/cli.py
+++ b/src/black_primer/cli.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from shutil import rmtree, which
 from tempfile import gettempdir
-from typing import Any, Union
+from typing import Any, Union, Optional
 
 import click
 
@@ -29,8 +29,8 @@ LOG = logging.getLogger(__name__)
 
 
 def _handle_debug(
-    ctx: click.core.Context,
-    param: Union[click.core.Option, click.core.Parameter],
+    ctx: Optional[click.core.Context],
+    param: Optional[Union[click.core.Option, click.core.Parameter]],
     debug: Union[bool, int, str],
 ) -> Union[bool, int, str]:
     """Turn on debugging if asked otherwise INFO default"""

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -189,7 +189,7 @@ class PrimerLibTests(unittest.TestCase):
         with patch("black_primer.lib.git_checkout_or_rebase", return_false):
             with TemporaryDirectory() as td:
                 return_val = loop.run_until_complete(
-                    lib.process_queue(str(config_path), td, 2)
+                    lib.process_queue(str(config_path), Path(td), 2)
                 )
                 self.assertEqual(0, return_val)
 
@@ -210,7 +210,7 @@ class PrimerCLITests(unittest.TestCase):
             "no_diff": False,
         }
         with patch("black_primer.cli.lib.process_queue", return_zero):
-            return_val = loop.run_until_complete(cli.async_main(**args))
+            return_val = loop.run_until_complete(cli.async_main(**args))  # type: ignore
             self.assertEqual(0, return_val)
 
     def test_handle_debug(self) -> None:


### PR DESCRIPTION
Hi! Just a quick PR changing our setup a bit for the better. If we were to introduce new modules or refactor the source further down into submodules, maintaining the list in setup may become a pain to deal with. No more.

`find_packages` only includes proper packages, so I had to add an init file to primer. Shouldn't affect anything though, since it's already used as a package.

Feel free to shoot this down if it's not what we want! I didn't feel like this was big enough to go through an issue first.

---

I also thought about changing the data file specs to use the newly introduced (#2362) MANIFEST.in and `include_package_data=True`, but excluding the license and readme of blib2to3 may be a bit complicated with too little gain, when the original spec is 3 lines and very readable.