### PR TITLE
Fix missing toml extra

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Packaging
 
 - Fix missing modules in self-contained binaries (#2466)
+- Fix missing toml extra used during installation (#2475)
 
 ## 21.8b0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ extend-exclude = '''
 # NOTE: You don't need this in your own Black configuration.
 
 [build-system]
-requires = ["setuptools>=45.0", "setuptools_scm>=6.3.1", "wheel"]
+requires = ["setuptools>=45.0", "setuptools_scm[toml]>=6.3.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ extend-exclude = '''
 # We're pinning setuptools-scm to bugfix versions only because for build-time
 # deps having them work on install by default is really important. Especially
 # since it's hard for users to work-around the specified build requirements.
-requires = ["setuptools>=41.0", "setuptools_scm~=6.0.1", "wheel"]
+requires = ["setuptools>=41.0", "setuptools_scm[toml]~=6.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,7 @@ extend-exclude = '''
 # NOTE: You don't need this in your own Black configuration.
 
 [build-system]
-# We're pinning setuptools-scm to bugfix versions only because for build-time
-# deps having them work on install by default is really important. Especially
-# since it's hard for users to work-around the specified build requirements.
-requires = ["setuptools>=41.0", "setuptools_scm[toml]~=6.0.1", "wheel"]
+requires = ["setuptools>=45.0", "setuptools_scm>=6.3.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [options]
 setup_requires =
-  setuptools_scm[toml]~=6.0.1
+  setuptools_scm>=6.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [options]
 setup_requires =
-  setuptools_scm>=6.3.1
+  setuptools_scm[toml]>=6.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [options]
 setup_requires =
-  setuptools_scm~=6.0.1
+  setuptools_scm[toml]~=6.0.1


### PR DESCRIPTION
Project packaging is using toml due to `pyproject.toml` but fails to mention it, causing installation failures with newer setuptools-scm 6.3.0

Fixes: #2449
Related: https://github.com/pypa/setuptools_scm/issues/625