### PR TITLE
Improve black startup to format a single file. Fixes #2564

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ src/_black_version.py
 .hypothesis/
 venv/
 .ipynb_checkpoints/
+/.mypy_cache/
+.project
+.pydevproject
+/.pytest_cache/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Fixed `match` statements with open sequence subjects, like `match a, b:` (#2639)
 - Fixed assignment to environment variables in Jupyter Notebooks (#2642)
 - Add `flake8-simplify` and `flake8-comprehensions` plugins (#2653)
+- Faster startup when formatting a single file (#2656)
 
 ## 21.11b1
 

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -1,3 +1,7 @@
+"""
+Note: this module should only be imported if support for formatting multiple
+files is needed.
+"""
 import asyncio
 import logging
 import sys

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -1,3 +1,10 @@
+import typing
+
+if typing.TYPE_CHECKING:
+    # Don't import the pathspec module unless really needed (it's only needed
+    # when listing contents to format from a directory).
+    from pathspec import PathSpec
+
 from functools import lru_cache
 import io
 import os
@@ -18,8 +25,6 @@ from typing import (
 )
 
 from mypy_extensions import mypyc_attr
-from pathspec import PathSpec
-from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 import tomli
 
 from black.output import err
@@ -118,8 +123,11 @@ def find_user_pyproject_toml() -> Path:
 
 
 @lru_cache()
-def get_gitignore(root: Path) -> PathSpec:
+def get_gitignore(root: Path) -> "PathSpec":
     """Return a PathSpec matching gitignore content if present."""
+    from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
+    from pathspec import PathSpec
+
     gitignore = root / ".gitignore"
     lines: List[str] = []
     if gitignore.is_file():
@@ -172,7 +180,7 @@ def gen_python_files(
     extend_exclude: Optional[Pattern[str]],
     force_exclude: Optional[Pattern[str]],
     report: Report,
-    gitignore: Optional[PathSpec],
+    gitignore: Optional["PathSpec"],
     *,
     verbose: bool,
     quiet: bool,

--- a/src/black/reformat_many.py
+++ b/src/black/reformat_many.py
@@ -1,0 +1,148 @@
+"""
+Note: this module should only be imported if support for formatting multiple
+files is needed.
+"""
+import asyncio
+import signal
+import sys
+import typing
+
+from multiprocessing import Manager
+from concurrent.futures import Executor, ThreadPoolExecutor, ProcessPoolExecutor
+from mypy_extensions import mypyc_attr
+from pathlib import Path
+from typing import Set, Optional
+
+import black
+
+from black import WriteBack, format_file_in_place, DEFAULT_WORKERS
+from black.cache import Cache, read_cache, filter_cached, write_cache
+from black.concurrency import cancel, shutdown, maybe_install_uvloop
+from black.mode import Mode
+from black.report import Changed
+
+if typing.TYPE_CHECKING:
+    from black.report import Report
+
+
+async def schedule_formatting(
+    sources: Set[Path],
+    fast: bool,
+    write_back: WriteBack,
+    mode: Mode,
+    report: "Report",
+    loop: asyncio.AbstractEventLoop,
+    executor: Executor,
+) -> None:
+    """Run formatting of `sources` in parallel using the provided `executor`.
+
+    (Use ProcessPoolExecutors for actual parallelism.)
+
+    `write_back`, `fast`, and `mode` options are passed to
+    :func:`format_file_in_place`.
+    """
+    cache: Cache = {}
+    if write_back not in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
+        cache = read_cache(mode)
+        sources, cached = filter_cached(cache, sources)
+        for src in sorted(cached):
+            report.done(src, Changed.CACHED)
+    if not sources:
+        return
+
+    cancelled = []
+    sources_to_cache = []
+    lock = None
+    if write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
+        # For diff output, we need locks to ensure we don't interleave output
+        # from different processes.
+        manager = Manager()
+        lock = manager.Lock()
+    tasks = {
+        asyncio.ensure_future(
+            loop.run_in_executor(
+                executor, format_file_in_place, src, fast, mode, write_back, lock
+            )
+        ): src
+        for src in sorted(sources)
+    }
+    pending = tasks.keys()
+    try:
+        loop.add_signal_handler(signal.SIGINT, cancel, pending)
+        loop.add_signal_handler(signal.SIGTERM, cancel, pending)
+    except NotImplementedError:
+        # There are no good alternatives for these on Windows.
+        pass
+    while pending:
+        done, _ = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            src = tasks.pop(task)
+            if task.cancelled():
+                cancelled.append(task)
+            elif task.exception():
+                report.failed(src, str(task.exception()))
+            else:
+                changed = Changed.YES if task.result() else Changed.NO
+                # If the file was written back or was successfully checked as
+                # well-formatted, store this information in the cache.
+                if write_back is WriteBack.YES or (
+                    write_back is WriteBack.CHECK and changed is Changed.NO
+                ):
+                    sources_to_cache.append(src)
+                report.done(src, changed)
+    if cancelled:
+        if sys.version_info >= (3, 7):
+            await asyncio.gather(*cancelled, return_exceptions=True)
+        else:
+            await asyncio.gather(*cancelled, loop=loop, return_exceptions=True)
+    if sources_to_cache:
+        write_cache(cache, sources_to_cache, mode)
+
+
+# diff-shades depends on being to monkeypatch this function to operate. I know it's
+# not ideal, but this shouldn't cause any issues ... hopefully. ~ichard26
+@mypyc_attr(patchable=True)
+def reformat_many(
+    sources: Set[Path],
+    fast: bool,
+    write_back: WriteBack,
+    mode: Mode,
+    report: "Report",
+    workers: Optional[int],
+) -> None:
+    """Reformat multiple files using a ProcessPoolExecutor."""
+    if black.__BLACK_MAIN_CALLED__:
+        maybe_install_uvloop()
+
+    executor: Executor
+    loop = asyncio.get_event_loop()
+    worker_count = workers if workers is not None else DEFAULT_WORKERS
+    if sys.platform == "win32":
+        # Work around https://bugs.python.org/issue26903
+        assert worker_count is not None
+        worker_count = min(worker_count, 60)
+    try:
+        executor = ProcessPoolExecutor(max_workers=worker_count)
+    except (ImportError, NotImplementedError, OSError):
+        # we arrive here if the underlying system does not support multi-processing
+        # like in AWS Lambda or Termux, in which case we gracefully fallback to
+        # a ThreadPoolExecutor with just a single worker (more workers would not do us
+        # any good due to the Global Interpreter Lock)
+        executor = ThreadPoolExecutor(max_workers=1)
+
+    try:
+        loop.run_until_complete(
+            schedule_formatting(
+                sources=sources,
+                fast=fast,
+                write_back=write_back,
+                mode=mode,
+                report=report,
+                loop=loop,
+                executor=executor,
+            )
+        )
+    finally:
+        shutdown(loop)
+        if executor is not None:
+            executor.shutdown()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Make the startup of black faster when formatting a single file by importing less modules and skipping loading of `.gitignore`.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

With this patch the time to format one file went from a baseline of:
(min /max time from doing many runs on my machine)
`0.29s -> 0.47s` to `0.17s -> 0.32s`

-- Note that this includes the time to format too, not just the startup time. Also, this depends a lot on the target machine (slower machines will probably have more to gain)... in my machine I'd say there's around a 50% increase in the startup speed. There's still room for improvement, but I'd say that the low-hanging fruits have been taken care of.

The number of imported modules for doing a run in this case went from `268` to `202`.

It went something as:

Modules imported (baseline):
268

Without asyncio:
235

Without concurrent.futures
222

Without pathspec:
214

Without multiprocessing:
202



<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
