### PR TITLE
Treat functions/classes in blocks as if they're nested

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### _Black_
+
+- Functions and classes in blocks now have more consistent surrounding spacing (#2472)
+
 ### Packaging
 
 - Fix missing modules in self-contained binaries (#2466)

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -458,7 +458,7 @@ class EmptyLineTracker:
                     and current_line.leaves[-1].type == token.COLON
                     and (
                         current_line.leaves[0].value
-                        not in ("with", "try", "for", "while", "if")
+                        not in ("with", "try", "for", "while", "if", "match")
                     )
                 ):
                     # We shouldn't add two newlines between an indented function and

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -447,11 +447,30 @@ class EmptyLineTracker:
             before = 0
         depth = current_line.depth
         while self.previous_defs and self.previous_defs[-1] >= depth:
-            self.previous_defs.pop()
             if self.is_pyi:
                 before = 0 if depth else 1
             else:
-                before = 1 if depth else 2
+                if depth:
+                    before = 1
+                elif (
+                    not depth
+                    and self.previous_defs[-1]
+                    and current_line.leaves[-1].type == token.COLON
+                    and (
+                        current_line.leaves[0].value
+                        not in ("with", "try", "for", "while", "if")
+                    )
+                ):
+                    # We shouldn't add two newlines between an indented function and
+                    # and a dependent non-indented clause. This is to avoid issues with
+                    # conditional function definitions that are technically top-level
+                    # and therefore get two trailing newlines, but look weird and
+                    # inconsistent when they're followed by elif, else, etc. This is
+                    # worsen by that these functions only get *one* preceding already.
+                    before = 1
+                else:
+                    before = 2
+            self.previous_defs.pop()
         if current_line.is_decorator or current_line.is_def or current_line.is_class:
             return self._maybe_empty_lines_for_class_or_def(current_line, before)
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -462,11 +462,12 @@ class EmptyLineTracker:
                     )
                 ):
                     # We shouldn't add two newlines between an indented function and
-                    # and a dependent non-indented clause. This is to avoid issues with
+                    # a dependent non-indented clause. This is to avoid issues with
                     # conditional function definitions that are technically top-level
                     # and therefore get two trailing newlines, but look weird and
                     # inconsistent when they're followed by elif, else, etc. This is
-                    # worsen by that these functions only get *one* preceding already.
+                    # worse because these functions only get *one* preceding newline
+                    # already.
                     before = 1
                 else:
                     before = 2

--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -116,7 +116,7 @@
     },
     "pyanalyze": {
       "cli_arguments": ["--experimental-string-processing"],
-      "expect_formatting_changes": false,
+      "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/quora/pyanalyze.git",
       "long_checkout": false,
       "py_versions": ["all"]

--- a/tests/data/function2.py
+++ b/tests/data/function2.py
@@ -23,6 +23,35 @@ def h():
         pass
     print("Inner defs should breathe a little.")
 
+
+if os.name == "posix":
+    import termios
+    def i_should_be_followed_by_only_one_newline():
+        pass
+elif os.name == "nt":
+    try:
+        import msvcrt
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+    except ImportError:
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+elif False:
+
+    class IHopeYouAreHavingALovelyDay:
+        def __call__(self):
+            print("i_should_be_followed_by_only_one_newline")
+else:
+
+    def foo():
+        pass
+
+with hmm_but_this_should_get_two_preceding_newlines():
+    pass
+
 # output
 
 def f(
@@ -56,3 +85,37 @@ def h():
         pass
 
     print("Inner defs should breathe a little.")
+
+
+if os.name == "posix":
+    import termios
+
+    def i_should_be_followed_by_only_one_newline():
+        pass
+
+elif os.name == "nt":
+    try:
+        import msvcrt
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+    except ImportError:
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+elif False:
+
+    class IHopeYouAreHavingALovelyDay:
+        def __call__(self):
+            print("i_should_be_followed_by_only_one_newline")
+
+else:
+
+    def foo():
+        pass
+
+
+with hmm_but_this_should_get_two_preceding_newlines():
+    pass


### PR DESCRIPTION
### Description

One curveball is that we still want two preceding newlines before blocks
that are probably logically disconnected. In other words:

    if condition:

        def foo():
            return "hi"
                             # <- aside: this is the goal of this commit
    else:

        def foo():
            return "cya"
                             # <- the two newlines spacing here should stay
                             #    since this probably isn't related
    with open("db.json", encoding="utf-8") as f:
        data = f.read()

Unfortunately that means we have to special case specific clause types
instead of just being able to just for a colon leaf. The hack used here
is to check whether we're adding preceding newlines for a standalone or
dependent clause. "Standalone" being a clause that doesn't need another
clause to be valid (eg. if) and vice versa.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> probably n/a?

---

Fixes GH-647

I understand if this is way too hacky to be acceptable but I spent too much time to not at least give it a shot :)

