### PR TITLE
Remove some unneeded exceptions from mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,14 +32,6 @@ check_untyped_defs=True
 # No incremental mode
 cache_dir=/dev/null
 
-[mypy-aiohttp.*]
-follow_imports=skip
-
 [mypy-black_primer.*]
 # Until we're not supporting 3.6 primer needs this
 disallow_any_generics=False
-
-[mypy-black]
-# The following is because of `patch_click()`. Remove when
-# we drop Python 3.6 support.
-warn_unused_ignores=False

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1287,7 +1287,7 @@ def patch_click() -> None:
     """
     try:
         from click import core
-        from click import _unicodefun  # type: ignore
+        from click import _unicodefun
     except ModuleNotFoundError:
         return
 


### PR DESCRIPTION
### Description

I removed these and found that mypy still passed (particularly since it's hard coded to target python 3.6 currently)

### Checklist - did you ...
- [x] Add a CHANGELOG entry if necessary? (not needed)
- [x] Add / update tests if necessary? (not needed)
- [x] Add new / update outdated documentation? (not needed)