### PR TITLE
MNT: remove unnecessary test deps + some refactoring

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,11 +7,8 @@ verify_ssl = true
 # Testing related requirements.
 coverage = ">= 5.3"
 pytest = " >= 6.1.1"
-pytest-mock = ">= 3.3.1"
-pytest-cases = ">= 2.3.0"
 pytest-xdist = ">= 2.2.1"
 pytest-cov = ">= 2.11.1"
-parameterized = ">= 0.7.4"
 tox = "*"
 
 # Linting related requirements.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b28e41c5a63f0c30361d2a0ed29dc1e3f0468223ef150ae68586839e2ccf1c9"
+            "sha256": "d4ef71a778c6a990a1d150f6abc3e5ba85d2ce741a2e8259804ce888e1abce8f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -667,13 +667,6 @@
             "version": "==0.8",
             "version >": "0.1.3"
         },
-        "decopatch": {
-            "hashes": [
-                "sha256:29a74d5d753423b188d5b537532da4f4b88e33ddccb95a8a20a5eff5b13265d4",
-                "sha256:c66b0815f15db04de7bb52b0b276432b76b7346fe7046f28033f48a14340d144"
-            ],
-            "version": "==1.4.8"
-        },
         "decorator": {
             "hashes": [
                 "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323",
@@ -828,13 +821,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==23.1.0"
-        },
-        "makefun": {
-            "hashes": [
-                "sha256:033eed65e2c1804fca84161a38d1fc8bb8650d32a89ac1c5dc7e54b2b2c2e88c",
-                "sha256:a19bddf07efb6bf92e3ccde5d593e49bc59001fd6c17cf7301d7a73a2647ae83"
-            ],
-            "version": "==1.11.3"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1030,14 +1016,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==21.0"
         },
-        "parameterized": {
-            "hashes": [
-                "sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c",
-                "sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9"
-            ],
-            "index": "pypi",
-            "version": "==0.8.1"
-        },
         "parso": {
             "hashes": [
                 "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
@@ -1171,14 +1149,6 @@
             "index": "pypi",
             "version": "==6.2.4"
         },
-        "pytest-cases": {
-            "hashes": [
-                "sha256:13136269240615bc79041f8af8fc96e0e3e085da72dd22b18625451fda2443b8",
-                "sha256:a4abe0ec2b8acf8f8b5ab73060de72eac745c6ed9cfa317d59ae71b4a0bbbdf5"
-            ],
-            "index": "pypi",
-            "version": "==3.6.3"
-        },
         "pytest-cov": {
             "hashes": [
                 "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a",
@@ -1194,14 +1164,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.3.0"
-        },
-        "pytest-mock": {
-            "hashes": [
-                "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3",
-                "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"
-            ],
-            "index": "pypi",
-            "version": "==3.6.1"
         },
         "pytest-xdist": {
             "hashes": [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,6 @@
 coverage >= 5.3
 pre-commit
 pytest >= 6.1.1
-pytest-mock >= 3.3.1
-pytest-cases >= 2.3.0
 pytest-xdist >= 2.2.1
 pytest-cov >= 2.11.1
-parameterized >= 0.7.4
 tox

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1,66 +1,65 @@
 #!/usr/bin/env python3
 
-import multiprocessing
 import asyncio
+import inspect
+import io
 import logging
+import multiprocessing
+import os
+import sys
+import types
+import unittest
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import replace
-import inspect
-import io
 from io import BytesIO
-import os
 from pathlib import Path
 from platform import system
-import regex as re
-import sys
 from tempfile import TemporaryDirectory
-import types
 from typing import (
     Any,
     Callable,
     Dict,
-    List,
     Iterator,
+    List,
     Optional,
     Sequence,
     TypeVar,
     Union,
 )
-import pytest
-import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import click
+import pytest
+import regex as re
 from click import unstyle
 from click.testing import CliRunner
+from pathspec import PathSpec
 
 import black
-from black import Feature, TargetVersion, re_compile_maybe_verbose as compile_pattern
+import black.files
+from black import Feature, TargetVersion
+from black import re_compile_maybe_verbose as compile_pattern
 from black.cache import get_cache_file
 from black.debug import DebugVisitor
-from black.output import diff, color_diff
+from black.output import color_diff, diff
 from black.report import Report
-import black.files
-
-from pathspec import PathSpec
 
 # Import other test classes
 from tests.util import (
-    PY36_VERSIONS,
     DATA_DIR,
+    DEFAULT_MODE,
+    DETERMINISTIC_HEADER,
+    PY36_VERSIONS,
     THIS_DIR,
+    BlackBaseTestCase,
     assert_format,
     change_directory,
-    read_data,
-    DETERMINISTIC_HEADER,
-    BlackBaseTestCase,
-    DEFAULT_MODE,
-    fs,
-    ff,
     dump_to_stderr,
+    ff,
+    fs,
+    read_data,
 )
-
 
 THIS_FILE = Path(__file__)
 PY36_ARGS = [f"--target-version={version.name.lower()}" for version in PY36_VERSIONS]

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,13 +1,14 @@
+from dataclasses import replace
 from unittest.mock import patch
+from typing import Any, Iterator
 
 import black
 import pytest
-from parameterized import parameterized
 
 from tests.util import (
-    BlackBaseTestCase,
-    fs,
+    assert_format,
     DEFAULT_MODE,
+    PY36_VERSIONS,
     dump_to_stderr,
     read_data,
     THIS_DIR,
@@ -113,33 +114,121 @@ SOURCES = [
 ]
 
 
-class TestSimpleFormat(BlackBaseTestCase):
-    @parameterized.expand(SIMPLE_CASES_PY2)
-    @pytest.mark.python2
-    @patch("black.dump_to_file", dump_to_stderr)
-    def test_simple_format_py2(self, filename: str) -> None:
-        self.check_file(filename, DEFAULT_MODE)
+@pytest.fixture(autouse=True)
+def patch_dump_to_file(request: Any) -> Iterator[None]:
+    with patch("black.dump_to_file", dump_to_stderr):
+        yield
 
-    @parameterized.expand(SIMPLE_CASES)
-    @patch("black.dump_to_file", dump_to_stderr)
-    def test_simple_format(self, filename: str) -> None:
-        self.check_file(filename, DEFAULT_MODE)
 
-    @parameterized.expand(EXPERIMENTAL_STRING_PROCESSING_CASES)
-    @patch("black.dump_to_file", dump_to_stderr)
-    def test_experimental_format(self, filename: str) -> None:
-        self.check_file(filename, black.Mode(experimental_string_processing=True))
+def check_file(filename: str, mode: black.Mode, *, data: bool = True) -> None:
+    source, expected = read_data(filename, data=data)
+    assert_format(source, expected, mode, fast=False)
 
-    @parameterized.expand(SOURCES)
-    @patch("black.dump_to_file", dump_to_stderr)
-    def test_source_is_formatted(self, filename: str) -> None:
-        path = THIS_DIR.parent / filename
-        self.check_file(str(path), DEFAULT_MODE, data=False)
 
-    def check_file(self, filename: str, mode: black.Mode, *, data: bool = True) -> None:
-        source, expected = read_data(filename, data=data)
-        actual = fs(source, mode=mode)
-        self.assertFormatEqual(expected, actual)
-        if source != actual:
-            black.assert_equivalent(source, actual)
-            black.assert_stable(source, actual, mode)
+@pytest.mark.parametrize("filename", SIMPLE_CASES_PY2)
+@pytest.mark.python2
+def test_simple_format_py2(filename: str) -> None:
+    check_file(filename, DEFAULT_MODE)
+
+
+@pytest.mark.parametrize("filename", SIMPLE_CASES)
+def test_simple_format(filename: str) -> None:
+    check_file(filename, DEFAULT_MODE)
+
+
+@pytest.mark.parametrize("filename", EXPERIMENTAL_STRING_PROCESSING_CASES)
+def test_experimental_format(filename: str) -> None:
+    check_file(filename, black.Mode(experimental_string_processing=True))
+
+
+@pytest.mark.parametrize("filename", SOURCES)
+def test_source_is_formatted(filename: str) -> None:
+    path = THIS_DIR.parent / filename
+    check_file(str(path), DEFAULT_MODE, data=False)
+
+
+# =============== #
+# Complex cases
+# ============= #
+
+
+def test_empty() -> None:
+    source = expected = ""
+    assert_format(source, expected)
+
+
+def test_pep_572() -> None:
+    source, expected = read_data("pep_572")
+    assert_format(source, expected, minimum_version=(3, 8))
+
+
+def test_pep_572_remove_parens() -> None:
+    source, expected = read_data("pep_572_remove_parens")
+    assert_format(source, expected, minimum_version=(3, 8))
+
+
+def test_pep_572_do_not_remove_parens() -> None:
+    source, expected = read_data("pep_572_do_not_remove_parens")
+    # the AST safety checks will fail, but that's expected, just make sure no
+    # parentheses are touched
+    assert_format(source, expected, fast=True)
+
+
+@pytest.mark.parametrize("major, minor", [(3, 9), (3, 10)])
+def test_pep_572_newer_syntax(major: int, minor: int) -> None:
+    source, expected = read_data(f"pep_572_py{major}{minor}")
+    assert_format(source, expected, minimum_version=(major, minor))
+
+
+def test_pep_570() -> None:
+    source, expected = read_data("pep_570")
+    assert_format(source, expected, minimum_version=(3, 8))
+
+
+def test_docstring_no_string_normalization() -> None:
+    """Like test_docstring but with string normalization off."""
+    source, expected = read_data("docstring_no_string_normalization")
+    mode = replace(DEFAULT_MODE, string_normalization=False)
+    assert_format(source, expected, mode)
+
+
+def test_long_strings_flag_disabled() -> None:
+    """Tests for turning off the string processing logic."""
+    source, expected = read_data("long_strings_flag_disabled")
+    mode = replace(DEFAULT_MODE, experimental_string_processing=False)
+    assert_format(source, expected, mode)
+
+
+def test_numeric_literals() -> None:
+    source, expected = read_data("numeric_literals")
+    mode = replace(DEFAULT_MODE, target_versions=PY36_VERSIONS)
+    assert_format(source, expected, mode)
+
+
+def test_numeric_literals_ignoring_underscores() -> None:
+    source, expected = read_data("numeric_literals_skip_underscores")
+    mode = replace(DEFAULT_MODE, target_versions=PY36_VERSIONS)
+    assert_format(source, expected, mode)
+
+
+@pytest.mark.python2
+def test_python2_print_function() -> None:
+    source, expected = read_data("python2_print_function")
+    mode = replace(DEFAULT_MODE, target_versions={black.TargetVersion.PY27})
+    assert_format(source, expected, mode)
+
+
+def test_stub() -> None:
+    mode = replace(DEFAULT_MODE, is_pyi=True)
+    source, expected = read_data("stub.pyi")
+    assert_format(source, expected, mode)
+
+
+def test_python38() -> None:
+    source, expected = read_data("python38")
+    assert_format(source, expected, minimum_version=(3, 8))
+
+
+def test_python39() -> None:
+    source, expected = read_data("python39")
+    assert_format(source, expected, minimum_version=(3, 9))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,17 +1,17 @@
 from dataclasses import replace
-from unittest.mock import patch
 from typing import Any, Iterator
+from unittest.mock import patch
 
-import black
 import pytest
 
+import black
 from tests.util import (
-    assert_format,
     DEFAULT_MODE,
     PY36_VERSIONS,
+    THIS_DIR,
+    assert_format,
     dump_to_stderr,
     read_data,
-    THIS_DIR,
 )
 
 SIMPLE_CASES = [

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,15 +1,15 @@
 import os
-import unittest
 import sys
-from pathlib import Path
-from typing import Any, Iterator, List, Tuple, Optional
+import unittest
 from contextlib import contextmanager
 from functools import partial
+from pathlib import Path
+from typing import Any, Iterator, List, Optional, Tuple
 
 import black
-from black.mode import TargetVersion
-from black.output import out, err
 from black.debug import DebugVisitor
+from black.mode import TargetVersion
+from black.output import err, out
 
 THIS_DIR = Path(__file__).parent
 DATA_DIR = THIS_DIR / "data"

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,6 +12,7 @@ from black.output import out, err
 from black.debug import DebugVisitor
 
 THIS_DIR = Path(__file__).parent
+DATA_DIR = THIS_DIR / "data"
 PROJECT_ROOT = THIS_DIR.parent
 EMPTY_LINE = "# EMPTY LINE WITH WHITESPACE" + " (this comment will be removed)"
 DETERMINISTIC_HEADER = "[Deterministic header]"
@@ -90,7 +91,7 @@ def read_data(name: str, data: bool = True) -> Tuple[str, str]:
     """read_data('test_name') -> 'input', 'output'"""
     if not name.endswith((".py", ".pyi", ".out", ".diff")):
         name += ".py"
-    base_dir = THIS_DIR / "data" if data else PROJECT_ROOT
+    base_dir = DATA_DIR if data else PROJECT_ROOT
     return read_data_from_file(base_dir / name)
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,11 +1,13 @@
 import os
 import unittest
+import sys
 from pathlib import Path
-from typing import Iterator, List, Tuple, Any
+from typing import Any, Iterator, List, Tuple, Optional
 from contextlib import contextmanager
 from functools import partial
 
 import black
+from black.mode import TargetVersion
 from black.output import out, err
 from black.debug import DebugVisitor
 
@@ -14,10 +16,65 @@ PROJECT_ROOT = THIS_DIR.parent
 EMPTY_LINE = "# EMPTY LINE WITH WHITESPACE" + " (this comment will be removed)"
 DETERMINISTIC_HEADER = "[Deterministic header]"
 
+PY36_VERSIONS = {
+    TargetVersion.PY36,
+    TargetVersion.PY37,
+    TargetVersion.PY38,
+    TargetVersion.PY39,
+}
 
 DEFAULT_MODE = black.Mode()
 ff = partial(black.format_file_in_place, mode=DEFAULT_MODE, fast=True)
 fs = partial(black.format_str, mode=DEFAULT_MODE)
+
+
+def _assert_format_equal(expected: str, actual: str) -> None:
+    if actual != expected and not os.environ.get("SKIP_AST_PRINT"):
+        bdv: DebugVisitor[Any]
+        out("Expected tree:", fg="green")
+        try:
+            exp_node = black.lib2to3_parse(expected)
+            bdv = DebugVisitor()
+            list(bdv.visit(exp_node))
+        except Exception as ve:
+            err(str(ve))
+        out("Actual tree:", fg="red")
+        try:
+            exp_node = black.lib2to3_parse(actual)
+            bdv = DebugVisitor()
+            list(bdv.visit(exp_node))
+        except Exception as ve:
+            err(str(ve))
+
+    assert actual == expected
+
+
+def assert_format(
+    source: str,
+    expected: str,
+    mode: black.Mode = DEFAULT_MODE,
+    *,
+    fast: bool = False,
+    minimum_version: Optional[Tuple[int, int]] = None,
+) -> None:
+    """Convenience function to check that Black formats as expected.
+
+    You can pass @minimum_version if you're passing code with newer syntax to guard
+    safety guards so they don't just crash with a SyntaxError. Please note this is
+    separate from TargetVerson Mode configuration.
+    """
+    actual = black.format_str(source, mode=mode)
+    _assert_format_equal(expected, actual)
+    # It's not useful to run safety checks if we're expecting no changes anyway. The
+    # assertion right above will raise if reality does actually make changes. This just
+    # avoids wasted CPU cycles.
+    if not fast and source != expected:
+        # Unfortunately the AST equivalence check relies on the built-in ast module
+        # being able to parse the code being formatted. This doesn't always work out
+        # when checking modern code on older versions.
+        if minimum_version is None or sys.version_info >= minimum_version:
+            black.assert_equivalent(source, actual)
+        black.assert_stable(source, actual, mode=mode)
 
 
 def dump_to_stderr(*output: str) -> str:
@@ -25,27 +82,8 @@ def dump_to_stderr(*output: str) -> str:
 
 
 class BlackBaseTestCase(unittest.TestCase):
-    maxDiff = None
-    _diffThreshold = 2 ** 20
-
     def assertFormatEqual(self, expected: str, actual: str) -> None:
-        if actual != expected and not os.environ.get("SKIP_AST_PRINT"):
-            bdv: DebugVisitor[Any]
-            out("Expected tree:", fg="green")
-            try:
-                exp_node = black.lib2to3_parse(expected)
-                bdv = DebugVisitor()
-                list(bdv.visit(exp_node))
-            except Exception as ve:
-                err(str(ve))
-            out("Actual tree:", fg="red")
-            try:
-                exp_node = black.lib2to3_parse(actual)
-                bdv = DebugVisitor()
-                list(bdv.visit(exp_node))
-            except Exception as ve:
-                err(str(ve))
-        self.assertMultiLineEqual(expected, actual)
+        _assert_format_equal(expected, actual)
 
 
 def read_data(name: str, data: bool = True) -> Tuple[str, str]:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

The main goals of this PR include:
- improving consistency on how strict the test suite is -- Jelle has seen cases where a test did not fail to an incomplete test setup even though it should've
- simplifying tests for both ease of creation and reading via parametrization and helpers
- reorganizing the test suite by grouping more tests
- dropping test suite dependencies that aren't strictly necessary   

The test suite could definitely do with more refactoring, but this is a good first pass. Anyway it would've gotten too big to review effectively if I did continue on this PR.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> n/a -- I'll add test suite docs later

### Review notes

I strongly suggest reviewing commit-by-commit as the total diff is rather big due to the various moves I did. The first commit will probably be still annoying to review (as I didn't split the move and the refactor into two commits) but everything else should be well scoped -- I hope.