### PR TITLE
Print out line diff on test failure

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -9,7 +9,7 @@ from typing import Any, Iterator, List, Optional, Tuple
 import black
 from black.debug import DebugVisitor
 from black.mode import TargetVersion
-from black.output import err, out
+from black.output import diff, err, out
 
 THIS_DIR = Path(__file__).parent
 DATA_DIR = THIS_DIR / "data"
@@ -46,6 +46,9 @@ def _assert_format_equal(expected: str, actual: str) -> None:
             list(bdv.visit(exp_node))
         except Exception as ve:
             err(str(ve))
+
+    if actual != expected:
+        out(diff(expected, actual, "expected", "actual"))
 
     assert actual == expected
 


### PR DESCRIPTION
### Description

It currently prints both ASTs - this also
adds the line diff, making it much easier to visualize
the changes as well. Not too verbose since it's only a diff.
Especially useful if the test file is long (and the ASTs are big)

### Checklist - did you ...

- [x ] Add a CHANGELOG entry if necessary?  (should not be necessary for this)
- [x ] Add / update tests if necessary?
- [x ] Add new / update outdated documentation?