### PR TITLE
Cache grammar tables after finishing, not at startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   (#2686)
 - No longer color diff headers white as it's unreadable in light themed terminals
   (#2691)
+- No longer attempt to write grammar table cache on import emitting confusing log
+  messages (#2701)
 
 ## 21.12b0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 - No longer color diff headers white as it's unreadable in light themed terminals
   (#2691)
 - No longer attempt to write grammar table cache on import emitting confusing log
-  messages (#2701)
+  messages (#2702)
 - Tuple unpacking on `return` and `yield` constructs now implies 3.8+ (#2700)
 
 ## 21.12b0

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -42,7 +42,14 @@ from black.linegen import transform_line, LineGenerator, LN
 from black.comments import normalize_fmt_off
 from black.mode import FUTURE_FLAG_TO_FEATURE, Mode, TargetVersion
 from black.mode import Feature, supports_feature, VERSION_TO_FEATURES
-from black.cache import read_cache, write_cache, get_cache_info, filter_cached, Cache
+from black.cache import (
+    CACHE_DIR,
+    read_cache,
+    write_cache,
+    get_cache_info,
+    filter_cached,
+    Cache,
+)
 from black.concurrency import cancel, shutdown, maybe_install_uvloop
 from black.output import dump_to_file, ipynb_diff, diff, color_diff, out, err
 from black.report import Report, Changed, NothingChanged
@@ -63,6 +70,7 @@ from black.handle_ipynb_magics import (
 
 
 # lib2to3 fork
+import blib2to3.pgen2.driver
 from blib2to3.pytree import Node, Leaf
 from blib2to3.pgen2 import token
 
@@ -494,6 +502,7 @@ def main(
                 workers=workers,
             )
 
+    blib2to3.pgen2.driver.cache_loaded_grammars(CACHE_DIR)
     if verbose or not quiet:
         out(error_msg if report.return_code else "All done! ✨ 🍰 ✨")
         if code is None:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1776,8 +1776,8 @@ class TestCaching:
             assert str(path) not in two
 
     def test_grammar_cache_is_written(self) -> None:
-        with cache_dir(exists=False) as workspace:
-            assert not workspace.exists()
+        with cache_dir() as workspace:
+            assert not list(workspace.iterdir())
             blib2to3.pgen2.driver.cache_loaded_grammars(workspace)
             cache_entries = sorted(p.name for p in workspace.iterdir())
             assert str(cache_entries[0]).startswith("Grammar")


### PR DESCRIPTION
### Description

*and also get rid of the confusing log messages related to the grammar cache which just confuses everyone and leads to confused issues to be opened

Resolves GH-2681.
Resolves GH-2058.
Resolves GH-1143.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
