### PR TITLE
Quote black[jupyter] and black[d] in installation docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,7 +17,7 @@ Also, you can try out _Black_ online for minimal fuss on the
 ## Installation
 
 _Black_ can be installed by running `pip install black`. It requires Python 3.6.2+ to
-run. If you want to format Jupyter Notebooks, install with `pip install black[jupyter]`.
+run. If you want to format Jupyter Notebooks, install with `pip install 'black[jupyter]'`.
 
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,7 +17,8 @@ Also, you can try out _Black_ online for minimal fuss on the
 ## Installation
 
 _Black_ can be installed by running `pip install black`. It requires Python 3.6.2+ to
-run. If you want to format Jupyter Notebooks, install with `pip install 'black[jupyter]'`.
+run. If you want to format Jupyter Notebooks, install with
+`pip install 'black[jupyter]'`.
 
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:
 

--- a/docs/usage_and_configuration/black_as_a_server.md
+++ b/docs/usage_and_configuration/black_as_a_server.md
@@ -7,7 +7,7 @@ process every time you want to blacken a file.
 ## Usage
 
 `blackd` is not packaged alongside _Black_ by default because it has additional
-dependencies. You will need to execute `pip install black[d]` to install it.
+dependencies. You will need to execute `pip install 'black[d]'` to install it.
 
 You can start the server on the default port, binding only to the local interface by
 running `blackd`. You will see a single line mentioning the server's version, and the


### PR DESCRIPTION
We just got someone on Discord who was confused because the command as written caused their shell to try to do command expansion.