### PR TITLE
Move test for g:load_black to improve plugin performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -134,6 +134,7 @@ and the first release covered by our new
 
 ### Integrations
 
+- Move test to disable plugin in vim/neovim, which speeds up loading (#2896)
 - Update GitHub action to support containerized runs (#2748)
 
 ### Documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Move test to disable plugin in Vim/Neovim, which speeds up loading (#2896)
 
 ### Output
 
@@ -134,7 +135,6 @@ and the first release covered by our new
 
 ### Integrations
 
-- Move test to disable plugin in vim/neovim, which speeds up loading (#2896)
 - Update GitHub action to support containerized runs (#2748)
 
 ### Documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+
 - Move test to disable plugin in Vim/Neovim, which speeds up loading (#2896)
 
 ### Output

--- a/plugin/black.vim
+++ b/plugin/black.vim
@@ -15,6 +15,10 @@
 "  1.2:
 "    - use autoload script
 
+if exists("g:load_black")
+  finish
+endif
+
 if v:version < 700 || !has('python3')
     func! __BLACK_MISSING()
         echo "The black.vim plugin requires vim7.0+ with Python 3.6 support."
@@ -23,10 +27,6 @@ if v:version < 700 || !has('python3')
     command! BlackUpgrade :call __BLACK_MISSING()
     command! BlackVersion :call __BLACK_MISSING()
     finish
-endif
-
-if exists("g:load_black")
-  finish
 endif
 
 let g:load_black = "py1.0"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

If a vim/neovim user wishes to suppress loading the vim plugin by setting `g:load_black` in their VIMRC (for me, Arch linux automatically adds the plugin to Neovim's RTP, even though I'm not using it), the [current location of the test](https://github.com/psf/black/blob/9b161072c13c0ec32c9ca9bd48fad17f781a56d4/plugin/black.vim#L28-L30) comes [after a call to `has('python3')`](https://github.com/psf/black/blob/9b161072c13c0ec32c9ca9bd48fad17f781a56d4/plugin/black.vim#L18). This adds, in my tests, between 35 and 45 ms to Vim load time (which I know isn't a lot but it's also unnecessary). Moving the call to `exists('g:load_black')` to before the call to `has('python3')` removes this unnecessary test and speeds up loading.

Here is `nvim --startuptime` output for the plugin as written up to loading black.vim (note the 35ms load time due to sourcing python providers):

~~~
times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.015  000.015: --- NVIM STARTING ---
000.562  000.547: locale set
001.016  000.454: inits 1
001.037  000.021: window checked
004.140  003.103: parsing arguments
004.233  000.093: expanding arguments
004.256  000.023: inits 2
004.598  000.342: init highlight
004.600  000.002: waiting for UI
005.949  001.349: done waiting for UI
005.960  000.011: init screen for UI
005.975  000.015: init default mappings
006.038  000.063: init default autocommands
006.706  000.045  000.045: sourcing /usr/local/share/nvim/runtime/ftplugin.vim
006.819  000.023  000.023: sourcing /usr/local/share/nvim/runtime/indent.vim
006.870  000.011  000.011: sourcing /usr/share/nvim/archlinux.vim
006.874  000.029  000.018: sourcing /etc/xdg/nvim/sysinit.vim
008.355  000.177  000.177: sourcing /usr/local/share/nvim/runtime/autoload/provider/clipboard.vim
010.398  000.648  000.648: sourcing /home/andrew/.config/nvim/colors/lushwal.vim
010.897  004.000  003.175: sourcing /home/andrew/.config/nvim/init.lua
010.916  000.780: sourcing vimrc file(s)
011.331  000.012  000.012: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/fusion.vim
011.357  000.013  000.013: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gdresource.vim
011.378  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gdscript.vim
011.399  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/glimmer.vim
011.420  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/glsl.vim
011.441  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gowork.vim
011.466  000.013  000.013: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/graphql.vim
011.488  000.011  000.011: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hack.vim
011.513  000.013  000.013: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hcl.vim
011.533  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/heex.vim
011.554  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hjson.vim
011.575  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/json5.vim
011.599  000.013  000.013: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/ledger.vim
011.620  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/nix.vim
011.640  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/prisma.vim
011.660  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/pug.vim
011.682  000.010  000.010: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/ql.vim
011.711  000.018  000.018: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/query.vim
011.732  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/surface.vim
011.753  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/teal.vim
011.772  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/tlaplus.vim
011.792  000.009  000.009: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/yang.vim
011.912  000.011  000.011: sourcing /usr/share/vim/vimfiles/ftdetect/PKGBUILD.vim
011.940  000.017  000.017: sourcing /usr/share/vim/vimfiles/ftdetect/meson.vim
012.122  001.065  000.804: sourcing /usr/local/share/nvim/runtime/filetype.lua
012.176  000.013  000.013: sourcing /usr/local/share/nvim/runtime/filetype.vim
012.394  000.068  000.068: sourcing /usr/local/share/nvim/runtime/syntax/synload.vim
012.463  000.230  000.161: sourcing /usr/local/share/nvim/runtime/syntax/syntax.vim
013.144  000.014  000.014: sourcing /usr/local/share/nvim/runtime/plugin/gzip.vim
013.165  000.009  000.009: sourcing /usr/local/share/nvim/runtime/plugin/health.vim
013.212  000.037  000.037: sourcing /usr/local/share/nvim/runtime/plugin/man.vim
013.627  000.172  000.172: sourcing /usr/local/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
013.706  000.482  000.310: sourcing /usr/local/share/nvim/runtime/plugin/matchit.vim
013.831  000.113  000.113: sourcing /usr/local/share/nvim/runtime/plugin/matchparen.vim
014.130  000.286  000.286: sourcing /usr/local/share/nvim/runtime/plugin/netrwPlugin.vim
014.163  000.009  000.009: sourcing /usr/local/share/nvim/runtime/plugin/rplugin.vim
014.225  000.046  000.046: sourcing /usr/local/share/nvim/runtime/plugin/shada.vim
014.270  000.019  000.019: sourcing /usr/local/share/nvim/runtime/plugin/spellfile.vim
014.302  000.015  000.015: sourcing /usr/local/share/nvim/runtime/plugin/tarPlugin.vim
014.327  000.011  000.011: sourcing /usr/local/share/nvim/runtime/plugin/tohtml.vim
014.377  000.035  000.035: sourcing /usr/local/share/nvim/runtime/plugin/tutor.vim
014.413  000.018  000.018: sourcing /usr/local/share/nvim/runtime/plugin/zipPlugin.vim
015.539  000.059  000.059: sourcing /usr/local/share/nvim/runtime/autoload/provider/pythonx.vim
049.773  000.377  000.377: sourcing /usr/local/share/nvim/runtime/autoload/remote/host.vim
049.973  034.593  034.157: sourcing /usr/local/share/nvim/runtime/autoload/provider/python3.vim
050.018  035.498  000.905: sourcing /usr/share/vim/vimfiles/plugin/black.vim
~~~

Here's `nvim --startuptime` with my PR applied (note that the python provider is not loaded):

~~~


times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.017  000.017: --- NVIM STARTING ---
000.557  000.540: locale set
001.132  000.575: inits 1
001.158  000.026: window checked
006.759  005.601: parsing arguments
007.022  000.264: expanding arguments
007.063  000.041: inits 2
008.126  001.063: init highlight
008.132  000.006: waiting for UI
010.211  002.079: done waiting for UI
010.247  000.036: init screen for UI
010.286  000.038: init default mappings
010.444  000.158: init default autocommands
012.239  000.102  000.102: sourcing /usr/local/share/nvim/runtime/ftplugin.vim
012.543  000.066  000.066: sourcing /usr/local/share/nvim/runtime/indent.vim
012.677  000.026  000.026: sourcing /usr/share/nvim/archlinux.vim
012.687  000.072  000.046: sourcing /etc/xdg/nvim/sysinit.vim
017.120  000.536  000.536: sourcing /usr/local/share/nvim/runtime/autoload/provider/clipboard.vim
022.962  001.965  001.965: sourcing /home/andrew/.config/nvim/colors/lushwal.vim
024.390  011.644  009.143: sourcing /home/andrew/.config/nvim/init.lua
024.429  002.102: sourcing vimrc file(s)
025.665  000.041  000.041: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/fusion.vim
025.750  000.042  000.042: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gdresource.vim
025.816  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gdscript.vim
025.880  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/glimmer.vim
025.943  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/glsl.vim
026.006  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/gowork.vim
026.087  000.044  000.044: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/graphql.vim
026.193  000.070  000.070: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hack.vim
026.278  000.044  000.044: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hcl.vim
026.341  000.025  000.025: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/heex.vim
026.404  000.027  000.027: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/hjson.vim
026.467  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/json5.vim
026.545  000.042  000.042: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/ledger.vim
026.607  000.025  000.025: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/nix.vim
026.669  000.025  000.025: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/prisma.vim
026.725  000.026  000.026: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/pug.vim
026.795  000.037  000.037: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/ql.vim
026.886  000.054  000.054: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/query.vim
026.951  000.027  000.027: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/surface.vim
027.015  000.027  000.027: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/teal.vim
027.076  000.024  000.024: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/tlaplus.vim
027.137  000.025  000.025: sourcing /home/andrew/.local/share/nvim/site/pack/packer/start/nvim-treesitter/ftdetect/yang.vim
027.491  000.037  000.037: sourcing /usr/share/vim/vimfiles/ftdetect/PKGBUILD.vim
027.581  000.053  000.053: sourcing /usr/share/vim/vimfiles/ftdetect/meson.vim
028.147  003.307  002.485: sourcing /usr/local/share/nvim/runtime/filetype.lua
028.277  000.040  000.040: sourcing /usr/local/share/nvim/runtime/filetype.vim
028.893  000.191  000.191: sourcing /usr/local/share/nvim/runtime/syntax/synload.vim
029.080  000.644  000.452: sourcing /usr/local/share/nvim/runtime/syntax/syntax.vim
031.100  000.045  000.045: sourcing /usr/local/share/nvim/runtime/plugin/gzip.vim
031.165  000.026  000.026: sourcing /usr/local/share/nvim/runtime/plugin/health.vim
031.294  000.093  000.093: sourcing /usr/local/share/nvim/runtime/plugin/man.vim
032.570  000.537  000.537: sourcing /usr/local/share/nvim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
032.823  001.491  000.954: sourcing /usr/local/share/nvim/runtime/plugin/matchit.vim
033.221  000.356  000.356: sourcing /usr/local/share/nvim/runtime/plugin/matchparen.vim
034.091  000.825  000.825: sourcing /usr/local/share/nvim/runtime/plugin/netrwPlugin.vim
034.188  000.028  000.028: sourcing /usr/local/share/nvim/runtime/plugin/rplugin.vim
034.389  000.147  000.147: sourcing /usr/local/share/nvim/runtime/plugin/shada.vim
034.530  000.064  000.064: sourcing /usr/local/share/nvim/runtime/plugin/spellfile.vim
034.626  000.042  000.042: sourcing /usr/local/share/nvim/runtime/plugin/tarPlugin.vim
034.699  000.029  000.029: sourcing /usr/local/share/nvim/runtime/plugin/tohtml.vim
034.790  000.044  000.044: sourcing /usr/local/share/nvim/runtime/plugin/tutor.vim
034.888  000.051  000.051: sourcing /usr/local/share/nvim/runtime/plugin/zipPlugin.vim
035.160  000.043  000.043: sourcing /usr/share/vim/vimfiles/plugin/black.vim

~~~

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
