### PR TITLE
Action: Support running in a docker container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
 
 - All upper version bounds on dependencies have been removed (#2718)
 
+### Integrations
+
+- Update GitHub action to support containerized runs (#2748)
+
 ## 21.12b0
 
 ### _Black_

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         import subprocess;
         from pathlib import Path;
 
-        MAIN_SCRIPT = Path(r'${{ github.action_path }}') / 'action' / 'main.py';
+        MAIN_SCRIPT = Path(r'${GITHUB_ACTION_PATH}') / 'action' / 'main.py';
 
         proc = subprocess.run([sys.executable, str(MAIN_SCRIPT)]);
         sys.exit(proc.returncode)


### PR DESCRIPTION
`${{ github.action_path }}` doesn't point to the correct path when run in a docker container, you have to use the environmental variable `GITHUB_ACTION_PATH` 

https://github.com/actions/runner/issues/716

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
