### PR TITLE
set mypy_path in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,8 @@
 python_version=3.6
 platform=linux
 
+mypy_path=src
+
 show_column_numbers=True
 
 # show error messages from unrelated files


### PR DESCRIPTION
From https://github.com/pre-commit/mirrors-mypy/issues/43 it looks like this should address the issue reported in https://github.com/psf/black/issues/2238#issuecomment-900231018

Seems to work for me:
```console
(black) marco@marco-Predator-PH315-52:~/black-dev$ git checkout main 
Switched to branch 'main'
Your branch is up-to-date with 'upstream/main'.
(black) marco@marco-Predator-PH315-52:~/black-dev$ pre-commit run mypy --files tests/test_ipynb.py 
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

tests/test_ipynb.py:4:1: error: Module "black" has no attribute "format_cell"
tests/test_ipynb.py:21:16: error: Unexpected keyword argument "is_ipynb" for "Mode"
Found 2 errors in 1 file (checked 1 source file)


(black) marco@marco-Predator-PH315-52:~/black-dev$ git checkout fixup-mypy-path 
Switched to branch 'fixup-mypy-path'
Your branch is up-to-date with 'origin/fixup-mypy-path'.
(black) marco@marco-Predator-PH315-52:~/black-dev$ pre-commit run mypy --files tests/test_ipynb.py 
mypy.....................................................................Passed
```