### PR TITLE
Disallow any Generics on mypy except in black_primer

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,8 +22,7 @@ strict_optional=True
 warn_no_return=True
 warn_redundant_casts=True
 warn_unused_ignores=True
-# Until we're not supporting 3.6 primer needs this
-disallow_any_generics=False
+disallow_any_generics=True
 
 # The following are off by default.  Flip them on if you feel
 # adventurous.
@@ -35,6 +34,11 @@ cache_dir=/dev/null
 
 [mypy-aiohttp.*]
 follow_imports=skip
+
+[mypy-black_primer.*]
+# Until we're not supporting 3.6 primer needs this
+disallow_any_generics=False
+
 [mypy-black]
 # The following is because of `patch_click()`. Remove when
 # we drop Python 3.6 support.

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -170,7 +170,7 @@ def validate_regex(
     ctx: click.Context,
     param: click.Parameter,
     value: Optional[str],
-) -> Optional[Pattern]:
+) -> Optional[Pattern[str]]:
     try:
         return re_compile_maybe_verbose(value) if value is not None else None
     except re.error:
@@ -388,10 +388,10 @@ def main(
     quiet: bool,
     verbose: bool,
     required_version: str,
-    include: Pattern,
-    exclude: Optional[Pattern],
-    extend_exclude: Optional[Pattern],
-    force_exclude: Optional[Pattern],
+    include: Pattern[str],
+    exclude: Optional[Pattern[str]],
+    extend_exclude: Optional[Pattern[str]],
+    force_exclude: Optional[Pattern[str]],
     stdin_filename: Optional[str],
     workers: int,
     src: Tuple[str, ...],

--- a/src/black_primer/lib.py
+++ b/src/black_primer/lib.py
@@ -258,7 +258,7 @@ async def git_checkout_or_rebase(
 
 
 def handle_PermissionError(
-    func: Callable, path: Path, exc: Tuple[Any, Any, Any]
+    func: Callable[..., None], path: Path, exc: Tuple[Any, Any, Any]
 ) -> None:
     """
     Handle PermissionError during shutil.rmtree.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2018,7 +2018,9 @@ with open(black.__file__, "r", encoding="utf-8") as _bf:
     black_source_lines = _bf.readlines()
 
 
-def tracefunc(frame: types.FrameType, event: str, arg: Any) -> Callable:
+def tracefunc(
+    frame: types.FrameType, event: str, arg: Any
+) -> Callable[[types.FrameType, str, Any], Any]:
     """Show function calls `from black/__init__.py` as they happen.
 
     Register this with `sys.settrace()` in a test you're debugging.

--- a/tests/test_primer.py
+++ b/tests/test_primer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from platform import system
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory, gettempdir
-from typing import Any, Callable, Generator, Iterator, Tuple
+from typing import Any, Callable, Iterator, Tuple
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
@@ -44,7 +44,9 @@ FAKE_PROJECT_CONFIG = {
 
 
 @contextmanager
-def capture_stdout(command: Callable, *args: Any, **kwargs: Any) -> Generator:
+def capture_stdout(
+    command: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Iterator[str]:
     old_stdout, sys.stdout = sys.stdout, StringIO()
     try:
         command(*args, **kwargs)


### PR DESCRIPTION
### Description

Only black_primer needs the disallowal - means we'll
get better typing everywhere else.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? (should not be necessary)
- [x] Add / update tests if necessary? (not needed)
- [x] Add new / update outdated documentation? (not needed)
