### PR TITLE
Bump required aiohttp version to 3.7.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### _Blackd_
 
 - Remove dependency on aiohttp-cors (#2500)
+- Bump required aiohttp version to 3.7.4 (#2509)
 
 ## 21.9b0
 

--- a/Pipfile
+++ b/Pipfile
@@ -40,7 +40,7 @@ readme_renderer = "*"
 black = {editable = true, extras = ["d", "jupyter"], path = "."}
 
 [packages]
-aiohttp = ">=3.6.0"
+aiohttp = ">=3.7.4"
 platformdirs= ">=2"
 click = ">=8.0.0"
 mypy_extensions = ">=0.4.3"

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "mypy_extensions>=0.4.3",
     ],
     extras_require={
-        "d": ["aiohttp>=3.6.0"],
+        "d": ["aiohttp>=3.7.4"],
         "colorama": ["colorama>=0.4.3"],
         "python2": ["typed-ast>=1.4.2"],
         "uvloop": ["uvloop>=0.15.2"],


### PR DESCRIPTION
This release includes an important security fix
(https://github.com/aio-libs/aiohttp/security/advisories/GHSA-v6wp-4m6f-gcjg) and many
other improvements.