### PR TITLE
Declare support for Python 3.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)
+- Declare support for Python 3.10 (#2562)
 
 ## 21.10b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)
-- Declare support for Python 3.10 (#2562)
+- Declare support for Python 3.10 for running Black (#2562)
 
 ## 21.10b0
 

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Python 3.10 final is already tested, just needs the Trove classifier.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [n/a] Add / update tests if necessary?
- [n/a] Add new / update outdated documentation?

Is a changelog entry needed?

---

By the way, Black was first released in March 2018 and took the forward-thinking view to only support Python 3.6, which was the newest release, and therefore Black hasn't needed to drop any EOL versions yet.

Python 3.6 is EOL on 2021-12-23; will Black be dropping 3.6 before the (potentially stable) 2022 Q1 release?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
