### PR TITLE
Strip pointless f-string

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+with (import <nixpkgs> { });
+mkShell {
+  buildInputs = with python3.pkgs; [ python pytest pathspec click mypy-extensions typing-extensions platformdirs tomli aiohttp ];
+  shellHooks = ''
+    export PYTHONPATH=$PWD/src:$PYTHONPATH
+    echo "version = '0.0'" > src/_black_version.py
+  '';
+}

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -26,7 +26,7 @@ from black.comments import generate_comments, list_comments, FMT_OFF
 from black.numerics import normalize_numeric_literal
 from black.strings import get_string_prefix, fix_docstring
 from black.strings import normalize_string_prefix, normalize_string_quotes
-from black.trans import Transformer, CannotTransform, StringMerger, StringSplitter
+from black.trans import Transformer, CannotTransform, StringMerger, StringSplitter, PointlessFStripper
 from black.trans import StringParenWrapper, StringParenStripper, hug_power_op
 from black.mode import Mode, Feature, Preview
 
@@ -390,6 +390,7 @@ def transform_line(
     string_paren_strip = StringParenStripper(ll, sn)
     string_split = StringSplitter(ll, sn)
     string_paren_wrap = StringParenWrapper(ll, sn)
+    string_fstrip = PointlessFStripper(ll, sn)
 
     transformers: List[Transformer]
     if (
@@ -470,6 +471,7 @@ def transform_line(
                 transformers = [delimiter_split, standalone_comment_split, rhs]
             else:
                 transformers = [rhs]
+    transformers.insert(0, string_fstrip)
     # It's always safe to attempt hugging of power operations and pretty much every line
     # could match.
     transformers.append(hug_power_op)

--- a/tests/data/fstring.py
+++ b/tests/data/fstring.py
@@ -10,9 +10,9 @@ f'Hello \'{tricky + "example"}\''
 
 # output
 
-f"f-string without formatted values is just a string"
-f"{{NOT a formatted value}}"
-f'{{NOT \'a\' "formatted" "value"}}'
+"f-string without formatted values is just a string"
+"{NOT a formatted value}"
+'{NOT \'a\' "formatted" "value"}'
 f"some f-string with {a} {few():.2f} {formatted.values!r}"
 f'some f-string with {a} {few(""):.2f} {formatted.values!r}'
 f"{f'''{'nested'} inner'''} outer"

--- a/tests/data/long_strings.py
+++ b/tests/data/long_strings.py
@@ -600,8 +600,8 @@ def foo():
 
 x = (
     "This is a {really} long string that needs to be split without a doubt (i.e."
-    f" most definitely). In short, this {string} that can't possibly be {{expected}} to"
-    f" fit all together on one line. In {fact} it may even take up three or more"
+    " most definitely). In short, this {string} that can't possibly be {{expected}} to"
+    " fit all together on one line. In {fact} it may even take up three or more"
     " lines... like four or five... but probably just four."
 )
 


### PR DESCRIPTION
### Description

As promised, I came with patch that mostly does what is discussed in #3081.
Code quality is back-of-envelope, and not all tests are converted. I will fix
it once we decide what to do with the most major issue:

```
Black produced code that is not equivalent to the source
```

I can't argue that it is very good and valuable sanity check, and just turning
it off seems reckless. Ideas?
