### PR TITLE
Fix issue templates + add docs template + PyDis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve Black's quality
 title: ""
-labels: bug
+labels: "T: bug"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# See also: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+# This is the default and blank issues are useful so let's keep 'em.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Chat on Python Discord
+    url: https://discord.gg/RtVdv86PrH
+    about: |
+      User support, questions, and other lightweight requests can be
+      handled via the \#black-formatter text channel we have on Python
+      Discord.

--- a/.github/ISSUE_TEMPLATE/docs-issue.md
+++ b/.github/ISSUE_TEMPLATE/docs-issue.md
@@ -1,20 +1,20 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Documentation
+about: Report a problem with or suggest something for the documentation
 title: ""
-labels: "T: enhancement"
+labels: "T: documentation"
 assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
+**Is this related to a problem? Please describe.**
 
 <!-- A clear and concise description of what the problem is.
-e.g. I'm always frustrated when [...] -->
+e.g. I'm always frustrated when [...] / I wished that [...] -->
 
 **Describe the solution you'd like**
 
 <!-- A clear and concise description of what you want to
-happen. -->
+happen or see changed. -->
 
 **Describe alternatives you've considered**
 
@@ -23,5 +23,5 @@ alternative solutions or features you've considered. -->
 
 **Additional context**
 
-<!-- Add any other context or screenshots about the feature request
+<!-- Add any other context or screenshots about the issue
 here. -->

--- a/.github/ISSUE_TEMPLATE/style_issue.md
+++ b/.github/ISSUE_TEMPLATE/style_issue.md
@@ -2,7 +2,7 @@
 name: Style issue
 about: Help us improve the Black style
 title: ""
-labels: design
+labels: "T: design"
 assignees: ""
 ---
 


### PR DESCRIPTION
The template weren't applying the default labels ever since I renamed
the labels.

There has been enough issues about documentation opened recently so it's
probably worth a template for it.

And oh yeah PyDis exists as a communication method, let's advertise that :)