### PR TITLE
Drop upper version bounds on dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 - Unparenthesized tuples on annotated assignments (e.g
   `values: Tuple[int, ...] = 1, 2, 3`) now implies 3.8+ (#2708)
 
+### Packaging
+
+- All dependencies upper version bounds have been removed (#2718)
+
 ## 21.12b0
 
 ### _Black_

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 
 ### Packaging
 
-- All dependencies upper version bounds have been removed (#2718)
+- All upper version bounds on dependencies have been removed (#2718)
 
 ## 21.12b0
 

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,9 @@ setup(
     install_requires=[
         "click>=7.1.2",
         "platformdirs>=2",
-        "tomli>=1.1.0,<3.0.0",
+        "tomli>=1.1.0",
         "typed-ast>=1.4.2; python_version < '3.8' and implementation_name == 'cpython'",
-        "pathspec>=0.9.0, <1",
+        "pathspec>=0.9.0",
         "dataclasses>=0.6; python_version < '3.7'",
         "typing_extensions>=3.10.0.0",
         # 3.10.0.1 is broken on at least Python 3.10,


### PR DESCRIPTION
They mostly cause unnecessary trouble.