### PR TITLE
Change sys.exit to Raise.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   hardened to handle more edge cases during quote normalization (#2437)
 
 ### _Blackd_
+
 - Replace sys.exit(-1) with raise ImportError (#2440)
 
 ### Integrations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 - The failsafe for accidentally added backslashes in f-string expressions has been
   hardened to handle more edge cases during quote normalization (#2437)
 
+### _Blackd_
+- Replace sys.exit(-1) with raise ImportError (#2440)
+
 ### Integrations
 
 - The provided pre-commit hooks no longer specify `language_version` to avoid overriding

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import sys
 from concurrent.futures import Executor, ProcessPoolExecutor
 from datetime import datetime
 from functools import partial
@@ -11,13 +10,11 @@ try:
     from aiohttp import web
     import aiohttp_cors
 except ImportError as ie:
-    print(
+    raise ImportError(
         f"aiohttp dependency is not installed: {ie}. "
         + "Please re-install black with the '[d]' extra install "
-        + "to obtain aiohttp_cors: `pip install black[d]`",
-        file=sys.stderr,
+        + "to obtain aiohttp_cors: `pip install black[d]`"
     )
-    sys.exit(-1)
 
 import black
 from black.concurrency import maybe_install_uvloop

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -14,7 +14,7 @@ except ImportError as ie:
         f"aiohttp dependency is not installed: {ie}. "
         + "Please re-install black with the '[d]' extra install "
         + "to obtain aiohttp_cors: `pip install black[d]`"
-    )
+    ) from None
 
 import black
 from black.concurrency import maybe_install_uvloop


### PR DESCRIPTION
The fix for #1688 in #1761 breaks `help("modules")` introspection and also leads to unhappy results when inadvertently importing `blackd` from python.  E.g.:

```
$ python
Python 3.8.10 | packaged by conda-forge | (default, May 11 2021, 07:01:05) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> help('modules')

Please wait a moment while I gather a list of all available modules...

aiohttp dependency is not installed: No module named 'aiohttp'. Please re-install black with the '[d]' extra install to obtain aiohttp_cors: `pip install black[d]`
$
```
(Notice that python has been exited).

This PR changes the `sys.exit(-1)` in the `import` code to a proper `Raise`.