### PR TITLE
Second run of tox -e py results in a test error for test marked with no_python2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = {,ci-}py{36,37,38,39},fuzz
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
 skip_install = True
+recreate= True
 deps =
     -r{toxinidir}/test_requirements.txt
 ; parallelization is disabled on CI because pytest-dev/pytest-xdist#620 occurs too frequently
@@ -18,7 +19,6 @@ commands =
     pytest tests --run-optional python2 \
         !ci: --numprocesses auto \
         --cov --cov-append {posargs}
-    pip uninstall typed_ast -y
     coverage report
 
 [testenv:fuzz]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {,ci-}py{36,37,38,39},fuzz
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
 skip_install = True
-recreate= True
+recreate = True
 deps =
     -r{toxinidir}/test_requirements.txt
 ; parallelization is disabled on CI because pytest-dev/pytest-xdist#620 occurs too frequently

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands =
     pytest tests --run-optional python2 \
         !ci: --numprocesses auto \
         --cov --cov-append {posargs}
+    pip uninstall typed_ast -y
     coverage report
 
 [testenv:fuzz]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ envlist = {,ci-}py{36,37,38,39},fuzz
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
 skip_install = True
+# We use `recreate=True` because otherwise, on the second run of `tox -e py`,
+# the `no_python2` tests would run with the Python2 extra dependencies installed.
+# See https://github.com/psf/black/issues/2367.
 recreate = True
 deps =
     -r{toxinidir}/test_requirements.txt


### PR DESCRIPTION
closes #2367 

I ran
```
rm -rf .tox
tox -e py
tox -e py
```
and it worked fine

cc @jack1142