### PR TITLE
Stubs: preserve blank line between attributes and methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 - Tuple unpacking on `return` and `yield` constructs now implies 3.8+ (#2700)
 - Unparenthesized tuples on annotated assignments (e.g
   `values: Tuple[int, ...] = 1, 2, 3`) now implies 3.8+ (#2708)
+- For stubs, one blank line between class attributes and methods is now kept if there's
+  at least one pre-existing blank line (#2736)
 
 ### Packaging
 

--- a/tests/data/stub.pyi
+++ b/tests/data/stub.pyi
@@ -2,32 +2,55 @@ X: int
 
 def f(): ...
 
+
+class D: 
+    ...
+
+
 class C:
     ...
 
 class B:
-    ...
+    this_lack_of_newline_should_be_kept: int
+    def b(self) -> None: ...
+
+    but_this_newline_should_also_be_kept: int
 
 class A:
+    attr: int
+    attr2: str
+
     def f(self) -> int:
         ...
 
     def g(self) -> str: ...
+
+
 
 def g():
     ...
 
 def h(): ...
 
+
 # output
 X: int
 
 def f(): ...
 
+class D: ...
 class C: ...
-class B: ...
+
+class B:
+    this_lack_of_newline_should_be_kept: int
+    def b(self) -> None: ...
+
+    but_this_newline_should_also_be_kept: int
 
 class A:
+    attr: int
+    attr2: str
+
     def f(self) -> int: ...
     def g(self) -> str: ...
 


### PR DESCRIPTION
### Description

Fixes https://github.com/psf/black/issues/2706.

[diff-shades result comparing this PR to 21.12b0](https://github.com/ichard26/black/runs/4670954474?check_suite_focus=true#step:12:1):

```
╭─────────────────────── Summary ────────────────────────╮
│ 0 projects & 0 files changed / 0 changes [+0/-0]       │
│                                                        │
│ ... out of 2 057 623 lines, 10 045 files & 23 projects │
╰────────────────────────────────────────────────────────╯

Nothing-changed.
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> n/a
