### PR TITLE
Allow `for`'s target expression to be starred

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@
 
 ### Parser
 
-- Black can now parse starred expressions in the target of the `for`/`async for`
+- Black can now parse starred expressions in the target of `for` and `async for`
   statements, e.g `for item in *items_1, *items_2: pass` (#2879).
 
 ### Performance

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,8 @@
 
 ### Parser
 
-<!-- Changes to the parser or to version autodetection -->
+- Black can now parse starred expressions in the target of the `for`/`async for`
+  statements, e.g `for item in *items_1, *items_2: pass` (#2879).
 
 ### Performance
 

--- a/src/blib2to3/Grammar.txt
+++ b/src/blib2to3/Grammar.txt
@@ -109,7 +109,7 @@ compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef 
 async_stmt: ASYNC (funcdef | with_stmt | for_stmt)
 if_stmt: 'if' namedexpr_test ':' suite ('elif' namedexpr_test ':' suite)* ['else' ':' suite]
 while_stmt: 'while' namedexpr_test ':' suite ['else' ':' suite]
-for_stmt: 'for' exprlist 'in' testlist ':' suite ['else' ':' suite]
+for_stmt: 'for' exprlist 'in' testlist_star_expr ':' suite ['else' ':' suite]
 try_stmt: ('try' ':' suite
            ((except_clause ':' suite)+
 	    ['else' ':' suite]

--- a/tests/data/starred_for_target.py
+++ b/tests/data/starred_for_target.py
@@ -1,0 +1,27 @@
+for x in *a, *b:
+    print(x)
+
+for x in a, b, *c:
+    print(x)
+
+for x in *a, b, c:
+    print(x)
+
+for x in *a, b, *c:
+    print(x)
+
+async for x in *a, *b:
+    print(x)
+
+async for x in *a, b, *c:
+    print(x)
+
+async for x in a, b, *c:
+    print(x)
+
+async for x in (
+    *loooooooooooooooooooooong,
+    very,
+    *loooooooooooooooooooooooooooooooooooooooooooooooong,
+):
+    print(x)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -62,6 +62,7 @@ SIMPLE_CASES: List[str] = [
 ]
 
 PY310_CASES: List[str] = [
+    "starred_for_target",
     "pattern_matching_simple",
     "pattern_matching_complex",
     "pattern_matching_extras",


### PR DESCRIPTION
Fixes #2878 