### PR TITLE
Improve Python 2 only syntax detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## _Unreleased_
+
+### _Black_
+
+- Warn about Python 2 deprecation in more cases by improving Python 2 only syntax
+  detection (#2592)
+
 ## 21.10b0
 
 ### _Black_

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -44,6 +44,11 @@ class Feature(Enum):
     # temporary for Python 2 deprecation
     PRINT_STMT = 200
     EXEC_STMT = 201
+    AUTOMATIC_PARAMETER_UNPACKING = 202
+    COMMA_STYLE_EXCEPT = 203
+    COMMA_STYLE_RAISE = 204
+    LONG_INT_LITERAL = 205
+    BACKQUOTE_REPR = 206
 
 
 VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
@@ -51,6 +56,11 @@ VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
         Feature.ASYNC_IDENTIFIERS,
         Feature.PRINT_STMT,
         Feature.EXEC_STMT,
+        Feature.AUTOMATIC_PARAMETER_UNPACKING,
+        Feature.COMMA_STYLE_EXCEPT,
+        Feature.COMMA_STYLE_RAISE,
+        Feature.LONG_INT_LITERAL,
+        Feature.BACKQUOTE_REPR,
     },
     TargetVersion.PY33: {Feature.UNICODE_LITERALS, Feature.ASYNC_IDENTIFIERS},
     TargetVersion.PY34: {Feature.UNICODE_LITERALS, Feature.ASYNC_IDENTIFIERS},

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -48,7 +48,8 @@ class Feature(Enum):
     COMMA_STYLE_EXCEPT = 203
     COMMA_STYLE_RAISE = 204
     LONG_INT_LITERAL = 205
-    BACKQUOTE_REPR = 206
+    OCTAL_INT_LITERAL = 206
+    BACKQUOTE_REPR = 207
 
 
 VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
@@ -60,6 +61,7 @@ VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
         Feature.COMMA_STYLE_EXCEPT,
         Feature.COMMA_STYLE_RAISE,
         Feature.LONG_INT_LITERAL,
+        Feature.OCTAL_INT_LITERAL,
         Feature.BACKQUOTE_REPR,
     },
     TargetVersion.PY33: {Feature.UNICODE_LITERALS, Feature.ASYNC_IDENTIFIERS},

--- a/src/blib2to3/pgen2/token.py
+++ b/src/blib2to3/pgen2/token.py
@@ -74,9 +74,6 @@ ERRORTOKEN: Final = 58
 COLONEQUAL: Final = 59
 N_TOKENS: Final = 60
 NT_OFFSET: Final = 256
-# temporary for Python 2 deprecation
-PRINT_STMT: Final = 316
-EXEC_STMT: Final = 288
 # --end constants--
 
 tok_name: Final[Dict[int, str]] = {}

--- a/tests/data/python2_detection.py
+++ b/tests/data/python2_detection.py
@@ -30,6 +30,14 @@ raise RuntimeError, "I feel like crashing today :p"
 
 10L
 
+###
+
+10l
+
+###
+
+0123
+
 # output
 
 print("hello python three!")
@@ -58,9 +66,25 @@ raise RuntimeError(make_msg(1, 2))
 
 ###
 
+raise RuntimeError("boom!",)
+
+###
+
 def set_position(x, y, value):
     pass
 
 ###
 
 10
+
+###
+
+0
+
+###
+
+000
+
+###
+
+0o12

--- a/tests/data/python2_detection.py
+++ b/tests/data/python2_detection.py
@@ -1,0 +1,66 @@
+# This uses a similar construction to the decorators.py test data file FYI.
+
+print "hello, world!"
+
+###
+
+exec "print('hello, world!')"
+
+###
+
+def set_position((x, y), value):
+    pass
+
+###
+
+try:
+    pass
+except Exception, err:
+    pass
+
+###
+
+raise RuntimeError, "I feel like crashing today :p"
+
+###
+
+`wow_these_really_did_exist`
+
+###
+
+10L
+
+# output
+
+print("hello python three!")
+
+###
+
+exec("I'm not sure if you can use exec like this but that's not important here!")
+
+###
+
+try:
+    pass
+except make_exception(1, 2):
+    pass
+
+###
+
+try:
+    pass
+except Exception as err:
+    pass
+
+###
+
+raise RuntimeError(make_msg(1, 2))
+
+###
+
+def set_position(x, y, value):
+    pass
+
+###
+
+10

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2017,6 +2017,7 @@ class TestFileCollection:
         )
 
 
+@pytest.mark.python2
 @pytest.mark.parametrize("explicit", [True, False], ids=["explicit", "autodetection"])
 def test_python_2_deprecation_with_target_version(explicit: bool) -> None:
     args = [
@@ -2030,6 +2031,18 @@ def test_python_2_deprecation_with_target_version(explicit: bool) -> None:
     with cache_dir():
         result = BlackRunner().invoke(black.main, args)
     assert "DEPRECATION: Python 2 support will be removed" in result.stderr
+
+
+@pytest.mark.python2
+def test_python_2_deprecation_autodetection_extended() -> None:
+    # this test has a similar construction to test_get_features_used_decorator
+    python2, non_python2 = read_data("python2_detection")
+    for python2_case in python2.split("###"):
+        node = black.lib2to3_parse(python2_case)
+        assert black.detect_target_versions(node) == {TargetVersion.PY27}
+    for non_python2_case in non_python2.split("###"):
+        node = black.lib2to3_parse(non_python2_case)
+        assert black.detect_target_versions(node) != {TargetVersion.PY27}
 
 
 with open(black.__file__, "r", encoding="utf-8") as _bf:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2039,10 +2039,12 @@ def test_python_2_deprecation_autodetection_extended() -> None:
     python2, non_python2 = read_data("python2_detection")
     for python2_case in python2.split("###"):
         node = black.lib2to3_parse(python2_case)
-        assert black.detect_target_versions(node) == {TargetVersion.PY27}
+        assert black.detect_target_versions(node) == {TargetVersion.PY27}, python2_case
     for non_python2_case in non_python2.split("###"):
         node = black.lib2to3_parse(non_python2_case)
-        assert black.detect_target_versions(node) != {TargetVersion.PY27}
+        assert black.detect_target_versions(node) != {
+            TargetVersion.PY27
+        }, non_python2_case
 
 
 with open(black.__file__, "r", encoding="utf-8") as _bf:


### PR DESCRIPTION
### Description

First of all this fixes a mistake I made in Python 2 deprecation PR
using token.* to check for print/exec statements. Turns out that
for nodes with a type value higher than 256 its numeric type isn't
guaranteed to be constant. Using syms.* instead fixes this.

Also add support for the following cases:

    print "hello, world!"

    exec "print('hello, world!')"

    def set_position((x, y), value):
        pass

    try:
        pass
    except Exception, err:
        pass

    raise RuntimeError, "I feel like crashing today :p"

    `wow_these_really_did_exist`

    10L

This should also fix the Python 2 related failures in #2586.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> /na