### PR TITLE
Improve CLI reference wording

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -26,13 +26,13 @@ python -m black {source_file_or_directory}
 
 ### Command line options
 
-_Black_ has quite a few knobs these days, although _Black_ is opinionated so style
-configuration options are deliberately limited and rarely added. You can list them by
-running `black --help`.
+The CLI options of _Black_ can be displayed by expanding the view below or by running
+`black --help`. While _Black_ has quite a few knobs these days, it is still opinionated
+so style options are deliberately limited and rarely added.
 
 <details>
 
-<summary>Help output</summary>
+<summary>CLI reference</summary>
 
 ```{program-output} black --help
 


### PR DESCRIPTION
### Description
The CLI reference is a bit buried in the documentation. Hopefully, with this change it is at least a bit more visible. I put the important information first to not distract the reader and changed the summary line to match what a user would actually be looking for when browsing.

### Checklist

- [x] Add a CHANGELOG entry if necessary? N/A
- [x] Add / update tests if necessary? N/A
- [x] Add new / update outdated documentation?
