### PR TITLE
perf: drop the initial stack copy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 - Fix styling of starred expressions inside `match` subject (#2667)
 - Fix parser error location on invalid syntax in a `match` statement (#2649)
 - Fix Python 3.10 support on platforms without ProcessPoolExecutor (#2631)
+- Improve parsing performance on code that uses `match` under `--target-version py310`
+  up to ~50% (#2670)
 
 ### Packaging
 

--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -53,7 +53,7 @@ class Recorder:
         self.context = context  # not really matter
 
         self._dead_ilabels: Set[int] = set()
-        self._start_point = copy.deepcopy(self.parser.stack)
+        self._start_point = self.parser.stack
         self._points = {ilabel: copy.deepcopy(self._start_point) for ilabel in ilabels}
 
     @property


### PR DESCRIPTION
This isn't much, but at least a good start (we did 3 overall copies, but seem like the initial one is unnecessary since we never touch that stack, so we do 2 of them now).

main:
```
$ touch t.py; time black -tpy310 --check t.py > /dev/null
would reformat t.py
Oh no! 💥 💔 💥
1 file would be reformatted.
black -tpy310 --check t.py > /dev/null  0,33s user 0,02s system 99% cpu 0,358 total
```
this branch:
```
$ touch t.py; time black -tpy310 --check t.py > /dev/null
would reformat t.py
Oh no! 💥 💔 💥
1 file would be reformatted.
black -tpy310 --check t.py > /dev/null  0,27s user 0,01s system 99% cpu 0,275 total
```
test script: https://gist.github.com/isidentical/2911e41262314e6f189149da45a10054