### PR TITLE
Fix 3.10's supported features

### DIFF
--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -111,6 +111,15 @@ VERSION_TO_FEATURES: Dict[TargetVersion, Set[Feature]] = {
         Feature.POS_ONLY_ARGUMENTS,
     },
     TargetVersion.PY310: {
+        Feature.UNICODE_LITERALS,
+        Feature.F_STRINGS,
+        Feature.NUMERIC_UNDERSCORES,
+        Feature.TRAILING_COMMA_IN_CALL,
+        Feature.TRAILING_COMMA_IN_DEF,
+        Feature.ASYNC_KEYWORDS,
+        Feature.ASSIGNMENT_EXPRESSIONS,
+        Feature.RELAXED_DECORATORS,
+        Feature.POS_ONLY_ARGUMENTS,
         Feature.PATTERN_MATCHING,
     },
 }


### PR DESCRIPTION
### Description

To avoid this situation:

```diff
~/programming/oss/black on main [$?⇡] via Python v3.8.5 (black) 
❯ black test.py --diff --color -q
--- test.py    2021-11-15 21:31:38.652666 +0000
+++ test.py    2021-11-15 21:32:00.444694 +0000
@@ -1,2 +1,6 @@
-def daylily(this_is_a_long_parameter_name_because_i_am_testing, something, **related_to_target_version_py310):
+def daylily(
+    this_is_a_long_parameter_name_because_i_am_testing,
+    something,
+    **related_to_target_version_py310,
+):
     pass

~/programming/oss/black on main [$?⇡] via Python v3.8.5 (black) took 427ms 
❯ black test.py --diff --color -q -t py310
--- test.py    2021-11-15 21:31:38.652666 +0000
+++ test.py    2021-11-15 21:32:04.028799 +0000
@@ -1,2 +1,6 @@
-def daylily(this_is_a_long_parameter_name_because_i_am_testing, something, **related_to_target_version_py310):
+def daylily(
+    this_is_a_long_parameter_name_because_i_am_testing,
+    something,
+    **related_to_target_version_py310
+):
     pass
```

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
