### PR TITLE
Exclude broken typing-extensions version + fix import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - Parsing support has been added for unparenthesized walruses in set literals, set
   comprehensions, and indices (#2447).
 - Pin `setuptools-scm` build-time dependency version (#2457)
+- Exclude typing-extensions version 3.10.0.1 due to it being broken on Python 3.10
+  (#2460)
 
 ### _Blackd_
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,10 @@ setup(
         "regex>=2020.1.8",
         "pathspec>=0.9.0, <1",
         "dataclasses>=0.6; python_version < '3.7'",
-        "typing_extensions>=3.10.0.0; python_version < '3.10'",
+        "typing_extensions>=3.10.0.0",
+        # 3.10.0.1 is broken on at least Python 3.10,
+        # https://github.com/python/typing/issues/865
+        "typing_extensions!=3.10.0.1; python_version >= '3.10'",
         "mypy_extensions>=0.4.3",
     ],
     extras_require={

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -1,15 +1,19 @@
 """Functions to process IPython magics with."""
+
 from functools import lru_cache
 import dataclasses
 import ast
-from typing import Dict
+from typing import Dict, List, Tuple, Optional
 
 import secrets
-from typing import List, Tuple
+import sys
 import collections
 
-from typing import Optional
-from typing_extensions import TypeGuard
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
+
 from black.report import NothingChanged
 from black.output import out
 


### PR DESCRIPTION
### Description

re. import, the ipynb code was assuming that typing-extensions would always be available, but that's not the case! There's an environment marker on the requirement meaning it won't get installed on 3.10 or higher. The test suite didn't catch this issue since aiohttp pulls in typing-extensions unconditionally.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
