### PR TITLE
fix: allow tests to be run from the tests/ directory

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1513,9 +1513,11 @@ class BlackTestCase(BlackBaseTestCase):
         """
         with patch.object(black, "parse_pyproject_toml", return_value={}) as parse:
             args = ["--code", "print"]
-            CliRunner().invoke(black.main, args)
+            # This is the only directory known to contain a pyproject.toml
+            with change_directory(PROJECT_ROOT):
+                CliRunner().invoke(black.main, args)
+                pyproject_path = Path(Path.cwd(), "pyproject.toml").resolve()
 
-            pyproject_path = PROJECT_ROOT / "pyproject.toml"
             assert (
                 len(parse.mock_calls) >= 1
             ), "Expected config parse to be called with the current directory."

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -50,6 +50,7 @@ from tests.util import (
     DATA_DIR,
     DEFAULT_MODE,
     DETERMINISTIC_HEADER,
+    PROJECT_ROOT,
     PY36_VERSIONS,
     THIS_DIR,
     BlackBaseTestCase,
@@ -1514,7 +1515,7 @@ class BlackTestCase(BlackBaseTestCase):
             args = ["--code", "print"]
             CliRunner().invoke(black.main, args)
 
-            pyproject_path = Path(Path().cwd(), "pyproject.toml").resolve()
+            pyproject_path = PROJECT_ROOT / "pyproject.toml"
             assert (
                 len(parse.mock_calls) >= 1
             ), "Expected config parse to be called with the current directory."
@@ -1529,7 +1530,7 @@ class BlackTestCase(BlackBaseTestCase):
         Test that the code option finds the pyproject.toml in the parent directory.
         """
         with patch.object(black, "parse_pyproject_toml", return_value={}) as parse:
