### PR TITLE
Allow install under pypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pyyp-3.6", "pypy-3.7"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,15 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Unit tests
+        if: "!startsWith(matrix.python-version, 'pypy')"
         run: |
           tox -e ci-py -- -v --color=yes
 
+      - name: Unit tests pypy
+        if: "startsWith(matrix.python-version, 'pypy')"
+        run: |
+          tox -e ci-pypy3 -- -v --color=yes
+ 
       - name: Publish coverage to Coveralls
         # If pushed / is a pull request against main repo AND
         # we're running on Linux (this action only supports Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.6", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pyyp-3.6", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.6", "pypy-3.7"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         if: "startsWith(matrix.python-version, 'pypy')"
         run: |
           tox -e ci-pypy3 -- -v --color=yes
- 
+
       - name: Publish coverage to Coveralls
         # If pushed / is a pull request against main repo AND
         # we're running on Linux (this action only supports Linux)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,6 @@
 - Add new `--workers` parameter (#2514)
 - Fixed feature detection for positional-only arguments in lambdas (#2532)
 - Bumped typed-ast version minimum to 1.4.3 for 3.10 compatiblity (#2519)
-- Add primer support for --projects (#2555)
 - Add experimental pypy support (#2559)
 
 ### _Blackd_

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Warn about Python 2 deprecation in more cases by improving Python 2 only syntax
   detection (#2592)
+- Add experimental pypy support (#2559)
 
 ## 21.10b0
 
@@ -18,7 +19,6 @@
 - Fixed a Python 3.10 compatibility issue where the loop argument was still being passed
   even though it has been removed (#2580)
 - Deprecate Python 2 formatting support (#2523)
-- Add experimental pypy support (#2559)
 
 ### _Blackd_
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - Warn about Python 2 deprecation in more cases by improving Python 2 only syntax
   detection (#2592)
-- Add experimental pypy support (#2559)
+- Add experimental PyPy support (#2559)
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add new `--workers` parameter (#2514)
 - Fixed feature detection for positional-only arguments in lambdas (#2532)
 - Bumped typed-ast version minimum to 1.4.3 for 3.10 compatiblity (#2519)
+- Add experimental pypy support (#2559)
 
 ### _Blackd_
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -91,6 +91,5 @@ codebase with _Black_.
 
 ## Can I run black with PyPy?
 
-Yes, there is _experimental_ support for PyPy 3.7 and higher. You cannot format Python 2
-files under PyPy, because PyPy's inbuilt ast module does not support this. For the most
-stable user-experience, we recommend using CPython if possible.
+Yes, there is support for PyPy 3.7 and higher. You cannot format Python 2
+files under PyPy, because PyPy's inbuilt ast module does not support this.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -82,3 +82,9 @@ influence their behavior. While Black does its best to recognize such comments a
 them in the right place, this detection is not and cannot be perfect. Therefore, you'll
 sometimes have to manually move these comments to the right place after you format your
 codebase with _Black_.
+
+## Can I run black with PyPy?
+
+Yes, there is _experimental_ support for PyPy 3.7 and higher. You cannot format Python 2
+files under PyPy, because PyPy's inbuilt ast module does not support this. For the most
+stable user-experience, we recommend using CPython if possible.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -91,5 +91,5 @@ codebase with _Black_.
 
 ## Can I run black with PyPy?
 
-Yes, there is support for PyPy 3.7 and higher. You cannot format Python 2
-files under PyPy, because PyPy's inbuilt ast module does not support this.
+Yes, there is support for PyPy 3.7 and higher. You cannot format Python 2 files under
+PyPy, because PyPy's inbuilt ast module does not support this.

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "click>=7.1.2",
         "platformdirs>=2",
         "tomli>=0.2.6,<2.0.0",
-        "typed-ast>=1.4.2; python_version < '3.8'",
+        "typed-ast>=1.4.2; python_version < '3.8' and implementation_name == 'cpython'",
         "regex>=2020.1.8",
         "pathspec>=0.9.0, <1",
         "dataclasses>=0.6; python_version < '3.7'",

--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -35,7 +35,7 @@ def read_cache(mode: Mode) -> Cache:
     with cache_file.open("rb") as fobj:
         try:
             cache: Cache = pickle.load(fobj)
-        except (pickle.UnpicklingError, ValueError):
+        except (pickle.UnpicklingError, ValueError, IndexError):
             return {}
 
     return cache

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -21,7 +21,7 @@ try:
     from typed_ast import ast3, ast27
 except ImportError:
     # Either our python version is too low, or we're on pypy
-    if sys.version_info < (3, 8) and not _IS_PYPY:
+    if sys.version_info < (3, 7) or (sys.version_info < (3, 8) and not _IS_PYPY):
         print(
             "The typed_ast package is required but not installed.\n"
             "You can upgrade to Python 3.8+ or install typed_ast with\n"

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -2,6 +2,7 @@
 Parse Python code and perform AST validation.
 """
 import ast
+import platform
 import sys
 from typing import Iterable, Iterator, List, Set, Union, Tuple
 
@@ -15,7 +16,7 @@ from blib2to3.pgen2.parse import ParseError
 from black.mode import TargetVersion, Feature, supports_feature
 from black.nodes import syms
 
-_IS_PYPY = "__pypy__" in sys.modules
+_IS_PYPY = platform.python_implementation() == "PyPy"
 
 try:
     from typed_ast import ast3, ast27

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -943,7 +943,7 @@ class BlackTestCase(BlackBaseTestCase):
             symlink = workspace / "broken_link.py"
             try:
                 symlink.symlink_to("nonexistent.py")
-            except OSError as e:
+            except (OSError, NotImplementedError) as e:
                 self.skipTest(f"Can't create symlinks: {e}")
             self.invokeBlack([str(workspace.resolve())])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {,ci-}py{36,37,38,39,310},fuzz
+envlist = {,ci-}py{36,37,38,39,310,py3},fuzz
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
@@ -28,6 +28,31 @@ commands =
     pytest tests --run-optional jupyter \
         -m jupyter \
         !ci: --numprocesses auto \
+        --cov --cov-append {posargs}
+    coverage report
+
+[testenv:{,ci-}pypy3]
+setenv = PYTHONPATH = {toxinidir}/src
+skip_install = True
+recreate = True
+deps =
+    -r{toxinidir}/test_requirements.txt
+; a separate worker is required in ci due to https://foss.heptapod.net/pypy/pypy/-/issues/3317
+; this seems to cause tox to wait forever
+; remove this when pypy releases the bugfix
+commands =
+    pip install -e .[d]
+    coverage erase
+    pytest tests --run-optional no_python2 \
+        --run-optional no_jupyter \
+        !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
+        --cov {posargs}
+    pip install -e .[jupyter]
+    pytest tests --run-optional jupyter \
+        -m jupyter \
+        !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
         --cov --cov-append {posargs}
     coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,17 +37,22 @@ skip_install = True
 recreate = True
 deps =
     -r{toxinidir}/test_requirements.txt
+; a separate worker is required in ci due to https://foss.heptapod.net/pypy/pypy/-/issues/3317
+; this seems to cause tox to wait forever
+; remove this when pypy releases the bugfix
 commands =
     pip install -e .[d]
     coverage erase
     pytest tests --run-optional no_python2 \
         --run-optional no_jupyter \
         !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
         --cov {posargs}
     pip install -e .[jupyter]
     pytest tests --run-optional jupyter \
         -m jupyter \
         !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
         --cov --cov-append {posargs}
     coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,22 +37,17 @@ skip_install = True
 recreate = True
 deps =
     -r{toxinidir}/test_requirements.txt
-; a separate worker is required in ci due to https://foss.heptapod.net/pypy/pypy/-/issues/3317
-; this seems to cause tox to wait forever
-; remove this when pypy releases the bugfix
 commands =
     pip install -e .[d]
     coverage erase
     pytest tests --run-optional no_python2 \
         --run-optional no_jupyter \
         !ci: --numprocesses auto \
-        ci: --numprocesses 1 \
         --cov {posargs}
     pip install -e .[jupyter]
     pytest tests --run-optional jupyter \
         -m jupyter \
         !ci: --numprocesses auto \
-        ci: --numprocesses 1 \
         --cov --cov-append {posargs}
     coverage report
 


### PR DESCRIPTION
### Description

This adds a minimal set of changes to use black under pypy. It's supposed to be a more acceptable version of https://github.com/psf/black/pull/1172 with the key point being there are zero changes for cpython users. The hope is that this will enough to close https://github.com/psf/black/issues/727

This is a draft - feedback appreciated - I plan to do all of the following (if needed):

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?