### PR TITLE
Update FAQ: Mention formatting of custom jupyter cell magic

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,7 @@ _Black_ is timid about formatting Jupyter Notebooks. Cells containing any of the
 following will not be formatted:
 
 - automagics (e.g. `pip install black`)
-- non-Python cell magics (e.g. `%%writeline`)
+- non-Python cell magics (e.g. `%%writeline`). However these non-Python cell magics can be added with the flag `--python-cell-magics` e.g. `black --python-cell-magics "%%writeline" notebooks/foo.ipynb`.
 - multiline magics, e.g.:
 
   ```python

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,8 @@ _Black_ is timid about formatting Jupyter Notebooks. Cells containing any of the
 following will not be formatted:
 
 - automagics (e.g. `pip install black`)
-- non-Python cell magics (e.g. `%%writeline`). These can be added with the flag `--python-cell-magics`, e.g. `black --python-cell-magics writeline hello.ipynb`.
+- non-Python cell magics (e.g. `%%writeline`). These can be added with the flag
+  `--python-cell-magics`, e.g. `black --python-cell-magics writeline hello.ipynb`.
 - multiline magics, e.g.:
 
   ```python

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,7 @@ _Black_ is timid about formatting Jupyter Notebooks. Cells containing any of the
 following will not be formatted:
 
 - automagics (e.g. `pip install black`)
-- non-Python cell magics (e.g. `%%writeline`). However these non-Python cell magics can be added with the flag `--python-cell-magics` e.g. `black --python-cell-magics "%%writeline" notebooks/foo.ipynb`.
+- non-Python cell magics (e.g. `%%writeline`). However these non-Python cell magics can be added with the flag `--python-cell-magics` e.g. `black --python-cell-magics writeline hello.ipynb`.
 - multiline magics, e.g.:
 
   ```python

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,7 @@ _Black_ is timid about formatting Jupyter Notebooks. Cells containing any of the
 following will not be formatted:
 
 - automagics (e.g. `pip install black`)
-- non-Python cell magics (e.g. `%%writeline`). However these non-Python cell magics can be added with the flag `--python-cell-magics` e.g. `black --python-cell-magics writeline hello.ipynb`.
+- non-Python cell magics (e.g. `%%writeline`). These can be added with the flag `--python-cell-magics`, e.g. `black --python-cell-magics writeline hello.ipynb`.
 - multiline magics, e.g.:
 
   ```python


### PR DESCRIPTION

### Description

Two month ago, #2744 introduced a way to support formatting of jupyter cells with custom python cell magics.
In the current FAQ it is mentioned that this would not be possible: https://black.readthedocs.io/en/latest/faq.html#why-is-my-jupyter-notebook-cell-not-formatted
Therefore I updated the FAQ and mentioned the new `black --python-cell-magics writeline hello.ipynb` syntax.
I've also tested this locally:

https://user-images.githubusercontent.com/44469195/160990792-58f1f950-dbd0-4f1a-9173-58a80a6336d5.mp4



### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary? nope
- [ ] Add / update tests if necessary? nope 
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
