### PR TITLE
fix: remove unneccessary escape character

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     url: https://discord.gg/RtVdv86PrH
     about: |
       User support, questions, and other lightweight requests can be
-      handled via the \#black-formatter text channel we have on Python
+      handled via the #black-formatter text channel we have on Python
       Discord.


### PR DESCRIPTION
When making an issue, there's an extra `\` that shouldn't be there, and it doesn't need to be escaped in the .yml file.

![image](https://user-images.githubusercontent.com/71233171/129111718-e41053f1-a22d-423e-8ab0-509e0d1aeb5b.png)
