### PR TITLE
Change git url for pip installation in README

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,10 @@
 
 - Update GitHub action to support containerized runs (#2748)
 
+### Documentation
+
+- Change protocol in pip installation instructions to `https://` (#2761)
+
 ## 21.12b0
 
 ### _Black_

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ run. If you want to format Jupyter Notebooks, install with `pip install black[ju
 
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:
 
-`pip install git+git://github.com/psf/black`
+`pip install git+https://github.com/psf/black`
 
 ### Usage
 


### PR DESCRIPTION
Unauthenticated git protocol was disabled recently by Github and should not be used anymore.

https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git