### PR TITLE
blib2to3 can raise TokenError and IndentationError too

### DIFF
--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -140,7 +140,7 @@ def matches_grammar(src_txt: str, grammar: Grammar) -> bool:
     drv = driver.Driver(grammar)
     try:
         drv.parse_string(src_txt, True)
-    except ParseError:
+    except (ParseError, TokenError, IndentationError):
         return False
     else:
         return True


### PR DESCRIPTION
Fix the regression of GH-2317 caused by GH-2668. I explicitly made this PR from my fork of psf/black so the workflows are triggered from the PR event which should catch post-merge issues.

- [x] Add a CHANGELOG entry if necessary? -> the regression hasn't been released yet
- [x] Add / update tests if necessary? -> CI will test this
- [x] Add new / update outdated documentation? -> n/a