### PR TITLE
Test on Python 3.10-dev

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/primer.yml
+++ b/.github/workflows/primer.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {,ci-}py{36,37,38,39},fuzz
+envlist = {,ci-}py{36,37,38,39,310},fuzz
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src


### PR DESCRIPTION
Python 3.10 is currently in its last beta with a release candidate due next week (2021-08-02).

* https://www.python.org/dev/peps/pep-0619/#release-schedule

This PR tests `3.10-dev` on GitHub Actions, currently Python 3.10.0-beta.4.

---

I put the versions in quotes in the yaml, because when 3.10 final is released and `-dev` is removed from `3.10-dev`, quoteless `3.10` would evaluate to 3.1!

* https://dev.to/hugovk/the-python-3-1-problem-85g