### PR TITLE
Return `NothingChanged` if non-Python cell magic is detected, to avoid tokenize error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 ### _Black_
 
-- Fixed non-Python cell magics sometimes failing due to indentation (#2630)
+- Cell magics are now only processed if they are known Python cell magics. Earlier, all
+  cell magics were tokenized, leading to possible indentation errors e.g. with
+  `%%writefile`. (#2630)
 
 ## 21.11b1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### _Black_
+
+- Fixed non-Python cell magics sometimes failing due to indentation (#2630)
+
 ## 21.11b1
 
 ### _Black_

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,6 +47,7 @@ _Black_ is timid about formatting Jupyter Notebooks. Cells containing any of the
 following will not be formatted:
 
 - automagics (e.g. `pip install black`)
+- non-Python cell magics (e.g. `%%writeline`)
 - multiline magics, e.g.:
 
   ```python

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -57,7 +57,7 @@ from black.handle_ipynb_magics import (
     remove_trailing_semicolon,
     put_trailing_semicolon_back,
     TRANSFORMED_MAGICS,
-    NON_PYTHON_CELL_MAGICS,
+    PYTHON_CELL_MAGICS,
     jupyter_dependencies_are_installed,
 )
 
@@ -962,7 +962,9 @@ def validate_cell(src: str) -> None:
     """
     if any(transformed_magic in src for transformed_magic in TRANSFORMED_MAGICS):
         raise NothingChanged
-    if any("%%" + cell_magic in src for cell_magic in NON_PYTHON_CELL_MAGICS):
+    if src[:2] == "%%" and src.split()[0] not in (
+        "%%" + magic for magic in PYTHON_CELL_MAGICS
+    ):
         raise NothingChanged
 
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -962,9 +962,7 @@ def validate_cell(src: str) -> None:
     """
     if any(transformed_magic in src for transformed_magic in TRANSFORMED_MAGICS):
         raise NothingChanged
-    if src[:2] == "%%" and src.split()[0] not in (
-        "%%" + magic for magic in PYTHON_CELL_MAGICS
-    ):
+    if src[:2] == "%%" and src.split()[0][2:] not in PYTHON_CELL_MAGICS:
         raise NothingChanged
 
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -945,7 +945,7 @@ def format_file_contents(src_contents: str, *, fast: bool, mode: Mode) -> FileCo
 
 def validate_cell(src: str) -> None:
     """Check that cell does not already contain TransformerManager transformations,
-    or cell magics, which might cause TransformerManager to break.
+    or cell magics, which might cause tokenizer_rt to break because of indentations.
 
     If a cell contains ``!ls``, then it'll be transformed to
     ``get_ipython().system('ls')``. However, if the cell originally contained

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -57,6 +57,7 @@ from black.handle_ipynb_magics import (
     remove_trailing_semicolon,
     put_trailing_semicolon_back,
     TRANSFORMED_MAGICS,
+    NON_PYTHON_CELL_MAGICS,
     jupyter_dependencies_are_installed,
 )
 
@@ -943,7 +944,7 @@ def format_file_contents(src_contents: str, *, fast: bool, mode: Mode) -> FileCo
 
 
 def validate_cell(src: str) -> None:
-    """Check that cell does not already contain TransformerManager transformations.
+    """Check that cell does not already contain TransformerManager transformations, or cell magics, which might cause TransformerManager to break.
 
     If a cell contains ``!ls``, then it'll be transformed to
     ``get_ipython().system('ls')``. However, if the cell originally contained
@@ -959,6 +960,8 @@ def validate_cell(src: str) -> None:
     """
     if any(transformed_magic in src for transformed_magic in TRANSFORMED_MAGICS):
         raise NothingChanged
+    elif any('%%' + cell_magic in src for cell_magic in NON_PYTHON_CELL_MAGICS):
+        raise NothingChanged        
 
 
 def format_cell(src: str, *, fast: bool, mode: Mode) -> str:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -944,7 +944,8 @@ def format_file_contents(src_contents: str, *, fast: bool, mode: Mode) -> FileCo
 
 
 def validate_cell(src: str) -> None:
-    """Check that cell does not already contain TransformerManager transformations, or cell magics, which might cause TransformerManager to break.
+    """Check that cell does not already contain TransformerManager transformations,
+    or cell magics, which might cause TransformerManager to break.
 
     If a cell contains ``!ls``, then it'll be transformed to
     ``get_ipython().system('ls')``. However, if the cell originally contained
@@ -960,8 +961,8 @@ def validate_cell(src: str) -> None:
     """
     if any(transformed_magic in src for transformed_magic in TRANSFORMED_MAGICS):
         raise NothingChanged
-    elif any('%%' + cell_magic in src for cell_magic in NON_PYTHON_CELL_MAGICS):
-        raise NothingChanged        
+    if any("%%" + cell_magic in src for cell_magic in NON_PYTHON_CELL_MAGICS):
+        raise NothingChanged
 
 
 def format_cell(src: str, *, fast: bool, mode: Mode) -> str:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -945,7 +945,8 @@ def format_file_contents(src_contents: str, *, fast: bool, mode: Mode) -> FileCo
 
 def validate_cell(src: str) -> None:
     """Check that cell does not already contain TransformerManager transformations,
-    or cell magics, which might cause tokenizer_rt to break because of indentations.
+    or non-Python cell magics, which might cause tokenizer_rt to break because of
+    indentations.
 
     If a cell contains ``!ls``, then it'll be transformed to
     ``get_ipython().system('ls')``. However, if the cell originally contained

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -42,6 +42,9 @@ PYTHON_CELL_MAGICS = frozenset(
         "capture",
         "prun",
         "pypy",
+        "python",
+        "python2",
+        "python3",
         "time",
         "timeit",
     )

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -37,20 +37,13 @@ TOKENS_TO_IGNORE = frozenset(
         "ESCAPED_NL",
     )
 )
-NON_PYTHON_CELL_MAGICS = frozenset(
+PYTHON_CELL_MAGICS = frozenset(
     (
-        "bash",
-        "html",
-        "javascript",
-        "js",
-        "latex",
-        "markdown",
-        "perl",
-        "ruby",
-        "script",
-        "sh",
-        "svg",
-        "writefile",
+        "capture",
+        "prun",
+        "pypy",
+        "time",
+        "timeit",
     )
 )
 TOKEN_HEX = secrets.token_hex
@@ -230,8 +223,6 @@ def replace_cell_magics(src: str) -> Tuple[str, List[Replacement]]:
     cell_magic_finder.visit(tree)
     if cell_magic_finder.cell_magic is None:
         return src, replacements
-    if cell_magic_finder.cell_magic.name in NON_PYTHON_CELL_MAGICS:
-        raise NothingChanged
     header = cell_magic_finder.cell_magic.header
     mask = get_token(src, header)
     replacements.append(Replacement(mask=mask, src=header))

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -43,7 +43,6 @@ PYTHON_CELL_MAGICS = frozenset(
         "prun",
         "pypy",
         "python",
-        "python2",
         "python3",
         "time",
         "timeit",

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -129,9 +129,9 @@ def test_magic_noop() -> None:
 
 
 def test_cell_magic_with_magic() -> None:
-    src = "%%t -n1\nls =!ls"
+    src = "%%timeit -n1\nls =!ls"
     result = format_cell(src, fast=True, mode=JUPYTER_MODE)
-    expected = "%%t -n1\nls = !ls"
+    expected = "%%timeit -n1\nls = !ls"
     assert result == expected
 
 

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -102,6 +102,7 @@ def test_magic(src: str, expected: str) -> None:
     (
         "%%bash\n2+2",
         "%%html --isolated\n2+2",
+        "%%writefile e.txt\n  meh\n meh",
     ),
 )
 def test_non_python_magics(src: str) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Fixes https://github.com/psf/black/issues/2627 , a non-Python cell magic such as `%%writeline` can legitimately contain "incorrect" indentation, however this causes `tokenize-rt` to return an error. To avoid this, `validate_cell` should early detect cell magics (just like it detects `TransformerManager` transformations).

Test added too, in the shape of a "badly indented" `%%writefile` within `test_non_python_magics`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [X] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
