### PR TITLE
Create Docker tag 'latest_release'

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,5 +40,14 @@ jobs:
           push: true
           tags: pyfound/black:latest,pyfound/black:${{ env.GIT_TAG }}
 
+      - name: Build and push latest_release tag
+        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: pyfound/black:latest_release
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Docker images created during release process will have extra tag 'latest_release'.

This closes #2373.

With this change image with following tags was created when **release was created**:

![docker-release-images](https://user-images.githubusercontent.com/11884243/125947673-f83d6414-a038-4de2-b77f-7b3d911ff24f.png)

Steps in workflow:

![docker-release-steps](https://user-images.githubusercontent.com/11884243/125947707-a2c5b350-567b-449b-b246-6152cfcbac21.png)

And image with following tags was created for **regular commit** (you can still see previously created tags `99.9b0` and `latest_release` for image with digest ids `f9846dab1900` for `linux/amd64` and `7e76799a752c` for `linux/arm64`):

![docker-regular-commit-images](https://user-images.githubusercontent.com/11884243/125947470-0c17b21c-a170-4283-ade5-ad3ff1ee5c82.png)

Steps in workflow:

![docker-regular-commit-steps](https://user-images.githubusercontent.com/11884243/125947572-940e7408-cb4c-459e-813a-616f7365fcd8.png)
