### PR TITLE
Add `--colour/--no-colour` alias to `--color/--no-color`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
   `--preview` (#2789)
 - Enable Python 3.10+ by default, without any extra need to specify
   `--target-version=py310`. (#2758)
+- Add `--colour/--no-colour` alias to `--color/--no-color` (#2803)
 
 ### Packaging
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -278,6 +278,7 @@ def validate_regex(
 )
 @click.option(
     "--color/--no-color",
+    "--colour/--no-colour",
     is_flag=True,
     help="Show colored diff. Only applies when `--diff` is given.",
 )


### PR DESCRIPTION
`color` is the preferred spelling in American English while in British English, `colour` is preferred. A lot of people use `colour` (me being one of them) and there is no reason to not support `--colour` and make them use `--color`.
