### PR TITLE
Remove usage of _unicodefun module from dependency: 'click'

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1429,11 +1429,10 @@ def patch_click() -> None:
     """
     try:
         from click import core
-        from click import _unicodefun
     except ModuleNotFoundError:
         return
 
-    for module in (core, _unicodefun):
+    for module in core:
         if hasattr(module, "_verify_python3_env"):
             module._verify_python3_env = lambda: None  # type: ignore
         if hasattr(module, "_verify_python_env"):

--- a/tests/data/remove_for_brackets.py
+++ b/tests/data/remove_for_brackets.py
@@ -20,7 +20,7 @@ for k, v in d.items():
     print(k, v)
 
 # Don't touch tuple brackets after `in`
-for module in (core, _unicodefun):
+for module in core:
     if hasattr(module, "_verify_python3_env"):
         module._verify_python3_env = lambda: None
 


### PR DESCRIPTION
### Description

The `_unicodefun` module has been removed from the click library. 

In addition, it is also not actively being used in the `black` repository.

See reports here: 
• https://github.com/pallets/click/issues/2225
• https://github.com/pallets/click/issues/2198

### Checklist - did you ...

- [ n/a ] Add a CHANGELOG entry if necessary?
- [ n/a ] Add / update tests if necessary?
- [ n/a ] Add new / update outdated documentation?