### PR TITLE
black/parser: support as-exprs within call args

### DIFF
--- a/src/blib2to3/Grammar.txt
+++ b/src/blib2to3/Grammar.txt
@@ -186,6 +186,7 @@ arglist: argument (',' argument)* [',']
 # that precede iterable unpackings are blocked; etc.
 argument: ( test [comp_for] |
             test ':=' test |
+            test 'as' test |
             test '=' test |
 	    '**' test |
             '*' test )

--- a/tests/data/pattern_matching_extras.py
+++ b/tests/data/pattern_matching_extras.py
@@ -1,0 +1,9 @@
+match something:
+    case [a as b]:
+        print(b)
+    case [a as b, c, d, e as f]:
+        print(f)
+    case Point(a as b):
+        print(b)
+    case Point(int() as x, int() as y):
+        print(x, y)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -73,6 +73,7 @@ EXPERIMENTAL_STRING_PROCESSING_CASES = [
 PY310_CASES = [
     "pattern_matching_simple",
     "pattern_matching_complex",
+    "pattern_matching_extras",
     "parenthesized_context_managers",
 ]
 


### PR DESCRIPTION
I apparently forget to `as`-exprs when they happen inside call arguments, which have their own special mini-grammar to support stuff like walrus (higher precedence operators). This patch should resolve that issue.