### PR TITLE
follow python typing export requirements

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -37,7 +37,6 @@ from click.core import ParameterSource
 from dataclasses import replace
 from mypy_extensions import mypyc_attr
 
-from . import const as const, mode as mode
 from black.const import (
     DEFAULT_LINE_LENGTH as DEFAULT_LINE_LENGTH,
     DEFAULT_INCLUDES,

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -68,7 +68,7 @@ from black.output import (
     dump_to_file as dump_to_file,
     ipynb_diff,
     diff as diff,
-    color_diff,
+    color_diff as color_diff,
     out as out,
     err as err,
 )
@@ -90,7 +90,7 @@ from black.files import (
     wrap_stream_for_windows,
 )
 from black.parsing import (
-    InvalidInput as InvalidInput,
+    InvalidInput as InvalidInput,  # noqa F401
     lib2to3_parse as lib2to3_parse,
     parse_ast,
     stringify_ast,

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -72,7 +72,11 @@ from black.output import (
     out as out,
     err as err,
 )
-from black.report import Report as Report, Changed, NothingChanged as NothingChanged
+from black.report import (
+    Report as Report,
+    Changed as Changed,
+    NothingChanged as NothingChanged,
+)
 from black.files import (
     find_project_root as find_project_root,
     find_pyproject_toml as find_pyproject_toml,

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -37,29 +37,60 @@ from click.core import ParameterSource
 from dataclasses import replace
 from mypy_extensions import mypyc_attr
 
-from black.const import DEFAULT_LINE_LENGTH, DEFAULT_INCLUDES, DEFAULT_EXCLUDES
-from black.const import STDIN_PLACEHOLDER
-from black.nodes import STARS, syms, is_simple_decorator_expression
-from black.nodes import is_string_token
+from . import const as const, mode as mode
+from black.const import (
+    DEFAULT_LINE_LENGTH as DEFAULT_LINE_LENGTH,
+    DEFAULT_INCLUDES,
+    DEFAULT_EXCLUDES,
+    STDIN_PLACEHOLDER,
+)
+from black.nodes import STARS, syms, is_simple_decorator_expression, is_string_token
 from black.lines import Line, EmptyLineTracker
 from black.linegen import transform_line, LineGenerator, LN
 from black.comments import normalize_fmt_off
-from black.mode import FUTURE_FLAG_TO_FEATURE, Mode, TargetVersion
-from black.mode import Feature, supports_feature, VERSION_TO_FEATURES
-from black.cache import read_cache, write_cache, get_cache_info, filter_cached, Cache
-from black.concurrency import cancel, shutdown, maybe_install_uvloop
-from black.output import dump_to_file, ipynb_diff, diff, color_diff, out, err
-from black.report import Report, Changed, NothingChanged
-from black.files import (
-    find_project_root,
-    find_pyproject_toml,
-    parse_pyproject_toml,
-    find_user_pyproject_toml,
+from black.mode import (
+    FUTURE_FLAG_TO_FEATURE,
+    Mode as Mode,
+    TargetVersion as TargetVersion,
+    Feature,
+    supports_feature,
+    VERSION_TO_FEATURES,
 )
-from black.files import gen_python_files, get_gitignore, normalize_path_maybe_ignore
-from black.files import wrap_stream_for_windows
-from black.parsing import InvalidInput  # noqa F401
-from black.parsing import lib2to3_parse, parse_ast, stringify_ast
+from black.cache import (
+    read_cache as read_cache,
+    write_cache as write_cache,
+    get_cache_info as get_cache_info,
+    filter_cached as filter_cached,
+    Cache,
+)
+from black.concurrency import cancel, shutdown, maybe_install_uvloop
+from black.output import (
+    dump_to_file as dump_to_file,
+    ipynb_diff,
+    diff as diff,
+    color_diff,
+    out as out,
+    err as err,
+)
+from black.report import Report as Report, Changed, NothingChanged as NothingChanged
+from black.files import (
+    find_project_root as find_project_root,
+    find_pyproject_toml as find_pyproject_toml,
+    parse_pyproject_toml as parse_pyproject_toml,
+    find_user_pyproject_toml as find_user_pyproject_toml,
+)
+from black.files import (
+    gen_python_files,
+    get_gitignore,
+    normalize_path_maybe_ignore,
+    wrap_stream_for_windows,
+)
+from black.parsing import (
+    InvalidInput as InvalidInput,
+    lib2to3_parse as lib2to3_parse,
+    parse_ast,
+    stringify_ast,
+)
 from black.handle_ipynb_magics import (
     mask_cell,
     unmask_cell,

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -81,8 +81,6 @@ from black.files import (
     find_pyproject_toml as find_pyproject_toml,
     parse_pyproject_toml as parse_pyproject_toml,
     find_user_pyproject_toml as find_user_pyproject_toml,
-)
-from black.files import (
     gen_python_files,
     get_gitignore,
     normalize_path_maybe_ignore,

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -29,11 +29,12 @@ from typing import (
 )
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 import re
+import click
 from click import unstyle
 from click.testing import CliRunner
+import click.testing
 from pathspec import PathSpec
 
 import black
@@ -1614,7 +1615,7 @@ class BlackTestCase(BlackBaseTestCase):
         """
         Test that an unexpected EOF SyntaxError is nicely presented.
         """
-        with pytest.raises(black.parsing.InvalidInput) as exc_info:
+        with pytest.raises(black.InvalidInput) as exc_info:
             black.lib2to3_parse("print(", {})
 
         exc_info.match("Cannot parse: 2:0: EOF in multi-line statement")


### PR DESCRIPTION
### Description

Black's` __init__.py` file does not explicitly alias imported modules as themselves which is required for type-checking.

I grepped the code for things that were directly called from `black.` and added `X as X` for anything mentioned in the code + anything I thought seemed related.

This isn't really very important, I was just annoyed by some of the pyright warnings I was getting when using `black.Mode`.

Happy to alter the PR in anyway, if you think more or less should be exported from `__init__.py`

https://github.com/python/typing/blob/master/docs/source/stubs.rst#imports

I don't think it needs a mention in the changelog.

### Checklist - did you ... 
- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
