### PR TITLE
Reorganize changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,24 +4,32 @@
 
 ### _Black_
 
-- Point users to using `--target-version py310` if we detect 3.10-only syntax (#2668)
+- Fix determination of f-string expression spans (#2654)
+- Fix bad formatting of error messages about EOF in multi-line statements (#2343)
+- Functions and classes in blocks now have more consistent surrounding spacing (#2472)
+
+#### Jupyter Notebook support
+
 - Cell magics are now only processed if they are known Python cell magics. Earlier, all
   cell magics were tokenized, leading to possible indentation errors e.g. with
   `%%writefile`. (#2630)
-- Fix Python 3.10 support on platforms without ProcessPoolExecutor (#2631)
-- Remove dependency on `regex` (#2644) (#2663)
+- Fix assignment to environment variables in Jupyter Notebooks (#2642)
+
+#### Python 3.10 support
+
+- Point users to using `--target-version py310` if we detect 3.10-only syntax (#2668)
 - Fix `match` statements with open sequence subjects, like `match a, b:` or
   `match a, *b:` (#2639) (#2659)
 - Fix `match`/`case` statements that contain `match`/`case` soft keywords multiple
   times, like `match re.match()` (#2661)
 - Fix `case` statements with an inline body (#2665)
 - Fix styling of starred expressions inside `match` subject (#2667)
-- Fix assignment to environment variables in Jupyter Notebooks (#2642)
-- Add `flake8-simplify` and `flake8-comprehensions` plugins (#2653)
-- Fix determination of f-string expression spans (#2654)
 - Fix parser error location on invalid syntax in a `match` statement (#2649)
-- Fix bad formatting of error messages about EOF in multi-line statements (#2343)
-- Functions and classes in blocks now have more consistent surrounding spacing (#2472)
+- Fix Python 3.10 support on platforms without ProcessPoolExecutor (#2631)
+
+### Packaging
+
+- Remove dependency on `regex` (#2644) (#2663)
 
 ## 21.11b1
 


### PR DESCRIPTION
I believe it would be useful to split up the long list of changes a bit more.

Specific changes:
- Removed the entry for new flake8 plugins; this is purely internal and not of interest to users
- Put regex in the packaging section
- New section for Jupyter Notebook
- New section for Python 3.10, mostly match/case stuff

Happy to change this though if others have a different opinion.