### PR TITLE
Speed up new backtracking parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
   at least one pre-existing blank line (#2736)
 - Verbose mode also now describes how a project root was discovered and which paths will
   be formatted. (#2526)
+- Speed-up the new backtracking parser about 4X in general (enabled when
+  `--target-version` is set to 3.10 and higher). (#2728)
 
 ### Packaging
 

--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -73,7 +73,7 @@ class Recorder:
 
     @contextmanager
     def switch_to(self, ilabel: int) -> Iterator[None]:
-        with self.patch():
+        with self.backtrack():
             self.parser.stack = self._points[ilabel]
             try:
                 yield
@@ -83,12 +83,11 @@ class Recorder:
                 self.parser.stack = self._start_point
 
     @contextmanager
-    def patch(self) -> Iterator[None]:
+    def backtrack(self) -> Iterator[None]:
         """
-        Patch basic state operations (push/pop/shift) with node-level
-        immutable variants. These still will operate on the stack; but
-        they won't create any new nodes, or modify the contents of any
-        other existing nodes.
+        Use the node-level invariant ones for basic parsing operations (push/pop/shift).
+        These still will operate on the stack; but they won't create any new nodes, or
+        modify the contents of any other existing nodes.
 
         This saves us a ton of time when we are backtracking, since we
         want to restore to the initial state as quick as possible, which
@@ -348,8 +347,6 @@ class Parser(object):
         if ilabel is None:
             raise ParseError("bad token", type, value, context)
         return [ilabel]
-
-    STATE_OPERATIONS = ["shift", "push", "pop"]
 
     def shift(self, type: int, value: Text, newstate: int, context: Context) -> None:
         """Shift a token.  (Internal)"""

--- a/tests/data/pattern_matching_generic.py
+++ b/tests/data/pattern_matching_generic.py
@@ -1,0 +1,107 @@
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+
+def get_grammars(target_versions: Set[TargetVersion]) -> List[Grammar]:
+    if not target_versions:
+        # No target_version specified, so try all grammars.
+        return [
+            # Python 3.7+
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords,
+            # Python 3.0-3.6
+            pygram.python_grammar_no_print_statement_no_exec_statement,
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    match match:
+        case case:
+            match match:
+                case case:
+                    pass
+
+    if all(version.is_python2() for version in target_versions):
+        # Python 2-only code, so try Python 2 grammars.
+        return [
+            # Python 2.7 with future print_function import
+            pygram.python_grammar_no_print_statement,
+            # Python 2.7
+            pygram.python_grammar,
+        ]
+
+    re.match()
+    match = a
+    with match() as match:
+        match = f"{match}"
+
+    def test_patma_139(self):
+        x = False
+        match x:
+            case bool(z):
+                y = 0
+        self.assertIs(x, False)
+        self.assertEqual(y, 0)
+        self.assertIs(z, x)
+
+    # Python 3-compatible code, so only try Python 3 grammar.
+    grammars = []
+    if supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.10+
+        grammars.append(pygram.python_grammar_soft_keywords)
+    # If we have to parse both, try to parse async as a keyword first
+    if not supports_feature(
+        target_versions, Feature.ASYNC_IDENTIFIERS
+    ) and not supports_feature(target_versions, Feature.PATTERN_MATCHING):
+        # Python 3.7-3.9
+        grammars.append(
+            pygram.python_grammar_no_print_statement_no_exec_statement_async_keywords
+        )
+    if not supports_feature(target_versions, Feature.ASYNC_KEYWORDS):
+        # Python 3.0-3.6
+        grammars.append(pygram.python_grammar_no_print_statement_no_exec_statement)
+
+    def test_patma_155(self):
+        x = 0
+        y = None
+        match x:
+            case 1e1000:
+                y = 0
+        self.assertEqual(x, 0)
+        self.assertIs(y, None)
+
+        x = range(3)
+        match x:
+            case [y, case as x, z]:
+                w = 0
+
+    # At least one of the above branches must have been taken, because every Python
+    # version has exactly one of the two 'ASYNC_*' flags
+    return grammars
+
+
+def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -> Node:
+    """Given a string with source, return the lib2to3 Node."""
+    if not src_txt.endswith("\n"):
+        src_txt += "\n"
+
+    grammars = get_grammars(set(target_versions))
+
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"
+
+re.match()
+match = a
+with match() as match:
+    match = f"{match}"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -69,6 +69,7 @@ PY310_CASES = [
     "pattern_matching_complex",
     "pattern_matching_extras",
     "pattern_matching_style",
+    "pattern_matching_generic",
     "parenthesized_context_managers",
 ]
 


### PR DESCRIPTION
Resolves #2727 
## Core Idea
The current parser; even when it is backtracking, builds nodes which is a terrible waste of time since every time we see a `match` or `case`, we need to copy the whole stack over and over in order to preserve the actual structure and not do any modifications on top of it. This is obviously not cheap. 

The following implementation does something very similar to old school state machines, where the parser is temporarily converted into a structure that tells you whether it accepts an input or not. It doesn't build any trees, at all. Which cuts a lot of time (see the benchmarks below). We simply change the parser's mode to accept-only from accept-and-build-tree when we are backtracking, and once we have the rule to follow, we switch back. 

The implementation is obviously not really straightforward, because lib2to3's code is very old and it is kind of hard to move pieces around. I did not want to make much modification to regular functions, in order to not cause any additional breakage. We simply change `push`/`pop`/`shift` from functions that create / modify nodes to functions that only modify the parser's state/transition table. This way, we don't need to copy the new nodes on each modification.

## Benchmarks

Benchmarking script is available [here](https://gist.github.com/isidentical/325325766daf7d3588b50704ef7bf064) (thanks to @ichard26 for sharing it with me).

> It'd be really appreciated if someone can also re-test these and share their results as well, for further verification.

An example that doesn't contain any PEP 634 syntax, but contains a lot of `match`/`case` keywords: [example.py](https://gist.github.com/isidentical/76d8b5e1777541d871ef1c4016952681).
```
-t py39 (main):: Mean +- std dev: 7.21 ms +- 0.25 ms
-t py39 (this branch):: Mean +- std dev: 7.25 ms +- 0.27 ms

-t py310 (main):: Mean +- std dev: 41.7 ms +- 2.5 ms
-t py310 (this branch):: Mean +- std dev: 13.8 ms +- 0.6 ms
```
From what I can interpret, this means that for `-t py310` there is a speed-up of ~**4X**.

An example that contains 25 non-PEP 634 usages and 25 PEP 634 usages of `match/case`: [example_2.py](https://gist.github.com/isidentical/0bfc74c21d351a87ae933087fd36304d)
```
-t py310 (main):: Mean +- std dev: 1.22 sec +- 0.03 sec
-t py310 (this branch):: Mean +- std dev: 93.0 ms +- 6.8 ms
```

And another example is parsing the [`Lib/test/test_patma.py`](https://github.com/python/cpython/blob/e6497fe698f6e87344501a68ffdea106eafcb257/Lib/test/test_patma.py), which has all of the pattern matching statement variations known to the humans (I've only run `lib2to3_parse()` once since it takes so much time on the `main`, so assume this is `+/- 20 seconds`):
```
main: 2 minutes, 33 seconds
this branch: 2.499 seconds
```

## Verification

Obviously, a change like this, at the core of the parser, should be verified though I do not have many examples of pattern matching myself. My script to parse every variation of pattern matching statements (originating through `Lib/test/test_patma.py`) says it can parse all of the examples. 

I've also taken the diff of the following command and compared it, which yielded no difference in formatting between main/this branch (speed-wise it is like 50X faster):
```console
$ black -tpy310 --fast --diff ~/projects/cpython/Lib/test/test_patma.py
```

Other than that, I've also tried formatting the whole stdlib (including tests) and there is also no relevant changes. If you have other ideas to verify this, that would be wonderful.
 