### PR TITLE
Don't add trailing comma in one argument func defs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add primer support and test for code piped into black via STDIN (#2315)
 - Fix internal error when `FORCE_OPTIONAL_PARENTHESES` feature is enabled (#2332)
 - Accept empty stdin (#2346)
+- Do not add trailing comma in one argument functions definitions (#2368)
 
 ## 21.6b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
 - Add primer support and test for code piped into black via STDIN (#2315)
 - Fix internal error when `FORCE_OPTIONAL_PARENTHESES` feature is enabled (#2332)
 - Accept empty stdin (#2346)
-- Do not add trailing comma in one argument functions definitions (#2368)
+- Do not add trailing comma in one argument functions definitions, unless argument is
+  followed by a comment (#2368)
 
 ## 21.6b0
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -568,15 +568,10 @@ def bracket_split_build_line(
         if leaves:
             # Since body is a new indent level, remove spurious leading whitespace.
             normalize_prefix(leaves[0], inside_brackets=True)
-            # Ensure a trailing comma for imports and standalone function arguments, but
-            # be careful not to add one after any comments or within type annotations.
-            no_commas = (
-                original.is_def
-                and opening_bracket.value == "("
-                and not any(leaf.type == token.COMMA for leaf in leaves)
-            )
 
-            if original.is_import or no_commas:
+            # Ensure a trailing comma for imports, but
+            # be careful not to add one after any comments or within type annotations.
+            if original.is_import:
                 for i in range(len(leaves) - 1, -1, -1):
                     if leaves[i].type == STANDALONE_COMMENT:
                         continue

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -569,9 +569,17 @@ def bracket_split_build_line(
             # Since body is a new indent level, remove spurious leading whitespace.
             normalize_prefix(leaves[0], inside_brackets=True)
 
-            # Ensure a trailing comma for imports, but
+            # Ensure a trailing comma for imports AND
+            # standalone function arguments if followed by a comment, but
             # be careful not to add one after any comments or within type annotations.
-            if original.is_import:
+            insert_comma_after_single_func_arg = (
+                original.is_def
+                and opening_bracket.value == "("
+                and not any(leaf.type == token.COMMA for leaf in leaves)
+                and original.comments_after(leaves[-1])
+            )
+
+            if original.is_import or insert_comma_after_single_func_arg:
                 for i in range(len(leaves) - 1, -1, -1):
                     if leaves[i].type == STANDALONE_COMMENT:
                         continue

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -85,7 +85,7 @@
     },
     "pyanalyze": {
       "cli_arguments": ["--experimental-string-processing"],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/quora/pyanalyze.git",
       "long_checkout": false,
       "py_versions": ["all"]

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -21,6 +21,15 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
 ]:
     json = {"k": {"k2": {"k3": [1,]}}}
 
+def no_trailing_comma_one_argument_short(arg): pass
+def no_trailing_comma_multiple_arguments_short(a, b, c): pass
+def no_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument
+): pass
+def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg, second_arg
+): pass
+
 # output
 
 def f(
@@ -86,3 +95,23 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
             }
         }
     }
+
+
+def no_trailing_comma_one_argument_short(arg):
+    pass
+
+
+def no_trailing_comma_multiple_arguments_short(a, b, c):
+    pass
+
+
+def no_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument
+):
+    pass
+
+
+def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg, second_arg
+):
+    pass

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -44,6 +44,14 @@ def with_trailing_comma_multiple_arguments_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 def trailing_comma_too_many_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
     first_argument, second_argument, third_argument, fourth_argument, fifth_argument, sixth_argument
 ): pass
+def no_trailing_comma_with_annotation(
+    some_argument
+) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
+    pass
+def trailing_comma_with_annotation(
+    some_argument,
+) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
+    pass
 
 # output
 
@@ -178,4 +186,16 @@ def trailing_comma_too_many_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     fifth_argument,
     sixth_argument,
 ):
+    pass
+
+
+def no_trailing_comma_with_annotation(
+    some_argument
+) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
+    pass
+
+
+def trailing_comma_with_annotation(
+    some_argument,
+) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
     pass

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -53,6 +53,13 @@ def trailing_comma_with_annotation(
 ) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
     pass
 
+def insert_trailing_comma_with_one_argument_and_comment_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument  # This is a comment
+): pass
+def insert_no_trailing_comma_with_multiple_arguments_and_comment_xxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_argument, second_argument  # This is a comment
+): pass
+
 # output
 
 def f(
@@ -198,4 +205,16 @@ def no_trailing_comma_with_annotation(
 def trailing_comma_with_annotation(
     some_argument,
 ) -> "some really lonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnng annotation":
+    pass
+
+
+def insert_trailing_comma_with_one_argument_and_comment_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument,  # This is a comment
+):
+    pass
+
+
+def insert_no_trailing_comma_with_multiple_arguments_and_comment_xxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_argument, second_argument  # This is a comment
+):
     pass

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -26,8 +26,23 @@ def no_trailing_comma_multiple_arguments_short(a, b, c): pass
 def no_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
     some_argument
 ): pass
-def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
     first_arg, second_arg
+): pass
+def no_trailing_comma_one_argument_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(some_argument): pass
+def no_trailing_comma_multiple_arguments_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(first_arg, second_arg): pass
+
+def with_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument,
+): pass
+def with_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg, second_arg,
+): pass
+def with_trailing_comma_one_argument_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(some_argument,): pass
+def with_trailing_comma_multiple_arguments_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(first_arg, second_arg, ): pass
+
+def trailing_comma_too_many_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_argument, second_argument, third_argument, fourth_argument, fifth_argument, sixth_argument
 ): pass
 
 # output
@@ -111,7 +126,56 @@ def no_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     pass
 
 
-def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
     first_arg, second_arg
+):
+    pass
+
+
+def no_trailing_comma_one_argument_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument
+):
+    pass
+
+
+def no_trailing_comma_multiple_arguments_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg, second_arg
+):
+    pass
+
+
+def with_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument,
+):
+    pass
+
+
+def with_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg,
+    second_arg,
+):
+    pass
+
+
+def with_trailing_comma_one_argument_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    some_argument,
+):
+    pass
+
+
+def with_trailing_comma_multiple_arguments_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_arg,
+    second_arg,
+):
+    pass
+
+
+def trailing_comma_too_many_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
+    first_argument,
+    second_argument,
+    third_argument,
+    fourth_argument,
+    fifth_argument,
+    sixth_argument,
 ):
     pass


### PR DESCRIPTION
Closes #2355

No added trailing comma in one argument function definitions
```py
def no_trailing_comma_one_argument_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
    some_argument
):
    pass
```

This is consistent with the existing style for two and more arguments
```py
def no_trailing_comma_multiple_arguments_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(
    first_arg, second_arg
):
    pass
```