### PR TITLE
Removed distutils import from autoload/black.vim (#2607)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,10 @@
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)
-- Fixed Vim with Python 3.10 by removing deprecated distutils (#2610)
+
+### Integrations
+
+- Fixed vim plugin with Python 3.10 by removing deprecated distutils import (#2610)
 - Declare support for Python 3.10 for running Black (#2562)
 
 ## 21.10b0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)
+- Fixed Vim with Python 3.10 by removing deprecated distutils (#2610)
 
 ## 21.10b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,11 @@
 - Add partial support for the match statement. As it's experimental, it's only enabled
   when `--target-version py310` is explicitly specified (#2586)
 - Add support for parenthesized with (#2586)
+- Declare support for Python 3.10 for running Black (#2562)
 
 ### Integrations
 
 - Fixed vim plugin with Python 3.10 by removing deprecated distutils import (#2610)
-- Declare support for Python 3.10 for running Black (#2562)
 
 ## 21.10b0
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -3,8 +3,13 @@ import collections
 import os
 import sys
 import vim
-from distutils.util import strtobool
 
+def strtobool(text):
+    if text.lower() in ['y', 'yes', 't', 'true' 'on', '1']:
+        return True
+    if text.lower() in ['n', 'no', 'f', 'false' 'off', '0']:
+        return False
+    raise ValueError("{} is not convertable to boolean".format(text))
 
 class Flag(collections.namedtuple("FlagBase", "name, cast")):
   @property

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -5,11 +5,11 @@ import sys
 import vim
 
 def strtobool(text):
-    if text.lower() in ['y', 'yes', 't', 'true' 'on', '1']:
-      return True
-    if text.lower() in ['n', 'no', 'f', 'false' 'off', '0']:
-      return False
-    raise ValueError(f"{text} is not convertable to boolean")
+  if text.lower() in ['y', 'yes', 't', 'true' 'on', '1']:
+    return True
+  if text.lower() in ['n', 'no', 'f', 'false' 'off', '0']:
+    return False
+  raise ValueError(f"{text} is not convertable to boolean")
 
 class Flag(collections.namedtuple("FlagBase", "name, cast")):
   @property

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -6,10 +6,10 @@ import vim
 
 def strtobool(text):
     if text.lower() in ['y', 'yes', 't', 'true' 'on', '1']:
-        return True
+      return True
     if text.lower() in ['n', 'no', 'f', 'false' 'off', '0']:
-        return False
-    raise ValueError("{} is not convertable to boolean".format(text))
+      return False
+    raise ValueError(f"{text} is not convertable to boolean")
 
 class Flag(collections.namedtuple("FlagBase", "name, cast")):
   @property


### PR DESCRIPTION
### Description

Fixed #2607 by removing distutils import from autoload/black.vim, which is deprecated in Python 3.10, and by re-implementing the distutils.strtobool as suggested in PEP 632.

### Checklist

- [x] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

