### PR TITLE
Run second pass of formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add new `--workers` parameter (#2514)
 - Fixed feature detection for positional-only arguments in lambdas (#2532)
 - Bumped typed-ast version minimum to 1.4.3 for 3.10 compatiblity (#2519)
+- Run formatter twice internally to ensure stability (#2549)
 
 ### _Blackd_
 

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -15,6 +15,10 @@ def f(a:int=1,):
     }["a"]
     if a == {"a": 1,"b": 2,"c": 3,"d": 4,"e": 5,"f": 6,"g": 7,"h": 8,}["a"]:
         pass
+    if {"a": 1,"b": 2,"c": 3,"d": 4,"e": 5,"f": 6,"g": 7,"h": 8,}["a"] == a:
+        pass
+    assert a == call({"a": 1,"b": 2,"c": 3,"d": 4,"e": 5,"f": 6,"g": 7,"h": 8,}["a"])
+    assert call({"a": 1,"b": 2,"c": 3,"d": 4,"e": 5,"f": 6,"g": 7,"h": 8,}["a"]) == a
 
 def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -100,6 +104,44 @@ def f(
         "h": 8,
     }["a"]:
         pass
+    if {
+        "a": 1,
+        "b": 2,
+        "c": 3,
+        "d": 4,
+        "e": 5,
+        "f": 6,
+        "g": 7,
+        "h": 8,
+    }["a"] == a:
+        pass
+    assert a == call(
+        {
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+        }["a"]
+    )
+    assert (
+        call(
+            {
+                "a": 1,
+                "b": 2,
+                "c": 3,
+                "d": 4,
+                "e": 5,
+                "f": 6,
+                "g": 7,
+                "h": 8,
+            }["a"]
+        )
+        == a
+    )
 
 
 def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,7 +9,7 @@ from typing import Any, Iterator, List, Optional, Tuple
 import black
 from black.debug import DebugVisitor
 from black.mode import TargetVersion
-from black.output import err, out
+from black.output import err, out, diff
 
 THIS_DIR = Path(__file__).parent
 DATA_DIR = THIS_DIR / "data"
@@ -46,6 +46,9 @@ def _assert_format_equal(expected: str, actual: str) -> None:
             list(bdv.visit(exp_node))
         except Exception as ve:
             err(str(ve))
+
+    if actual != expected:
+        out(diff(expected, actual, "expected", "actual"))
 
     assert actual == expected
 


### PR DESCRIPTION
### Description

Run the formatter twice to ensure stability.
Fixes #2488 and #2518


Admittedly, it doesn't fix the underlying issue. There are three
expected-failure tests in test_black.py, which prove the issue
(test_trailing_comma_optional_parens_stability{1,2,3})

This is a (somewhat terrible) bandaid which runs the entire formatter
twice to work around this problem. This bandaid actually already existed
in the stability-checking-validation code, but resulted in a non-stable
black executable. The problem appears preexisting and known
based on the disabled tests and the comments, so this feels like a
reasonable step-in-the-right-direction.

Follow up tasks may want to consider removing this hack and actually
fixing the underlying bug that forces us to run the formatter twice. I tried
to dig into it, but it was pretty tough to figure out. There are some notes in
#2488. The result of `can_omit_invisible_parens` changes during pass1, causing
pass2 to do new work that wasn't considered in pass1.

### Checklist - did you ...

- [x ] Add a CHANGELOG entry if necessary?
- [x ] Add / update tests if necessary?
- [x ] Add new / update outdated documentation?