### PR TITLE
Hint at likely cause of ast parsing failure in error message

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1315,7 +1315,9 @@ def assert_equivalent(src: str, dst: str, *, pass_num: int = 1) -> None:
         src_ast = parse_ast(src)
     except Exception as exc:
         raise AssertionError(
-            f"cannot use --safe with this file; failed to parse source file: {exc}"
+            f"cannot use --safe with this file; failed to parse source file AST: {exc}"
+            f"This could be caused by running black with an older python version "
+            f"that does not support new syntax used in your source file."
         ) from exc
 
     try:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1315,7 +1315,8 @@ def assert_equivalent(src: str, dst: str, *, pass_num: int = 1) -> None:
         src_ast = parse_ast(src)
     except Exception as exc:
         raise AssertionError(
-            f"cannot use --safe with this file; failed to parse source file AST: {exc}\n"
+            f"cannot use --safe with this file; failed to parse source file AST: "
+            f"{exc}\n"
             f"This could be caused by running black with an older python version "
             f"that does not support new syntax used in your source file."
         ) from exc

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1315,7 +1315,7 @@ def assert_equivalent(src: str, dst: str, *, pass_num: int = 1) -> None:
         src_ast = parse_ast(src)
     except Exception as exc:
         raise AssertionError(
-            f"cannot use --safe with this file; failed to parse source file AST: {exc}"
+            f"cannot use --safe with this file; failed to parse source file AST: {exc}\n"
             f"This could be caused by running black with an older python version "
             f"that does not support new syntax used in your source file."
         ) from exc

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1317,7 +1317,7 @@ def assert_equivalent(src: str, dst: str, *, pass_num: int = 1) -> None:
         raise AssertionError(
             f"cannot use --safe with this file; failed to parse source file AST: "
             f"{exc}\n"
-            f"This could be caused by running black with an older python version "
+            f"This could be caused by running Black with an older Python version "
             f"that does not support new syntax used in your source file."
         ) from exc
 


### PR DESCRIPTION
### Description

Add more descriptive error message to help prevent confusion when parsing source code AST fails as in #2782

### Checklist - did you ...

Nothing to do here. 
I don't think I need a change log entry for this - but happy to add if needed.
