### PR TITLE
Pin regex in docker to 2021.10.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
+- Pin regex module to 2021.10.8 as it has arm wheels available (#2579)
 
 ## 21.9b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,8 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
-- Pin regex module to 2021.10.8 as it has arm wheels available (#2579)
+- Pin regex module to 2021.10.8 in our docker file as it has arm wheels available
+  (#2579)
 
 ## 21.9b0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3-slim
 
+# TODO: Remove regex version pin once we get newer arm wheels
 RUN mkdir /src
 COPY . /src/
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     && apt update && apt install -y git \
     && cd /src \
+    && pip install --no-cache-dir regex==2021.10.8 \
     && pip install --no-cache-dir .[colorama,d] \
     && rm -rf /src \
     && apt remove -y git \


### PR DESCRIPTION
- This is due to 2021.10.8 having arm wheels and newer versions not

I will go see if I can help restore arm build @ https://bitbucket.org/mrabarnett/mrab-regex/issues/399/missing-wheel-for-macosx-and-the-new-m1 soon.