### PR TITLE
 install build-essential to compile dependencies and use multi-stage build 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,6 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
-- Pin regex module to 2021.10.8 in our docker file as it has arm wheels available
-  (#2579)
 
 ## 21.9b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,8 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
-- Install build tools in docker file and use multi-stage build to keep the
-  image size down (#2579)
+- Install build tools in docker file and use multi-stage build to keep the image size
+  down (#2582)
 
 ## 21.9b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 ### Integrations
 
 - Allow to pass `target_version` in the vim plugin (#1319)
+- Install build tools in docker file and use multi-stage build to keep the
+  image size down (#2579)
 
 ## 21.9b0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM python:3-slim
+FROM python:3-slim AS builder
 
-# TODO: Remove regex version pin once we get newer arm wheels
 RUN mkdir /src
 COPY . /src/
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && apt update && apt install -y git \
+    # Install build tools to compile dependencies that don't have prebuilt wheels
+    && apt update && apt install -y git build-essential \
     && cd /src \
-    && pip install --no-cache-dir regex==2021.10.8 \
-    && pip install --no-cache-dir .[colorama,d] \
-    && rm -rf /src \
-    && apt remove -y git \
-    && apt autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && pip install --user --no-cache-dir .[colorama,d]
+
+FROM python:3-slim
+
+# copy only Python packages to limit the image size
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 
 CMD ["black"]


### PR DESCRIPTION
- Install build-essential to avoid build issues like #2568 when dependencies don't have prebuilt wheels available
- Removed `regex` pinned version: not necessary as we can build from source if wheels are missing
- Use multi-stage build instead of trying to purge packages and cache from the image
  Copying `/root/.local/` installs only black's built Python dependencies (< 20 MB).
  So the image is barely larger than python:3-slim base image

Tested locally and in my fork GitHub Actions: https://github.com/vbarbaresi/black/runs/4062490765?check_suite_focus=true