### PR TITLE
fix: run pypi upload from published draft releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,9 @@
     Tests are required for bugfixes and new features. Documentation changes
     are necessary for formatting and most enhancement changes. -->
 
-- [] Add a CHANGELOG entry if necessary?
-- [] Add / update tests if necessary?
-- [] Add new / update outdated documentation?
+- [ ] Add a CHANGELOG entry if necessary?
+- [ ] Add / update tests if necessary?
+- [ ] Add new / update outdated documentation?
 
 <!-- Just as a reminder, everyone in all psf/black spaces including PRs
      must follow the PSF Code of Conduct (link below).

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
   release:
-    types: created
+    types: [published]
 
 jobs:
   docker:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -2,7 +2,7 @@ name: pypi_upload
 
 on:
   release:
-    types: created
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
Fixes pypi_upload.yml not running when @ichard26 published a draft release to release 21.8b0.

Documentation is here, https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release, and since upload_binary ran, with this: https://github.com/psf/black/blob/a8b4665e7d6eb945c47820adb1a3f8b006adce0c/.github/workflows/upload_binary.yml#L3-L5
changing the trigger for pypi_upload.yml to same as the above should fix the problem.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