-            with change_directory(Path("tests")):
+            with change_directory(THIS_DIR):
                 args = ["--code", "print"]
                 CliRunner().invoke(black.main, args)
 

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -1,4 +1,3 @@
-import pathlib
 from click.testing import CliRunner
 from black.handle_ipynb_magics import jupyter_dependencies_are_installed
 from black import (
@@ -8,11 +7,11 @@ from black import (
     format_file_contents,
     format_file_in_place,
 )
-import os
 import pytest
 from black import Mode
 from _pytest.monkeypatch import MonkeyPatch
 from py.path import local
+from tests.util import DATA_DIR
 
 pytestmark = pytest.mark.jupyter
 pytest.importorskip("IPython", reason="IPython is an optional dependency")
@@ -178,9 +177,7 @@ def test_empty_cell() -> None:
 
 
 def test_entire_notebook_empty_metadata() -> None:
-    with open(
-        os.path.join("tests", "data", "notebook_empty_metadata.ipynb"), "rb"
-    ) as fd:
+    with open(DATA_DIR / "notebook_empty_metadata.ipynb", "rb") as fd:
         content_bytes = fd.read()
     content = content_bytes.decode()
     result = format_file_contents(content, fast=True, mode=JUPYTER_MODE)
@@ -217,9 +214,7 @@ def test_entire_notebook_empty_metadata() -> None:
 
 
 def test_entire_notebook_trailing_newline() -> None:
-    with open(
-        os.path.join("tests", "data", "notebook_trailing_newline.ipynb"), "rb"
-    ) as fd:
+    with open(DATA_DIR / "notebook_trailing_newline.ipynb", "rb") as fd:
         content_bytes = fd.read()
     content = content_bytes.decode()
     result = format_file_contents(content, fast=True, mode=JUPYTER_MODE)
@@ -268,9 +263,7 @@ def test_entire_notebook_trailing_newline() -> None:
 
 
 def test_entire_notebook_no_trailing_newline() -> None:
-    with open(
-        os.path.join("tests", "data", "notebook_no_trailing_newline.ipynb"), "rb"
-    ) as fd:
+    with open(DATA_DIR / "notebook_no_trailing_newline.ipynb", "rb") as fd:
         content_bytes = fd.read()
     content = content_bytes.decode()
     result = format_file_contents(content, fast=True, mode=JUPYTER_MODE)
@@ -319,9 +312,7 @@ def test_entire_notebook_no_trailing_newline() -> None:
 
 
 def test_entire_notebook_without_changes() -> None:
-    with open(
-        os.path.join("tests", "data", "notebook_without_changes.ipynb"), "rb"
-    ) as fd:
+    with open(DATA_DIR / "notebook_without_changes.ipynb", "rb") as fd:
         content_bytes = fd.read()
     content = content_bytes.decode()
     with pytest.raises(NothingChanged):
@@ -329,7 +320,7 @@ def test_entire_notebook_without_changes() -> None:
 
 
 def test_non_python_notebook() -> None:
-    with open(os.path.join("tests", "data", "non_python_notebook.ipynb"), "rb") as fd:
+    with open(DATA_DIR / "non_python_notebook.ipynb", "rb") as fd:
         content_bytes = fd.read()
     content = content_bytes.decode()
     with pytest.raises(NothingChanged):
@@ -343,12 +334,12 @@ def test_empty_string() -> None:
 
 def test_unparseable_notebook() -> None:
     msg = (
-        r"File 'tests[/\\]data[/\\]notebook_which_cant_be_parsed\.ipynb' "
+        rf"File '{DATA_DIR}[/\\]notebook_which_cant_be_parsed.ipynb' "
         r"cannot be parsed as valid Jupyter notebook\."
     )
     with pytest.raises(ValueError, match=msg):
         format_file_in_place(
-            pathlib.Path("tests") / "data/notebook_which_cant_be_parsed.ipynb",
+            DATA_DIR / "notebook_which_cant_be_parsed.ipynb",
             fast=True,
             mode=JUPYTER_MODE,
         )
@@ -358,7 +349,7 @@ def test_ipynb_diff_with_change() -> None:
     result = runner.invoke(
         main,
         [
-            os.path.join("tests", "data", "notebook_trailing_newline.ipynb"),
+            str(DATA_DIR / "notebook_trailing_newline.ipynb"),
             "--diff",
         ],
     )
@@ -370,7 +361,7 @@ def test_ipynb_diff_with_no_change() -> None:
     result = runner.invoke(
         main,
         [
-            os.path.join("tests", "data", "notebook_without_changes.ipynb"),
+            str(DATA_DIR / "notebook_without_changes.ipynb"),
             "--diff",
         ],
     )
@@ -383,7 +374,7 @@ def test_cache_isnt_written_if_no_jupyter_deps_single(
 ) -> None:
     # Check that the cache isn't written to if Jupyter dependencies aren't installed.
     jupyter_dependencies_are_installed.cache_clear()
-    nb = os.path.join("tests", "data", "notebook_trailing_newline.ipynb")
+    nb = DATA_DIR / "notebook_trailing_newline.ipynb"
     tmp_nb = tmpdir / "notebook.ipynb"
     with open(nb) as src, open(tmp_nb, "w") as dst:
         dst.write(src.read())
@@ -405,7 +396,7 @@ def test_cache_isnt_written_if_no_jupyter_deps_dir(
 ) -> None:
     # Check that the cache isn't written to if Jupyter dependencies aren't installed.
     jupyter_dependencies_are_installed.cache_clear()
-    nb = os.path.join("tests", "data", "notebook_trailing_newline.ipynb")
+    nb = DATA_DIR / "notebook_trailing_newline.ipynb"
     tmp_nb = tmpdir / "notebook.ipynb"
     with open(nb) as src, open(tmp_nb, "w") as dst:
         dst.write(src.read())
@@ -423,7 +414,7 @@ def test_cache_isnt_written_if_no_jupyter_deps_dir(
 
 
 def test_ipynb_flag(tmpdir: local) -> None:
-    nb = os.path.join("tests", "data", "notebook_trailing_newline.ipynb")
+    nb = DATA_DIR / "notebook_trailing_newline.ipynb"
     tmp_nb = tmpdir / "notebook.a_file_extension_which_is_definitely_not_ipynb"
     with open(nb) as src, open(tmp_nb, "w") as dst:
         dst.write(src.read())
@@ -440,11 +431,11 @@ def test_ipynb_flag(tmpdir: local) -> None:
 
 
 def test_ipynb_and_pyi_flags() -> None:
-    nb = os.path.join("tests", "data", "notebook_trailing_newline.ipynb")
+    nb = DATA_DIR / "notebook_trailing_newline.ipynb"
     result = runner.invoke(
         main,
         [
-            nb,
+            str(nb),
             "--pyi",
             "--ipynb",
             "--diff",

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -1,3 +1,5 @@
+import re
+
 from click.testing import CliRunner
 from black.handle_ipynb_magics import jupyter_dependencies_are_installed
 from black import (
@@ -334,7 +336,7 @@ def test_empty_string() -> None:
 
 def test_unparseable_notebook() -> None:
     path = DATA_DIR / "notebook_which_cant_be_parsed.ipynb"
-    msg = rf"File '{path}' cannot be parsed as valid Jupyter notebook\."
+    msg = rf"File '{re.escape(str(path))}' cannot be parsed as valid Jupyter notebook\."
     with pytest.raises(ValueError, match=msg):
         format_file_in_place(path, fast=True, mode=JUPYTER_MODE)
 

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -333,16 +333,10 @@ def test_empty_string() -> None:
 
 
 def test_unparseable_notebook() -> None:
-    msg = (
-        rf"File '{DATA_DIR}[/\\]notebook_which_cant_be_parsed.ipynb' "
-        r"cannot be parsed as valid Jupyter notebook\."
-    )
+    path = DATA_DIR / "notebook_which_cant_be_parsed.ipynb"
+    msg = rf"File '{path}' cannot be parsed as valid Jupyter notebook\."
     with pytest.raises(ValueError, match=msg):
-        format_file_in_place(
-            DATA_DIR / "notebook_which_cant_be_parsed.ipynb",
-            fast=True,
-            mode=JUPYTER_MODE,
-        )
+        format_file_in_place(path, fast=True, mode=JUPYTER_MODE)
 
 
 def test_ipynb_diff_with_change() -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Fixes the issues described [on Discord](https://canary.discord.com/channels/267624335836053506/846434317021741086/903457339976351744).

At the moment, tests break when they're run from a directory that is not the project root. Specifically, `tests/`. This makes changes to use the `PROJECT_ROOT`, `THIS_DIR`, and `DATA_DIR` constants defined in `tests.util` so that tests will be runnable from multiple locations.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary? (not necessary)
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (not necessary afaik)

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->