### PR TITLE
Fix and speedup diff-shades integration 

### DIFF
--- a/.github/mypyc-requirements.txt
+++ b/.github/mypyc-requirements.txt
@@ -1,0 +1,14 @@
+mypy == 0.920
+
+# A bunch of packages for type information
+mypy-extensions >= 0.4.3
+tomli >= 0.10.2
+types-typed-ast >= 1.4.2
+types-dataclasses >= 0.1.3
+typing-extensions > 3.10.0.1
+click >= 8.0.0
+platformdirs >= 2.1.0
+
+# And because build isolation is disabled, we'll need to pull this too
+setuptools-scm[toml] >= 6.3.1
+wheel

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -38,8 +38,7 @@ jobs:
     env:
       # Clang is less picky with the C code it's given than gcc (and may
       # generate faster binaries too).
-      CC: clang
-      MYPYC_OPT_LEVEL: 2
+      CC: clang-12
 
     steps:
       - name: Checkout this repository (full clone)

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -3,10 +3,10 @@ name: diff-shades
 on:
   push:
     branches: [main]
-    paths-ignore: ["docs/**", "tests/**", "*.md"]
+    paths-ignore: ["docs/**", "tests/**", "**.md", "**.rst"]
 
   pull_request:
-    path-ignore: ["docs/**", "tests/**", "*.md"]
+    path-ignore: ["docs/**", "tests/**", "**.md", "**.rst"]
 
   workflow_dispatch:
     inputs:
@@ -26,6 +26,10 @@ on:
       target-args:
         description: "Custom Black arguments (eg. -S)"
         required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   analysis:

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -122,13 +122,14 @@ jobs:
           python helper.py comment-body
           ${{ steps.config.outputs.baseline-analysis }} ${{ steps.config.outputs.target-analysis }}
           ${{ steps.config.outputs.baseline-sha }} ${{ steps.config.outputs.target-sha }}
+          ${{ github.event.pull_request.number }}
 
       - name: Upload summary file (PR only)
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
-          name: .pr-comment-body.md
-          path: .pr-comment-body.md
+          name: .pr-comment.json
+          path: .pr-comment.json
 
         # This is last so the diff-shades-comment workflow can still work even if we
         # end up detecting failed files and failing the run.

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -35,6 +35,11 @@ jobs:
   analysis:
     name: analysis / linux
     runs-on: ubuntu-latest
+    env:
+      # Clang is less picky with the C code it's given than gcc (and may
+      # generate faster binaries too).
+      CC: clang
+      MYPYC_OPT_LEVEL: 2
 
     steps:
       - name: Checkout this repository (full clone)
@@ -49,6 +54,7 @@ jobs:
           python -m pip install pip --upgrade
           python -m pip install https://github.com/ichard26/diff-shades/archive/stable.zip
           python -m pip install click packaging urllib3
+          python -m pip install -r .github/mypyc-requirements.txt
           # After checking out old revisions, this might not exist so we'll use a copy.
           cat scripts/diff_shades_gha_helper.py > helper.py
           git config user.name "diff-shades-gha"
@@ -70,11 +76,14 @@ jobs:
           path: ${{ steps.config.outputs.baseline-analysis }}
           key: ${{ steps.config.outputs.baseline-cache-key }}
 
-      - name: Install baseline revision
+      - name: Build and install baseline revision
         if: steps.baseline-cache.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ${{ steps.config.outputs.baseline-setup-cmd }} && python -m pip install .
+        run: >
+          ${{ steps.config.outputs.baseline-setup-cmd }}
+          && python setup.py --use-mypyc bdist_wheel
+          && python -m pip install dist/*.whl && rm build dist -r
 
       - name: Analyze baseline revision
         if: steps.baseline-cache.outputs.cache-hit != 'true'
@@ -82,10 +91,13 @@ jobs:
           diff-shades analyze -v --work-dir projects-cache/
           ${{ steps.config.outputs.baseline-analysis }} -- ${{ github.event.inputs.baseline-args }}
 
-      - name: Install target revision
+      - name: Build and install target revision
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ${{ steps.config.outputs.target-setup-cmd }} && python -m pip install .
+        run: >
+          ${{ steps.config.outputs.target-setup-cmd }}
+          && python setup.py --use-mypyc bdist_wheel
+          && python -m pip install dist/*.whl
 
       - name: Analyze target revision
         run: >

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Try to find pre-existing PR comment
         if: steps.metadata.outputs.needs-comment == 'true'
         id: find-comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@d2dae40ed151c634e4189471272b57e76ec19ba8
         with:
           issue-number: ${{ steps.metadata.outputs.pr-number }}
           comment-author: "github-actions[bot]"
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create or update PR comment
         if: steps.metadata.outputs.needs-comment == 'true'
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ steps.metadata.outputs.pr-number }}

--- a/docs/contributing/gauging_changes.md
+++ b/docs/contributing/gauging_changes.md
@@ -74,7 +74,7 @@ to further information. If there's a pre-existing diff-shades comment, it'll be 
 instead the next time the workflow is triggered on the same PR.
 
 The workflow uploads 3-4 artifacts upon completion: the two generated analyses (they
-have the .json file extension), `diff.html`, and `.pr-comment-body.md` if triggered by a
+have the .json file extension), `diff.html`, and `.pr-comment.json` if triggered by a
 PR. The last one is downloaded by the `diff-shades-comment` workflow and shouldn't be
 downloaded locally. `diff.html` comes in handy for push-based or manually triggered
 runs. And the analyses exist just in case you want to do further analysis using the

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -206,7 +206,7 @@ def stringify_ast(node: Union[ast.AST, ast3.AST], depth: int = 0) -> Iterator[st
                 break
 
         try:
-            value = getattr(node, field)
+            value: object = getattr(node, field)
         except AttributeError:
             continue
 
@@ -237,6 +237,7 @@ def stringify_ast(node: Union[ast.AST, ast3.AST], depth: int = 0) -> Iterator[st
             yield from stringify_ast(value, depth + 2)
 
         else:
+            normalized: object
             # Constant strings may be indented across newlines, if they are
             # docstrings; fold spaces after newlines when comparing. Similarly,
             # trailing and leading space may be removed.


### PR DESCRIPTION
### Description

- Pins third party actions to a specific SHA to reduce supply chain risk
- Adds a concurrency group to diff-shades so quick pushes to PRs with little time in between doesn't end up running diff-shades only to overwrite the results soon after repeatedly
- Compiles the baseline/target revision w/ mypyc to hopefully see runtime reductions
- Fixes the PR comment bug (hence why this is from my fork and not a branch here)

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
