### PR TITLE
Use `magic_trailing_comma` for `FileMode` in `fuzz`

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -32,6 +32,7 @@ from blib2to3.pgen2.tokenize import TokenError
         black.FileMode,
         line_length=st.just(88) | st.integers(0, 200),
         string_normalization=st.booleans(),
+        preview=st.booleans(),
         is_pyi=st.booleans(),
         magic_trailing_comma=st.booleans(),
     ),

--- a/fuzz.py
+++ b/fuzz.py
@@ -33,6 +33,7 @@ from blib2to3.pgen2.tokenize import TokenError
         line_length=st.just(88) | st.integers(0, 200),
         string_normalization=st.booleans(),
         is_pyi=st.booleans(),
+        magic_trailing_comma=st.booleans(),
     ),
 )
 def test_idempotent_any_syntatically_valid_python(


### PR DESCRIPTION
Without it fuzz tests will always use the default value. Quick demo:

```python
>>> import hypothesis
>>> class Some:
...    def __init__(self, arg: bool = True):
...      print(arg)
... 
>>> hypothesis.strategies.builds(Some).example()
True
<__main__.Some object at 0x10c462490>
>>> hypothesis.strategies.builds(Some).example()
True
<__main__.Some object at 0x10c411850>
>>> hypothesis.strategies.builds(Some).example()
True
```

CC @Zac-HD 