### PR TITLE
Remove redundant parentheses around awaited coroutines/tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Parentheses around awaited coroutines/tasks are now managed (#2991)
+- Remove redundant parentheses around awaited objects (#2991)
 - Remove unnecessary parentheses from `with` statements (#2926)
 
 ### _Blackd_

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Parentheses around awaited coroutines/tasks are now managed (#2991)
 - Remove unnecessary parentheses from `with` statements (#2926)
 
 ### _Blackd_

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -226,6 +226,37 @@ class LineGenerator(Visitor[Line]):
             ):
                 wrap_in_parentheses(node, leaf)
 
+        if (
+            Preview.remove_redundant_parens in self.mode
+            and node.children[0].type == token.AWAIT
+            and len(node.children) > 1
+        ):
+            if (
+                node.children[1].type == syms.atom
+                and node.children[1].children[0].type == token.LPAR
+            ):
+                if maybe_make_parens_invisible_in_atom(
+                    node.children[1],
+                    parent=node,
+                    remove_brackets_around_comma=True,
+                ):
+                    wrap_in_parentheses(node, node.children[1], visible=False)
+                if (
+                    node.children[1].children[1].type != syms.power
+                    and isinstance(node.children[1].children[0], Leaf)
+                    and isinstance(node.children[1].children[-1], Leaf)
+                ):
+                    # Since await is an expression
+                    # it is syntactically possible
+                    # that someone would write `await (1 % 2)`
+                    # (although realistically unlikely given that it's a runtime error).
+                    # If we don't encounter a power being wrapped then we
+                    # should not remove all brackets due to operator precedence.
+                    # https://peps.python.org/pep-0492/#updated-operator-precedence-table
+                    # N.B. We've still removed any redundant nested brackets though :)
+                    ensure_visible(node.children[1].children[0])
+                    ensure_visible(node.children[1].children[-1])
+
         yield from self.visit_default(node)
 
     def visit_SEMI(self, leaf: Leaf) -> Iterator[Line]:

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -3,7 +3,7 @@ Generating lines of code.
 """
 from functools import partial, wraps
 import sys
-from typing import Collection, Iterator, List, Optional, Set, Union
+from typing import Collection, Iterator, List, Optional, Set, Union, cast
 
 from black.nodes import WHITESPACE, RARROW, STATEMENT, STANDALONE_COMMENT
 from black.nodes import ASSIGNMENTS, OPENING_BRACKETS, CLOSING_BRACKETS
@@ -226,42 +226,8 @@ class LineGenerator(Visitor[Line]):
             ):
                 wrap_in_parentheses(node, leaf)
 
-        if (
-            Preview.remove_redundant_parens in self.mode
-            and node.children[0].type == token.AWAIT
-            and len(node.children) > 1
-        ):
-            if (
-                node.children[1].type == syms.atom
-                and node.children[1].children[0].type == token.LPAR
-            ):
-                if maybe_make_parens_invisible_in_atom(
-                    node.children[1],
-                    parent=node,
-                    remove_brackets_around_comma=True,
-                ):
-                    wrap_in_parentheses(node, node.children[1], visible=False)
-                if (
-                    isinstance(node.children[1].children[0], Leaf)
-                    and isinstance(node.children[1].children[-1], Leaf)
-                    and (
-                        node.children[1].children[1].type != syms.power
-                        or (
-                            node.children[1].children[1].type == syms.power
-                            and node.children[1].children[1].children[0].type
-                            == token.AWAIT
-                        )
-                    )
-                ):
-                    # Since await is an expression we shouldn't remove
-                    # brackets in cases where this would change
-                    # the AST due to operator precedence.
-                    # Therefore we only aim to remove brackets around
-                    # power nodes that aren't also await expressions themselves.
-                    # https://peps.python.org/pep-0492/#updated-operator-precedence-table
-                    # N.B. We've still removed any redundant nested brackets though :)
-                    ensure_visible(node.children[1].children[0])
-                    ensure_visible(node.children[1].children[-1])
+        if Preview.remove_redundant_parens in self.mode:
+            remove_await_parens(node)
 
         yield from self.visit_default(node)
 
@@ -929,6 +895,42 @@ def normalize_invisible_parens(
         check_lpar = isinstance(child, Leaf) and (
             child.value in parens_after or comma_check
         )
+
+
+def remove_await_parens(node: Node) -> None:
+    if node.children[0].type == token.AWAIT and len(node.children) > 1:
+        if (
+            node.children[1].type == syms.atom
+            and node.children[1].children[0].type == token.LPAR
+        ):
+            if maybe_make_parens_invisible_in_atom(
+                node.children[1],
+                parent=node,
+                remove_brackets_around_comma=True,
+            ):
+                wrap_in_parentheses(node, node.children[1], visible=False)
+
+            # Since await is an expression we shouldn't remove
+            # brackets in cases where this would change
+            # the AST due to operator precedence.
+            # Therefore we only aim to remove brackets around
+            # power nodes that aren't also await expressions themselves.
+            # https://peps.python.org/pep-0492/#updated-operator-precedence-table
+            # N.B. We've still removed any redundant nested brackets though :)
+            opening_bracket = cast(Leaf, node.children[1].children[0])
+            closing_bracket = cast(Leaf, node.children[1].children[-1])
+            bracket_contents = cast(Node, node.children[1].children[1])
+            if bracket_contents.type != syms.power:
+                ensure_visible(opening_bracket)
+                ensure_visible(closing_bracket)
+            elif (
+                bracket_contents.type == syms.power
+                and bracket_contents.children[0].type == token.AWAIT
+            ):
+                ensure_visible(opening_bracket)
+                ensure_visible(closing_bracket)
+                # If we are in a nested await then recurse down.
+                remove_await_parens(bracket_contents)
 
 
 def remove_with_parens(node: Node, parent: Node) -> None:

--- a/tests/data/remove_await_parens.py
+++ b/tests/data/remove_await_parens.py
@@ -57,6 +57,13 @@ async def main():
         )))))))))))))
     )
 
+# Keep brackets around non power operations and nested awaits
+async def main():
+    await (set_of_tasks | other_set)
+
+async def main():
+    await (await asyncio.sleep(1))
+
 # output
 import asyncio
 
@@ -120,3 +127,12 @@ async def main():
 # Cr@zY Br@ck3Tz
 async def main():
     await black(1)
+
+
+# Keep brackets around non power operations and nested awaits
+async def main():
+    await (set_of_tasks | other_set)
+
+
+async def main():
+    await (await asyncio.sleep(1))

--- a/tests/data/remove_await_parens.py
+++ b/tests/data/remove_await_parens.py
@@ -64,6 +64,13 @@ async def main():
 async def main():
     await (await asyncio.sleep(1))
 
+# It's brackets all the way down...
+async def main():
+    await (await (asyncio.sleep(1)))
+
+async def main():
+    await (await (await (await (await (asyncio.sleep(1))))))
+
 # output
 import asyncio
 
@@ -136,3 +143,12 @@ async def main():
 
 async def main():
     await (await asyncio.sleep(1))
+
+
+# It's brackets all the way down...
+async def main():
+    await (await asyncio.sleep(1))
+
+
+async def main():
+    await (await (await (await (await asyncio.sleep(1)))))

--- a/tests/data/remove_await_parens.py
+++ b/tests/data/remove_await_parens.py
@@ -1,0 +1,122 @@
+import asyncio
+
+# Control example
+async def main():
+    await asyncio.sleep(1)
+
+# Remove brackets for short coroutine/task
+async def main():
+    await (asyncio.sleep(1))
+
+async def main():
+    await (
+        asyncio.sleep(1)
+    )
+
+async def main():
+    await (asyncio.sleep(1)
+    )
+
+# Check comments
+async def main():
+    await (  # Hello
+        asyncio.sleep(1)
+    )
+
+async def main():
+    await (
+        asyncio.sleep(1)  # Hello
+    )
+
+async def main():
+    await (
+        asyncio.sleep(1)
+    )  # Hello
+
+# Long lines
+async def main():
+    await asyncio.gather(asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1))
+
+# Same as above but with magic trailing comma in function
+async def main():
+    await asyncio.gather(asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1),)
+
+# Cr@zY Br@ck3Tz
+async def main():
+    await (
+        (((((((((((((
+        (((        (((
+        (((         (((
+        (((         (((
+        (((        (((
+        ((black(1)))
+        )))        )))
+        )))         )))
+        )))         )))
+        )))        )))
+        )))))))))))))
+    )
+
+# output
+import asyncio
+
+# Control example
+async def main():
+    await asyncio.sleep(1)
+
+
+# Remove brackets for short coroutine/task
+async def main():
+    await asyncio.sleep(1)
+
+
+async def main():
+    await asyncio.sleep(1)
+
+
+async def main():
+    await asyncio.sleep(1)
+
+
+# Check comments
+async def main():
+    await asyncio.sleep(1)  # Hello
+
+
+async def main():
+    await asyncio.sleep(1)  # Hello
+
+
+async def main():
+    await asyncio.sleep(1)  # Hello
+
+
+# Long lines
+async def main():
+    await asyncio.gather(
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+    )
+
+
+# Same as above but with magic trailing comma in function
+async def main():
+    await asyncio.gather(
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+        asyncio.sleep(1),
+    )
+
+
+# Cr@zY Br@ck3Tz
+async def main():
+    await black(1)

--- a/tests/data/remove_await_parens.py
+++ b/tests/data/remove_await_parens.py
@@ -64,7 +64,13 @@ async def main():
 async def main():
     await (await asyncio.sleep(1))
 
-# It's brackets all the way down...
+# It's awaits all the way down...
+async def main():
+    await (await x)
+
+async def main():
+    await (yield x)
+
 async def main():
     await (await (asyncio.sleep(1)))
 
@@ -145,7 +151,15 @@ async def main():
     await (await asyncio.sleep(1))
 
 
-# It's brackets all the way down...
+# It's awaits all the way down...
+async def main():
+    await (await x)
+
+
+async def main():
+    await (yield x)
+
+
 async def main():
     await (await asyncio.sleep(1))
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -83,6 +83,7 @@ PREVIEW_CASES: List[str] = [
     "remove_except_parens",
     "remove_for_brackets",
     "one_element_subscript",
+    "remove_await_parens",
 ]
 
 SOURCES: List[str] = [


### PR DESCRIPTION
### Description
Closes #275. Remove redundant parentheses around awaited coroutines/tasks.

This is a tricky one as `await` is technically an expression and therefore in certain situations requires brackets for operator precedence.
However, the vast majority of `await` usage is just `await some_coroutine(...)` and similar in format to `return` statements. Therefore this PR removes redundant parens around these `await` expressions.

Let's see what diff shades shades has to say...

### Checklist - did you ...

- [X] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?
