### PR TITLE
Use 'python -m build' to build wheel and source distributions

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
 
-      - name: Install latest pip, setuptools, twine + wheel
+      - name: Install latest pip, build, twine
         run: |
-          python -m pip install --upgrade pip setuptools twine wheel
+          python -m pip install --upgrade --disable-pip-version-check pip
+          python -m pip install --upgrade build twine
 
-      - name: Build wheels
+      - name: Build wheel and source distributions
         run: |
-          python setup.py bdist_wheel
-          python setup.py sdist
+          python -m build
 
       - name: Upload to PyPI via Twine
         env:


### PR DESCRIPTION
### Description

This PR uses modern approaches for building wheel and source distributions.

According to the [build docs](https://pypa-build.readthedocs.io/en/latest/differences.html):
> build is roughly the equivalent of `setup.py sdist bdist_wheel` but with [PEP 517](https://www.python.org/dev/peps/pep-0517/) support

So the modern equivalent is simply:
```
python -m build
```
which builds a `*.whl` and `*.tar.gz` file in `dist/`. Setuptools and wheel do not need to be installed, as these build dependancies are taken from pyproject.toml

### Checklist - did you ...

- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?