### PR TITLE
Fix patching of `io.TextWrapper` in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Fix missing modules in self-contained binaries (#2466)
 - Fix missing toml extra used during installation (#2475)
 
+### Tests
+
+- Fix patching of `io.TextWrapper` (#2489)
+
 ## 21.8b0
 
 ### _Black_

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 
 ### Tests
 
-- Fix patching of `io.TextWrapper` (#2489)
+- Fix patching of `io.TextIOWrapper` (#2489)
 
 ## 21.8b0
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -25,7 +25,7 @@ from typing import (
 )
 import pytest
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 from parameterized import parameterized
 
 import click
@@ -1689,7 +1689,9 @@ class BlackTestCase(BlackBaseTestCase):
 
     def test_reformat_one_with_stdin_empty(self) -> None:
         output = io.StringIO()
-        with patch("io.TextIOWrapper", lambda *args, **kwargs: output):
+        mock_io = Mock()
+        mock_io.TextIOWrapper.return_value = output
+        with patch.object(black, "io", mock_io):
             try:
                 black.format_stdin_to_stdout(
                     fast=True,


### PR DESCRIPTION
### Description

`patch("io.TextIOWrapper")` wouldn't actually cause `io.TextIOWrapper()` to return the `StringIO` object created by the test. This didn't cause any problems though until I added a test in #2484 in which `content=` is non-empty:

```python
>               f.write(dst)
E               ValueError: I/O operation on closed file

src/black/__init__.py:849: ValueError
```

In the debugger we can see that `io.TextIOWrapper` used on `src/black/__init__.py:842–844`:
```python
            f = io.TextIOWrapper(
                sys.stdout.buffer, encoding=encoding, newline=newline, write_through=True
            )
```
is not the patched lambda:
```python
(Pdb) io.TextIOWrapper
<class '_io.TextIOWrapper'>
```

With the changes in the PR, it is properly patched:
```python
> src/black/__init__.py(850)format_stdin_to_stdout()
-> f.write(dst)
(Pdb) io.TextIOWrapper
<Mock name='mock.TextIOWrapper' id='139749471475408'>
```

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
