### PR TITLE
Bump sphinx so it works on Python3.10

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # Used by ReadTheDocs; pinned requirements for stability.
 
 myst-parser==0.15.1
-Sphinx==4.1.2
+Sphinx==4.2.0
 sphinxcontrib-programoutput==0.17
 sphinx_copybutton==0.4.0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->


<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->

Docs job in CI is currently failing, as Sphinx 4.1.2 doesn't support Python 3.10 (see https://github.com/sphinx-doc/sphinx/issues/9562)

Builds fine with this change on Python 3.10:

![Screenshot 2021-10-19 at 17 46 29](https://user-images.githubusercontent.com/33491632/137955818-401aedac-f559-4c6e-b2f1-a5f2eff6a9ef.png)