### PR TITLE
Keep tests working w/ upcoming aiohttp 4.0.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,9 +32,6 @@ warn_unreachable=True
 disallow_untyped_defs=True
 check_untyped_defs=True
 
-# No incremental mode
-cache_dir=/dev/null
-
 [mypy-black]
 # The following is because of `patch_click()`. Remove when
 # we drop Python 3.6 support.

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -8,12 +9,18 @@ from tests.util import read_data, DETERMINISTIC_HEADER
 
 try:
     import blackd
-    from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+    from aiohttp.test_utils import AioHTTPTestCase
     from aiohttp import web
+except ImportError as e:
+    raise RuntimeError("Please install Black with the 'd' extra") from e
+
+try:
+    from aiohttp.test_utils import unittest_run_loop
 except ImportError:
-    has_blackd_deps = False
-else:
-    has_blackd_deps = True
+    # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
+    # removed it. To maintain compatibility we can make our own no-op decorator.
+    def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func
 
 
 @pytest.mark.blackd


### PR DESCRIPTION
### Description

aiohttp.test_utils.unittest_run_loop was deprecated since aiohttp 3.8 and aiohttp 4 (which isn't a thing quite yet) removes it. To maintain compatibility with the full range of versions we declare to support, test_blackd.py will now define a no-op replacement if it can't be imported.

Also, mypy is painfully slow to use without a cache, let's reenable it.

Resolves GH-2971.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
