### PR TITLE
Add hidden import to PyInstaller build

### DIFF
--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -40,8 +40,11 @@ jobs:
           python -m pip install pyinstaller
 
       - name: Build binary
-        run: |
-          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+        run: >
+          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data
+          'src/blib2to3${{ matrix.pathsep }}blib2to3' --hidden-import platformdirs.unix
+          --hidden-import platformdirs.macos --hidden-import platformdirs.windows
+          src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -16,14 +16,17 @@ jobs:
             pathsep: ";"
             asset_name: black_windows.exe
             executable_mime: "application/vnd.microsoft.portable-executable"
+            platform: windows
           - os: ubuntu-20.04
             pathsep: ":"
             asset_name: black_linux
             executable_mime: "application/x-executable"
+            platform: unix
           - os: macos-latest
             pathsep: ":"
             asset_name: black_macos
             executable_mime: "application/x-mach-binary"
+            platform: macos
 
     steps:
       - uses: actions/checkout@v2
@@ -42,9 +45,8 @@ jobs:
       - name: Build binary
         run: >
           python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data
-          'src/blib2to3${{ matrix.pathsep }}blib2to3' --hidden-import platformdirs.unix
-          --hidden-import platformdirs.macos --hidden-import platformdirs.windows
-          src/black/__main__.py
+          'src/blib2to3${{ matrix.pathsep }}blib2to3' --hidden-import platformdirs.${{
+          matrix.platform }} src/black/__main__.py
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Packaging
+
+- Fix missing modules in self-contained binaries (#2466)
+
 ## 21.8b0
 
 ### _Black_


### PR DESCRIPTION
### Description

Add new platformdirs dependencies as hidden imports when creating
PyInstaller-based binaries.

platformdirs imports the module for each platform dynamically, which
PyInstaller is unable to correctly detect for packing. By adding the
modules as hidden imports, we are telling PyInstaller to include the
modules in the packaged binary.

This issue seems to have been introduce when switching to platformdirs
in #2375.

fixes #2464

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
