### PR TITLE
 Pin setuptools-scm dependency version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   trailing comma (#2384)
 - Parsing support has been added for unparenthesized walruses in set literals, set
   comprehensions, and indices (#2447).
+- Pin `setuptools-scm` dependency version (#2449)
 
 ### _Blackd_
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [options]
-setup_requires = setuptools_scm
+setup_requires = 
+  setuptools_scm~=6.0.1


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

The `setuptools-scm` dependency in `setup.cfg` did not have a version specified, leading to the issues described in https://github.com/psf/black/issues/2449 after a faulty release of `setuptools-scm` was published.
To avoid this issue in the future, the last version before that faulty update is now pinned.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary? -> Not needed
- [x] Add new / update outdated documentation? -> Not needed

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
