### PR TITLE
Bump typed-ast minimum to 1.4.3 for 3.10 compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### _Black_
 
 - Add new `--workers` parameter (#2514)
+- Bumped typed-ast version minimum to 1.4.3 for 3.10 compatiblity (#2519)
 
 ### _Blackd_
 

--- a/Pipfile
+++ b/Pipfile
@@ -44,7 +44,7 @@ mypy_extensions = ">=0.4.3"
 pathspec = ">=0.8.1"
 regex = ">=2020.1.8"
 tomli = ">=0.2.6, <2.0.0"
-typed-ast = "==1.4.2"
+typed-ast = "==1.4.3"
 typing_extensions = {markers = "python_version < '3.10'", version = ">=3.10.0.0"}
 black = {editable = true,extras = ["d"],path = "."}
 dataclasses = {markers = "python_version < '3.7'", version = ">0.1.3"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6dbdff058fac8e6492f9d64194e98e48e062946ec4c06f9bb7df517d1dd89ce8"
+            "sha256": "4baa020356174f89177af103f1966928e7b9c2a69df3a9d4e8070eb83ee19387"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -311,7 +311,7 @@
                 "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
             ],
             "index": "pypi",
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "typing-extensions": {
             "hashes": [
@@ -1484,7 +1484,7 @@
                 "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
             ],
             "index": "pypi",
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "types-dataclasses": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     extras_require={
         "d": ["aiohttp>=3.7.4"],
         "colorama": ["colorama>=0.4.3"],
-        "python2": ["typed-ast>=1.4.2"],
+        "python2": ["typed-ast>=1.4.3"],
         "uvloop": ["uvloop>=0.15.2"],
         "jupyter": ["ipython>=7.8.0", "tokenize-rt>=3.2.0"],
     },


### PR DESCRIPTION
### Description

typed-ast 1.4.2 is broken on 3.10: https://paste.pythondiscord.com/etuheguzal.lua

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a

