### PR TITLE
torture test

### DIFF
--- a/tests/data/torture.py
+++ b/tests/data/torture.py
@@ -17,6 +17,11 @@ class A:
                 xxxxxxxxxxxx
             )
 
+def test(self, othr):
+    return (1 == 2 and
+            (name, description, self.default, self.selected, self.auto_generated, self.parameters, self.meta_data, self.schedule) ==
+            (name, description, othr.default, othr.selected, othr.auto_generated, othr.parameters, othr.meta_data, othr.schedule))
+
 # output
 
 importA
@@ -52,3 +57,25 @@ class A:
             aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(
                 xxxxxxxxxxxx
             )  # pylint: disable=no-member
+
+
+def test(self, othr):
+    return 1 == 2 and (
+        name,
+        description,
+        self.default,
+        self.selected,
+        self.auto_generated,
+        self.parameters,
+        self.meta_data,
+        self.schedule,
+    ) == (
+        name,
+        description,
+        othr.default,
+        othr.selected,
+        othr.auto_generated,
+        othr.parameters,
+        othr.meta_data,
+        othr.schedule,
+    )

--- a/tests/data/torture.py
+++ b/tests/data/torture.py
@@ -17,11 +17,6 @@ class A:
                 xxxxxxxxxxxx
             )
 
-assert (
-    a_function(very_long_arguments_that_surpass_the_limit, which_is_eighty_eight_in_this_case_plus_a_bit_more)
-    == {"x": "this need to pass the line limit as well", "b": "but only by a little bit"}
-)
-
 # output
 
 importA
@@ -57,8 +52,3 @@ class A:
             aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(
                 xxxxxxxxxxxx
             )  # pylint: disable=no-member
-
-assert (
-    a_function(very_long_arguments_that_surpass_the_limit, which_is_eighty_eight_in_this_case_plus_a_bit_more)
-    == {"x": "this need to pass the line limit as well", "b": "but only by a little bit"}
-)

--- a/tests/data/torture.py
+++ b/tests/data/torture.py
@@ -1,0 +1,64 @@
+importA;() << 0 ** 101234234242352525425252352352525234890264906820496920680926538059059209922523523525 #
+
+assert sort_by_dependency(
+    {
+        "1": {"2", "3"}, "2": {"2a", "2b"}, "3": {"3a", "3b"},
+        "2a": set(), "2b": set(), "3a": set(), "3b": set()
+    }
+) == ["2a", "2b", "2", "3a", "3b", "3", "1"]
+
+importA
+0;0^0#
+
+class A:
+    def foo(self):
+        for _ in range(10):
+            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(  # pylint: disable=no-member
+                xxxxxxxxxxxx
+            )
+
+assert (
+    a_function(very_long_arguments_that_surpass_the_limit, which_is_eighty_eight_in_this_case_plus_a_bit_more)
+    == {"x": "this need to pass the line limit as well", "b": "but only by a little bit"}
+)
+
+# output
+
+importA
+(
+    ()
+    << 0
+    ** 101234234242352525425252352352525234890264906820496920680926538059059209922523523525
+)  #
+
+assert (
+    sort_by_dependency(
+        {
+            "1": {"2", "3"},
+            "2": {"2a", "2b"},
+            "3": {"3a", "3b"},
+            "2a": set(),
+            "2b": set(),
+            "3a": set(),
+            "3b": set(),
+        }
+    )
+    == ["2a", "2b", "2", "3a", "3b", "3", "1"]
+)
+
+importA
+0
+0 ^ 0  #
+
+
+class A:
+    def foo(self):
+        for _ in range(10):
+            aaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbb.cccccccccc(
+                xxxxxxxxxxxx
+            )  # pylint: disable=no-member
+
+assert (
+    a_function(very_long_arguments_that_surpass_the_limit, which_is_eighty_eight_in_this_case_plus_a_bit_more)
+    == {"x": "this need to pass the line limit as well", "b": "but only by a little bit"}
+)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -52,6 +52,7 @@ SIMPLE_CASES: List[str] = [
     "remove_parens",
     "slices",
     "string_prefixes",
+    "torture",
     "trailing_comma_optional_parens1",
     "trailing_comma_optional_parens2",
     "trailing_comma_optional_parens3",


### PR DESCRIPTION
Fixes #2651. Fixes #2754. Fixes #2518. Fixes #2321.

This adds a test that lists a number of cases of unstable formatting
that we have seen in the issue tracker. Checking it in will ensure
that we don't regress on these cases.
