### PR TITLE
README: Add KeepTruckin to the list of orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Poetry, PyPA applications (Warehouse, Bandersnatch, Pipenv, virtualenv), pandas,
 Twisted, LocalStack, every Datadog Agent Integration, Home Assistant, Zulip, Kedro, and
 many more.
 
-The following organizations use _Black_: Facebook, Dropbox, Mozilla, Quora, Duolingo,
+The following organizations use _Black_: Facebook, Dropbox, KeepTruckin, Mozilla, Quora, Duolingo,
 QuantumBlack, Tesla.
 
 Are we missing anyone? Let us know.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Poetry, PyPA applications (Warehouse, Bandersnatch, Pipenv, virtualenv), pandas,
 Twisted, LocalStack, every Datadog Agent Integration, Home Assistant, Zulip, Kedro, and
 many more.
 
-The following organizations use _Black_: Facebook, Dropbox, KeepTruckin, Mozilla, Quora, Duolingo,
-QuantumBlack, Tesla.
+The following organizations use _Black_: Facebook, Dropbox, KeepTruckin, Mozilla, Quora,
+Duolingo, QuantumBlack, Tesla.
 
 Are we missing anyone? Let us know.
 


### PR DESCRIPTION
### Description

At KT, we used Black to format all Python code in our Mono-repo. Added it to the list of orgs using Black.
