### PR TITLE
Avoid crashing when the user has no homedir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 
 - Do not format `__pypackages__` directories by default (#2836)
 - Add support for specifying stable version with `--required-version` (#2832).
+- Avoid crashing when the user has no homedir (#2814)
 
 ### Documentation
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -87,7 +87,7 @@ def find_pyproject_toml(path_search_start: Tuple[str, ...]) -> Optional[str]:
             if path_user_pyproject_toml.is_file()
             else None
         )
-    except PermissionError as e:
+    except (PermissionError, RuntimeError) as e:
         # We do not have access to the user-level config directory, so ignore it.
         err(f"Ignoring user configuration directory due to {e!r}")
         return None
@@ -111,6 +111,10 @@ def find_user_pyproject_toml() -> Path:
 
     This looks for ~\.black on Windows and ~/.config/black on Linux and other
     Unix systems.
+
+    May raise:
+    - RuntimeError: if the current user has no homedir
+    - PermissionError: if the current process cannot access the user's homedir
     """
     if sys.platform == "win32":
         # Windows


### PR DESCRIPTION
### Description

See #2813 
Avoid crashing when the user has no homedir

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation? < not applicable

### Things left to discuss

Regarding the tests, I'm unsure what the best strategy is here. As far as I can tell, the current `PermissionError` path isn't tested, and the `find_pyproject_toml` function is not tested directly in the tests.

Should I:
- Add new tests for `find_pyproject_toml`, covering all function paths ?
- Add new tests for `find_pyproject_toml`, covering just my new path ?
- Add tests on the caller function `read_pyproject_toml` ?
- Or smething else ?