### PR TITLE
Stop pinning lark-parser

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,7 @@ skip_install = True
 deps =
     -r{toxinidir}/test_requirements.txt
     hypothesmith
-    lark-parser < 0.10.0
-; lark-parser's version is set due to a bug in hypothesis. Once it solved, that would be fixed.
+    lark-parser
 commands =
     pip install -e .[d]
     coverage erase


### PR DESCRIPTION
- Latest version works now

Test: `tox -e fuzz`