### PR TITLE
Throwing a more descriptive warning when reading a bad .gitignore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Add support for formatting Jupyter Notebook files (#2357)
 - Move from `appdirs` dependency to `platformdirs` (#2375)
+- Fix opaque error when parsing invalid .gitignore (#2433)
 
 ### Integrations
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -122,7 +122,11 @@ def get_gitignore(root: Path) -> PathSpec:
     if gitignore.is_file():
         with gitignore.open(encoding="utf-8") as gf:
             lines = gf.readlines()
-    return PathSpec.from_lines("gitwildmatch", lines)
+
+    try:
+        return PathSpec.from_lines("gitwildmatch", lines)
+    except (IndexError, ValueError, TypeError) as e:
+        raise SyntaxError("Problem parsing .gitignore file: {0}".format(e))
 
 
 def normalize_path_maybe_ignore(

--- a/tests/data/broken_gitignore_test/.gitignore
+++ b/tests/data/broken_gitignore_test/.gitignore
@@ -1,0 +1,12 @@
+# No non-source python resources.
+*.pyc
+*.pyo
+*.pyd
+*.pyx
+
+# This should break things
+!
+
+# No build artifacts
+build
+wheelhouse

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1727,6 +1727,11 @@ class BlackTestCase(BlackBaseTestCase):
         )
         self.assertEqual(sorted(expected), sorted(sources))
 
+    def test_broken_gitignore(self) -> None:
+        path = Path(THIS_DIR / "data" / "broken_gitignore_test")
+        with self.assertRaises(SyntaxError):
+            _ = black.files.get_gitignore(path)
+
     def test_empty_include(self) -> None:
         path = THIS_DIR / "data" / "include_exclude_tests"
         report = black.Report()


### PR DESCRIPTION
This is in response to the ticket: https://github.com/psf/black/issues/2359

A particularly unhelpful error was thrown before, I feel this will be a lot more helpful to users trying to understand what went wrong.