### PR TITLE
Dont require typing-extensions in 3.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@
 ### Packaging
 
 - All upper version bounds on dependencies have been removed (#2718)
-- `typing-extensions` is no longer a required dependency in Python3.10+ (#2772)
+- `typing-extensions` is no longer a required dependency in Python 3.10+ (#2772)
 
 ### Integrations
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 ### Packaging
 
 - All upper version bounds on dependencies have been removed (#2718)
+- `typing-extensions` is no longer a required dependency in Python3.10+ (#2772)
 
 ### Integrations
 

--- a/setup.py
+++ b/setup.py
@@ -103,10 +103,7 @@ setup(
         "typed-ast>=1.4.2; python_version < '3.8' and implementation_name == 'cpython'",
         "pathspec>=0.9.0",
         "dataclasses>=0.6; python_version < '3.7'",
-        "typing_extensions>=3.10.0.0",
-        # 3.10.0.1 is broken on at least Python 3.10,
-        # https://github.com/python/typing/issues/865
-        "typing_extensions!=3.10.0.1; python_version >= '3.10'",
+        "typing_extensions>=3.10.0.0; python_version < '3.10'",
         "mypy_extensions>=0.4.3",
     ],
     extras_require={


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

As noted on Discord by @ichard26 

My bad for bumping typing-extensions in the Jupyter PR without making it conditional on the Python version, so here's a PR to rectify

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
