### PR TITLE
Test run black on self

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.[d]'
+          python -m pip install tox
 
       - name: Lint
         uses: pre-commit/action@v2.0.3
+
+      - name: Run On Self
+        run: |
+          tox -e run_self

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,6 @@ exclude: ^(src/blib2to3/|profiling/|tests/data/)
 repos:
   - repo: local
     hooks:
-      - id: black
-        name: black
-        language: system
-        entry: black
-        minimum_pre_commit_version: 2.9.2
-        require_serial: true
-        types_or: [python, pyi]
-
       - id: check-pre-commit-rev-in-example
         name: Check pre-commit rev in example
         language: python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,10 @@
 
 - Fixed strtobool function. It didn't parse true/on/false/off. (#3025)
 
+### Maintenance
+
+- Black does not run anymore as a pre-commit hook, but via Tox
+
 ## 22.3.0
 
 ### Preview style

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,10 +72,6 @@
 
 - Fixed strtobool function. It didn't parse true/on/false/off. (#3025)
 
-### Maintenance
-
-- Black does not run anymore as a pre-commit hook, but via Tox (#3114)
-
 ## 22.3.0
 
 ### Preview style

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,7 +74,7 @@
 
 ### Maintenance
 
-- Black does not run anymore as a pre-commit hook, but via Tox
+- Black does not run anymore as a pre-commit hook, but via Tox (#3114)
 
 ## 22.3.0
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,5 +1,5 @@
 from dataclasses import replace
-from typing import Any, Iterator, List
+from typing import Any, Iterator
 from unittest.mock import patch
 
 import pytest
@@ -13,47 +13,6 @@ from tests.util import (
     read_data,
     all_data_cases,
 )
-
-SOURCES: List[str] = [
-    "src/black/__init__.py",
-    "src/black/__main__.py",
-    "src/black/brackets.py",
-    "src/black/cache.py",
-    "src/black/comments.py",
-    "src/black/concurrency.py",
-    "src/black/const.py",
-    "src/black/debug.py",
-    "src/black/files.py",
-    "src/black/linegen.py",
-    "src/black/lines.py",
-    "src/black/mode.py",
-    "src/black/nodes.py",
-    "src/black/numerics.py",
-    "src/black/output.py",
-    "src/black/parsing.py",
-    "src/black/report.py",
-    "src/black/rusty.py",
-    "src/black/strings.py",
-    "src/black/trans.py",
-    "src/blackd/__init__.py",
-    "src/blib2to3/pygram.py",
-    "src/blib2to3/pytree.py",
-    "src/blib2to3/pgen2/conv.py",
-    "src/blib2to3/pgen2/driver.py",
-    "src/blib2to3/pgen2/grammar.py",
-    "src/blib2to3/pgen2/literals.py",
-    "src/blib2to3/pgen2/parse.py",
-    "src/blib2to3/pgen2/pgen.py",
-    "src/blib2to3/pgen2/tokenize.py",
-    "src/blib2to3/pgen2/token.py",
-    "setup.py",
-    "tests/test_black.py",
-    "tests/test_blackd.py",
-    "tests/test_format.py",
-    "tests/optional.py",
-    "tests/util.py",
-    "tests/conftest.py",
-]
 
 
 @pytest.fixture(autouse=True)
@@ -84,11 +43,6 @@ def test_preview_minimum_python_39_format(filename: str) -> None:
     source, expected = read_data("preview_39", filename)
     mode = black.Mode(preview=True)
     assert_format(source, expected, mode, minimum_version=(3, 9))
-
-
-@pytest.mark.parametrize("filename", SOURCES)
-def test_source_is_formatted(filename: str) -> None:
-    check_file("", filename, DEFAULT_MODE, data=False)
 
 
 # =============== #

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {,ci-}py{36,37,38,39,310,py3},fuzz
+envlist = {,ci-}py{36,37,38,39,310,py3},fuzz,run_self
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
@@ -61,3 +61,10 @@ commands =
     coverage erase
     coverage run fuzz.py
     coverage report
+
+[testenv:run_self]
+setenv = PYTHONPATH = {toxinidir}/src
+skip_install = True
+commands =
+    pip install -e .[d]
+    black --check {toxinidir}/src {toxinidir}/tests {toxinidir}/setup.py


### PR DESCRIPTION
### Description

Removed the hard coded `SOURCE` list from *test_format.py*. Now, black is run as part of the *Lint* CI and looks for sources automatically.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
