### PR TITLE
Primer: exclude crashing sqlalchemy file for now

### DIFF
--- a/src/black_primer/primer.json
+++ b/src/black_primer/primer.json
@@ -150,7 +150,11 @@
       "py_versions": ["all"]
     },
     "sqlalchemy": {
-      "cli_arguments": ["--experimental-string-processing"],
+      "cli_arguments": [
+        "--experimental-string-processing",
+        "--extend-exclude",
+        "/test/orm/test_relationship_criteria.py"
+      ],
       "expect_formatting_changes": true,
       "git_clone_url": "https://github.com/sqlalchemy/sqlalchemy.git",
       "long_checkout": false,


### PR DESCRIPTION
### Description

We don't need primer to fail on every single build at this point. Let's ignore it until we can properly look into and fix it. Tracked in GH-2734. 

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a