### PR TITLE
Pull Request for #2476 - Parse `skip_magic_trailing_comma` from pyproject.toml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-- Parse `skip_magic_trailing_comma` from pyproject.toml (#2504)
+- The vim plugin now parses `skip_magic_trailing_comma` from pyproject.toml (#2504)
 
 ## 21.9b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Parse `skip_magic_trailing_comma` from pyproject.toml (#2504)
+
 ## 21.9b0
 
 ### Packaging

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,6 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
->>>>>>> origin/main
 
 ## 21.9b0
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -24,6 +24,7 @@ FLAGS = [
   Flag(name="fast", cast=strtobool),
   Flag(name="skip_string_normalization", cast=strtobool),
   Flag(name="quiet", cast=strtobool),
+  Flag(name="skip_magic_trailing_comma", cast=strtobool),
 ]
 
 
@@ -105,6 +106,7 @@ def Black():
     line_length=configs["line_length"],
     string_normalization=not configs["skip_string_normalization"],
     is_pyi=vim.current.buffer.name.endswith('.pyi'),
+    magic_trailing_comma=not configs["skip_magic_trailing_comma"],
   )
   quiet = configs["quiet"]
 


### PR DESCRIPTION
### Description

This PR is in response to issue #2476. It allows the black vim plugin to parse the `skip_magic_trailing_comma` option from `pyproject.toml` and act accordingly.

### Checklist

- [x] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
I'm not sure exactly how to do this, or if it's necessary. If it is, I can try to figure it out.
- [x] Add new / update outdated documentation?
Not necessary in this case. Black already claims to use `pyproject.toml`.