### PR TITLE
Elaborate on Python support policy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@ and the first release covered by our new stability policy.
 - Change HTML theme to Furo primarily for its responsive design and mobile support
   (#2793)
 - Deprecate the `black-primer` tool (#2809)
+- Document Python support policy (#2819)
 
 ## 21.12b0
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,9 +71,13 @@ readability because operators are misaligned. Disable W503 and enable the
 disabled-by-default counterpart W504. E203 should be disabled while changes are still
 [discussed](https://github.com/PyCQA/pycodestyle/issues/373).
 
-## Does Black support Python 2?
+## Which Python versions does Black support?
 
-Support for formatting Python 2 code was removed in version 22.0.
+_Black_ supports at least all Python versions that have not reached their end of life.
+This is the case for both running _Black_ and formatting code. Support for formatting
+Python 2 code was removed in version 22.0. While we've made no plans to stop supporting
+older Python 3 minor versions immediately, their support might also be removed some time
+in the future without a deprecation period.
 
 ## Why does my linter or typechecker complain after I format my code?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,11 +73,14 @@ disabled-by-default counterpart W504. E203 should be disabled while changes are 
 
 ## Which Python versions does Black support?
 
-_Black_ supports at least all Python versions that have not reached their end of life.
-This is the case for both running _Black_ and formatting code. Support for formatting
-Python 2 code was removed in version 22.0. While we've made no plans to stop supporting
-older Python 3 minor versions immediately, their support might also be removed some time
-in the future without a deprecation period.
+Currently the runtime requires Python 3.6. Formatting is supported for files containing
+syntax from Python 3.3 onwards. We promise to support at least all Python versions that
+have not reached their end of life. This is the case for both running _Black_ and
+formatting code.
+
+Support for formatting Python 2 code was removed in version 22.0. While we've made no
+plans to stop supporting older Python 3 minor versions immediately, their support might
+also be removed some time in the future without a deprecation period.
 
 ## Why does my linter or typechecker complain after I format my code?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,10 +73,10 @@ disabled-by-default counterpart W504. E203 should be disabled while changes are 
 
 ## Which Python versions does Black support?
 
-Currently the runtime requires Python 3.6. Formatting is supported for files containing
-syntax from Python 3.3 onwards. We promise to support at least all Python versions that
-have not reached their end of life. This is the case for both running _Black_ and
-formatting code.
+Currently the runtime requires Python 3.6-3.10. Formatting is supported for files
+containing syntax from Python 3.3 to 3.10. We promise to support at least all Python
+versions that have not reached their end of life. This is the case for both running
+_Black_ and formatting code.
 
 Support for formatting Python 2 code was removed in version 22.0. While we've made no
 plans to stop supporting older Python 3 minor versions immediately, their support might


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
Closes #2251: I've included a short Python support policy to our FAQ. TL;DR: we promise to support all non-EOL versions, but don't promise to keep old 3+ versions laying around if we decide to remove them at some point.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add new / update outdated documentation?

### Some discussion:
- Is the content fine? It's basically what we do now, or at least the least strict and most convenient version of it. We could promise a deprecation period as well.
- Should we relocate the text? The Python 2 support text was nice as a FAQ entry, but this could be better off somewhere else.