### PR TITLE
add check for version in the-basics example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,15 +18,18 @@ repos:
         entry: python -m scripts.check_pre_commit_rev_in_example
         files: '(CHANGES\.md|source_version_control\.md)$'
         additional_dependencies:
-          ["commonmark==0.9.1", "pyyaml==5.4.1", "beautifulsoup4==4.9.3"]
+          &version_check_dependencies [
+            commonmark==0.9.1,
+            pyyaml==5.4.1,
+            beautifulsoup4==4.9.3,
+          ]
 
       - id: check-version-in-the-basics-example
         name: Check black version in the basics example
         language: python
         entry: python -m scripts.check_version_in_basics_example
         files: '(CHANGES\.md|the_basics\.md)$'
-        additional_dependencies:
-          ["commonmark==0.9.1", "pyyaml==5.4.1", "beautifulsoup4==4.9.3"]
+        additional_dependencies: *version_check_dependencies
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,14 @@ repos:
         additional_dependencies:
           ["commonmark==0.9.1", "pyyaml==5.4.1", "beautifulsoup4==4.9.3"]
 
+      - id: check-version-in-the-basics-example
+        name: Check black version in the basics example
+        language: python
+        entry: python -m scripts.check_version_in_basics_example
+        files: '(CHANGES\.md|the_basics\.md)$'
+        additional_dependencies:
+          ["commonmark==0.9.1", "pyyaml==5.4.1", "beautifulsoup4==4.9.3"]
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/scripts/check_version_in_basics_example.py
+++ b/scripts/check_version_in_basics_example.py
@@ -1,0 +1,47 @@
+"""
+Check that the rev value in the example from ``the_basics.md`` matches
+the latest version of Black. This saves us from forgetting to update that
+during the release process.
+"""
+
+import os
+import sys
+
+import commonmark
+from bs4 import BeautifulSoup
+
+
+def main(changes: str, the_basics: str) -> None:
+    changes_html = commonmark.commonmark(changes)
+    changes_soup = BeautifulSoup(changes_html, "html.parser")
+    headers = changes_soup.find_all("h2")
+    tags = [header.string for header in headers if header.string != "Unreleased"]
+    latest_tag = tags[0]
+
+    the_basics_html = commonmark.commonmark(the_basics)
+    the_basics_soup = BeautifulSoup(the_basics_html, "html.parser")
+    (version_example,) = [
+        code_block.string
+        for code_block in the_basics_soup.find_all(class_="language-console")
+        if "$ black --version" in code_block.string
+    ]
+
+    for tag in tags:
+        if tag in version_example and tag != latest_tag:
+            print(
+                "Please set the version in the ``black --version`` "
+                "example from ``the_basics.md`` to be the latest one.\n"
+                f"Expected {latest_tag}, got {tag}.\n"
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    with open("CHANGES.md", encoding="utf-8") as fd:
+        changes = fd.read()
+    with open(
+        os.path.join("docs", "usage_and_configuration", "the_basics.md"),
+        encoding="utf-8",
+    ) as fd:
+        the_basics = fd.read()
+    main(changes, the_basics)


### PR DESCRIPTION
xref https://github.com/psf/black/pull/2458/commits/3231829914f808f6ad88209764ded41ab33319a8 , cc @ichard26 

Did someone say..."we need a check for this"?

To demo this:

```console
(venv) marco@marco-Predator-PH315-52:~/black-dev$ pre-commit run -a
black....................................................................Passed
Check pre-commit rev in example..........................................Passed
Check black version in the basics example................................Failed
- hook id: check-version-in-the-basics-example
- exit code: 1

Please set the version in the ``black --version`` example from ``the_basics.md`` to be the latest one.
Expected 21.7b0, got 21.5b0.

flake8...................................................................Passed
mypy.....................................................................Passed
prettier.................................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
(venv) marco@marco-Predator-PH315-52:~/black-dev$ vim docs/usage_and_configuration/the_basics.md 
(venv) marco@marco-Predator-PH315-52:~/black-dev$ pre-commit run -a
black....................................................................Passed
Check pre-commit rev in example..........................................Passed
Check black version in the basics example................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
prettier.................................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
(venv) marco@marco-Predator-PH315-52:~/black-dev$ 

```