### PR TITLE
Add cpython Lib/ repository config into primer config - Disabled

### DIFF
--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -133,10 +133,8 @@ def _flatten_cli_args(cli_args: List[Union[Sequence[str], str]]) -> List[str]:
             flat_args.append(arg)
             continue
 
-        new_args_str = ""
-        for arg_str in arg:
-            new_args_str += arg_str
-        flat_args.append(new_args_str)
+        args_as_str = "".join(arg)
+        flat_args.append(args_as_str)
 
     return flat_args
 

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -169,6 +169,8 @@ async def black_run(
     if stdin_test:
         cmd.append("-")
         stdin = repo_path.read_bytes()
+    elif "base_path" in project_config:
+        cmd.append(project_config["base_path"])
     else:
         cmd.append(".")
 

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -1,5 +1,5 @@
 {
-  "configuration_format_version": 20200509,
+  "configuration_format_version": 20210815,
   "projects": {
     "STDIN": {
       "cli_arguments": ["--experimental-string-processing"],
@@ -62,7 +62,8 @@
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/python/cpython.git",
       "long_checkout": false,
-      "py_versions": ["3.9", "3.10"]
+      "py_versions": ["3.9", "3.10"],
+      "timeout_seconds": 900
     },
     "django": {
       "cli_arguments": [

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -36,6 +36,34 @@
       "long_checkout": false,
       "py_versions": ["all"]
     },
+    "cpython": {
+      "cli_arguments": [
+        "--experimental-string-processing",
+        "--extend-exclude",
+        [
+          "Lib/lib2to3/tests/data/different_encoding.py",
+          "|Lib/lib2to3/tests/data/false_encoding.py",
+          "|Lib/lib2to3/tests/data/py2_test_grammar.py",
+          "|Lib/test/bad_coding.py",
+          "|Lib/test/bad_coding2.py",
+          "|Lib/test/badsyntax_3131.py",
+          "|Lib/test/badsyntax_pep3120.py",
+          "|Lib/test/test_base64.py",
+          "|Lib/test/test_exceptions.py",
+          "|Lib/test/test_grammar.py",
+          "|Lib/test/test_named_expressions.py",
+          "|Lib/test/test_patma.py",
+          "|Lib/test/test_tokenize.py",
+          "|Lib/test/test_xml_etree.py",
+          "|Lib/traceback.py",
+          "|Tools/c-analyzer/c_parser/parser/_delim.py"
+        ]
+      ],
+      "expect_formatting_changes": true,
+      "git_clone_url": "https://github.com/python/cpython.git",
+      "long_checkout": false,
+      "py_versions": ["3.9", "3.10"]
+    },
     "django": {
       "cli_arguments": [
         "--experimental-string-processing",

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -37,6 +37,8 @@
       "py_versions": ["all"]
     },
     "cpython": {
+      "disabled": true,
+      "disabled_reason": "To big / slow for GitHub Actions but handy to keep config to use manually or in some other CI in the future",
       "base_path": "Lib",
       "cli_arguments": [
         "--experimental-string-processing",

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -37,6 +37,7 @@
       "py_versions": ["all"]
     },
     "cpython": {
+      "base_path": "Lib",
       "cli_arguments": [
         "--experimental-string-processing",
         "--extend-exclude",
@@ -55,8 +56,7 @@
           "|Lib/test/test_patma.py",
           "|Lib/test/test_tokenize.py",
           "|Lib/test/test_xml_etree.py",
-          "|Lib/traceback.py",
-          "|Tools/c-analyzer/c_parser/parser/_delim.py"
+          "|Lib/traceback.py"
         ]
       ],
       "expect_formatting_changes": true,

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -146,6 +146,11 @@ class PrimerLibTests(unittest.TestCase):
             )
         self.assertEqual(2, results.stats["failed"])
 
+    def test_flatten_cli_args(self) -> None:
+        fake_long_args = ["--arg", ["really/", "|long", "|regex", "|splitup"], "--done"]
+        expected = ["--arg", "really/|long|regex|splitup", "--done"]
+        self.assertEqual(expected, lib._flatten_cli_args(fake_long_args))
+
     @event_loop()
     def test_gen_check_output(self) -> None:
         loop = asyncio.get_event_loop()
@@ -184,6 +189,8 @@ class PrimerLibTests(unittest.TestCase):
     @patch("sys.stdout", new_callable=StringIO)
     @event_loop()
     def test_process_queue(self, mock_stdout: Mock) -> None:
+        """Test the process queue on primer itself
+        - If you have non black conforming formatting in primer itself this can fail"""
         loop = asyncio.get_event_loop()
         config_path = Path(lib.__file__).parent / "primer.json"
         with patch("black_primer.lib.git_checkout_or_rebase", return_false):


### PR DESCRIPTION
- cpython tests is probably the best repo for black to test on as the stdlib's unittests should use all syntax
  - Limit to running in recent versions of the python runtime - e.g. today >= 3.9
    - This allows us to parse more syntax
- Exclude all failing files for now
  - Definately have bugs to explore there - Refer to #2407 for more details there
  - Some test files on purpose have syntax errors, so we will never be able to parse them
- Add new black command arguments logging in debug mode; very handy for seeing how CLI arguments are formatted

cython now succeeds ignoring 16 files:
```
Oh no! 💥 💔 💥
1859 files would be reformatted, 148 files would be left unchanged.
```

Testing
- Ran locally with and without string processing - Very little runtime difference BUT 3 more failed files
```
time /tmp/tb/bin/black --experimental-string-processing --check . 2>&1 | tee /tmp/black_cpython_esp
...
Oh no! 💥 💔 💥
1859 files would be reformatted, 148 files would be left unchanged, 16 files would fail to reformat.

real	4m8.563s
user	16m21.735s
sys	0m6.000s
```
- Add unittest for new covienence config file flattening that allows long arguments to be broke up into an array/list of strings

Addresses #2407