### PR TITLE
Fix process pool fallback on Python 3.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### _Black_
 
-- Fixed Python 3.10 support on platforms without ProcessPoolExecutor
+- Fixed Python 3.10 support on platforms without ProcessPoolExecutor (#2631)
 
 ## 21.11b1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### _Black_
+
+- Fixed Python 3.10 support on platforms without ProcessPoolExecutor
+
 ## 21.11b1
 
 ### _Black_

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -687,7 +687,7 @@ def reformat_many(
         worker_count = min(worker_count, 60)
     try:
         executor = ProcessPoolExecutor(max_workers=worker_count)
-    except (ImportError, OSError):
+    except (ImportError, NotImplementedError, OSError):
         # we arrive here if the underlying system does not support multi-processing
         # like in AWS Lambda or Termux, in which case we gracefully fallback to
         # a ThreadPoolExecutor with just a single worker (more workers would not do us


### PR DESCRIPTION
### Description

In Python 3.10 the exception generated by creating a process pool on a Python build that doesn't support this is now `NotImplementedError`.

Here is the stack trace I received on Python 3.10 on Termux / Android 11:

```
  File "/data/data/com.termux/files/home/my-project/.venv/lib/python3.10/site-packages/black/__init__.py", line 624, in reformat_many
    executor = ProcessPoolExecutor(max_workers=worker_count)
  File "/data/data/com.termux/files/usr/lib/python3.10/concurrent/futures/process.py", line 594, in __init__
    _check_system_limits()
  File "/data/data/com.termux/files/usr/lib/python3.10/concurrent/futures/process.py", line 542, in _check_system_limits
    raise NotImplementedError(_system_limited)
NotImplementedError: This Python build lacks multiprocessing.synchronize, usually due to named semaphores being unavailable on this platform.
```

### Checklist

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
  - We could parameterize the test that injects OSError into ProcessPoolExecutor but at that point we're just repeating code. 
- [X] Add new / update outdated documentation?
  - n/a