### PR TITLE
Output python version and implementation as part of `--version` flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 
 <!-- Changes to Black's terminal output and error messages -->
 
+- Output python version and implementation as part of `--version` flag (#2997)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -384,7 +384,7 @@ def validate_regex(
     version=__version__,
     message=(
         f"%(prog)s, %(version)s (compiled: {'yes' if COMPILED else 'no'})\n"
-        f"python, {platform.python_version()} ({platform.python_implementation()})"
+        f"Python ({platform.python_implementation()}) {platform.python_version()}"
     ),
 )
 @click.argument(

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -10,6 +10,7 @@ from multiprocessing import Manager, freeze_support
 import os
 from pathlib import Path
 from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
+import platform
 import re
 import signal
 import sys
@@ -381,7 +382,10 @@ def validate_regex(
 )
 @click.version_option(
     version=__version__,
-    message=f"%(prog)s, %(version)s (compiled: {'yes' if COMPILED else 'no'})",
+    message=(
+        f"%(prog)s, %(version)s (compiled: {'yes' if COMPILED else 'no'})\n"
+        f"python, {platform.python_version()} ({platform.python_implementation()})"
+    ),
 )
 @click.argument(
     "src",


### PR DESCRIPTION
### Description

Closes #2992. Updates the `--version` flag to include details of python version running black.
e.g.
```
black, 22.1.1.dev56+g421383d.d20220405 (compiled: no)
python, 3.9.12 (CPython)
```
I've also included the python implementation in case we ever get PyPy (or other implementation) specific issues.

### Checklist - did you ...

- [X] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?
