### PR TITLE
Remove trailing spaces in f-string expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Parentheses around return annotations are now managed (#2990)
 - Remove unnecessary parentheses from `with` statements (#2926)
 - Remove trailing newlines after code block open (#3035)
+- Remove trailing whitespaces inside f-string expressions (#3119)
 
 ### _Blackd_
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -74,3 +74,26 @@ def my_func():
 
 This new feature will be applied to **all code blocks**: `def`, `class`, `if`, `for`,
 `while`, `with`, `case` and `match`.
+
+### Removing trailing whitespaces in f-string expressions
+
+_Black_ will remove trailing whitespaces inside f-string expressions. That means that
+the following code:
+
+```python
+print(f"there are { 2 } unnecessary spaces in this f string")
+print(f"there are {   3} unnecessary spaces on the left")
+print(f"there are {3   } unnecessary spaces on the right")
+print(f"you should trim { 'me' } and {   'me!'  }")
+print(f"trimming is easy as {  1 + 1   } == {2}")
+```
+
+Will be changed to:
+
+```python
+print(f"there are {2} unnecessary spaces in this f string")
+print(f"there are {3} unnecessary spaces on the left")
+print(f"there are {3} unnecessary spaces on the right")
+print(f"you should trim {'me'} and {'me!'}")
+print(f"trimming is easy as {1 + 1} == {2}")
+```

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -26,7 +26,13 @@ from black.comments import generate_comments, list_comments, FMT_OFF
 from black.numerics import normalize_numeric_literal
 from black.strings import get_string_prefix, fix_docstring
 from black.strings import normalize_string_prefix, normalize_string_quotes
-from black.trans import Transformer, CannotTransform, StringMerger, StringSplitter
+from black.trans import (
+    Transformer,
+    CannotTransform,
+    StringMerger,
+    StringSplitter,
+    FStringNormalizer,
+)
 from black.trans import StringParenWrapper, StringParenStripper, hug_power_op
 from black.mode import Mode, Feature, Preview
 
@@ -409,6 +415,7 @@ def transform_line(
     ll = mode.line_length
     sn = mode.string_normalization
     string_merge = StringMerger(ll, sn)
+    f_string_normalizer = FStringNormalizer(ll, sn)
     string_paren_strip = StringParenStripper(ll, sn)
     string_split = StringSplitter(ll, sn)
     string_paren_wrap = StringParenWrapper(ll, sn)
@@ -426,7 +433,7 @@ def transform_line(
     ):
         # Only apply basic string preprocessing, since lines shouldn't be split here.
         if Preview.string_processing in mode:
-            transformers = [string_merge, string_paren_strip]
+            transformers = [string_merge, f_string_normalizer, string_paren_strip]
         else:
             transformers = []
     elif line.is_def:
@@ -472,6 +479,7 @@ def transform_line(
             if line.inside_brackets:
                 transformers = [
                     string_merge,
+                    f_string_normalizer,
                     string_paren_strip,
                     string_split,
                     delimiter_split,
@@ -482,6 +490,7 @@ def transform_line(
             else:
                 transformers = [
                     string_merge,
+                    f_string_normalizer,
                     string_paren_strip,
                     string_split,
                     string_paren_wrap,

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -270,6 +270,6 @@ def fixup_ast_constants(node: Union[ast.AST, ast3.AST]) -> Union[ast.AST, ast3.A
         return ast.Constant(value=node.value)
 
     if isinstance(node, (ast.JoinedStr, ast3.JoinedStr)) and len(node.values) == 1:
-        return node.values[0]
+        return fixup_ast_constants(node.values[0])
 
     return node

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -269,7 +269,7 @@ def fixup_ast_constants(node: Union[ast.AST, ast3.AST]) -> Union[ast.AST, ast3.A
     if isinstance(node, (ast.NameConstant, ast3.NameConstant)):
         return ast.Constant(value=node.value)
 
-    if isinstance(node, ast.JoinedStr) and len(node.values) == 1:
+    if isinstance(node, (ast.JoinedStr, ast3.JoinedStr)) and len(node.values) == 1:
         return node.values[0]
 
     return node

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -269,4 +269,7 @@ def fixup_ast_constants(node: Union[ast.AST, ast3.AST]) -> Union[ast.AST, ast3.A
     if isinstance(node, (ast.NameConstant, ast3.NameConstant)):
         return ast.Constant(value=node.value)
 
+    if isinstance(node, ast.JoinedStr) and len(node.values) == 1:
+        return node.values[0]
+
     return node

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -283,3 +283,36 @@ def iterate_f_string(s: str) -> Iterator[Tuple[int, int]]:
                 i += len(delim)
                 continue
         i += 1
+
+
+def fstring_contains_expr(s: str) -> bool:
+    """Checks if a given f-string contains an actual f-expression."""
+    return any(iterate_f_string(s))
+
+
+def normalize_f_string(string: str, prefix: str) -> str:
+    """
+    Pre-Conditions:
+        * assert_is_leaf_string(@string)
+
+    Returns:
+        * If @string is an f-string that contains no f-expressions, we
+        return a string identical to @string except that the 'f' prefix
+        has been stripped and all double braces (i.e. '{{' or '}}') have
+        been normalized (i.e. turned into '{' or '}').
+            OR
+        * Otherwise, we return @string.
+    """
+    assert_is_leaf_string(string)
+
+    if "f" in prefix and not fstring_contains_expr(string):
+        new_prefix = prefix.replace("f", "")
+
+        temp = string[len(prefix) :]
+        temp = re.sub(r"\{\{", "{", temp)
+        temp = re.sub(r"\}\}", "}", temp)
+        new_string = temp
+
+        return f"{new_prefix}{new_string}"
+    else:
+        return string

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -305,7 +305,9 @@ def normalize_f_string(string: str, prefix: str) -> str:
     """
     assert_is_leaf_string(string)
 
-    if "f" in prefix and not fstring_contains_expr(string):
+    if "f" not in prefix:
+        return string
+    if not fstring_contains_expr(string):
         new_prefix = prefix.replace("f", "")
 
         temp = string[len(prefix) :]
@@ -314,5 +316,9 @@ def normalize_f_string(string: str, prefix: str) -> str:
         new_string = temp
 
         return f"{new_prefix}{new_string}"
-    else:
-        return string
+    expr_indices_tuples = list(iterate_f_string(string))
+    expr_indices_tuples = expr_indices_tuples[::-1]
+    for i, j in expr_indices_tuples:
+        expr = string[i + 1 : j - 1].strip()
+        string = f"{string[:i]}{{{expr}}}{string[j:]}"
+    return string

--- a/tests/data/preview/docstring_preview.py
+++ b/tests/data/preview/docstring_preview.py
@@ -1,10 +1,13 @@
+a, b, c, d = 3, 5, 7, 9
+
+
 def docstring_almost_at_line_limit():
     """long docstring.................................................................
     """
 
 
 def docstring_almost_at_line_limit_with_prefix():
-    f"""long docstring................................................................
+    f"""long docstring {a}............................................................
     """
 
 
@@ -16,7 +19,7 @@ def mulitline_docstring_almost_at_line_limit():
 
 
 def mulitline_docstring_almost_at_line_limit_with_prefix():
-    f"""long docstring................................................................
+    f"""long docstring {b}............................................................
 
     ..................................................................................
     """
@@ -27,7 +30,7 @@ def docstring_at_line_limit():
 
 
 def docstring_at_line_limit_with_prefix():
-    f"""long docstring..............................................................."""
+    f"""long docstring {c}..........................................................."""
 
 
 def multiline_docstring_at_line_limit():
@@ -37,13 +40,15 @@ def multiline_docstring_at_line_limit():
 
 
 def multiline_docstring_at_line_limit_with_prefix():
-    f"""first line----------------------------------------------------------------------
+    f"""first line {d}------------------------------------------------------------------
 
     second line----------------------------------------------------------------------"""
 
 
 # output
 
+a, b, c, d = 3, 5, 7, 9
+
 
 def docstring_almost_at_line_limit():
     """long docstring.................................................................
@@ -51,7 +56,7 @@ def docstring_almost_at_line_limit():
 
 
 def docstring_almost_at_line_limit_with_prefix():
-    f"""long docstring................................................................
+    f"""long docstring {a}............................................................
     """
 
 
@@ -63,7 +68,7 @@ def mulitline_docstring_almost_at_line_limit():
 
 
 def mulitline_docstring_almost_at_line_limit_with_prefix():
-    f"""long docstring................................................................
+    f"""long docstring {b}............................................................
 
     ..................................................................................
     """
@@ -74,7 +79,7 @@ def docstring_at_line_limit():
 
 
 def docstring_at_line_limit_with_prefix():
-    f"""long docstring..............................................................."""
+    f"""long docstring {c}..........................................................."""
 
 
 def multiline_docstring_at_line_limit():
@@ -84,6 +89,6 @@ def multiline_docstring_at_line_limit():
 
 
 def multiline_docstring_at_line_limit_with_prefix():
-    f"""first line----------------------------------------------------------------------
+    f"""first line {d}------------------------------------------------------------------
 
     second line----------------------------------------------------------------------"""

--- a/tests/data/preview/long_strings.py
+++ b/tests/data/preview/long_strings.py
@@ -440,8 +440,8 @@ fstring = (
 )
 
 fstring_with_no_fexprs = (
-    f"Some regular string that needs to get split certainly but is NOT an fstring by"
-    f" any means whatsoever."
+    "Some regular string that needs to get split certainly but is NOT an fstring by any"
+    " means whatsoever."
 )
 
 comment_string = (  # This comment gets thrown to the top.

--- a/tests/data/preview/long_strings__regression.py
+++ b/tests/data/preview/long_strings__regression.py
@@ -1092,30 +1092,24 @@ assert (
     " 'rykangaroo$', 'ykangaroo$']"
 )
 message = (
-    f"1. Go to Google Developers Console and log in with your Google account."
-    f"(https://console.developers.google.com/)"
-    f"2. You should be prompted to create a new project (name does not matter)."
-    f"3. Click on Enable APIs and Services at the top."
-    f"4. In the list of APIs choose or search for YouTube Data API v3 and "
-    f"click on it. Choose Enable."
-    f"5. Click on Credentials on the left navigation bar."
-    f"6. Click on Create Credential at the top."
-    f'7. At the top click the link for "API key".'
-    f"8. No application restrictions are needed. Click Create at the bottom."
-    f"9. You now have a key to add to `{{prefix}}set api youtube api_key`"
+    "1. Go to Google Developers Console and log in with your Google"
+    " account.(https://console.developers.google.com/)2. You should be prompted to"
+    " create a new project (name does not matter).3. Click on Enable APIs and Services"
+    " at the top.4. In the list of APIs choose or search for YouTube Data API v3 and"
+    " click on it. Choose Enable.5. Click on Credentials on the left navigation bar.6."
+    ' Click on Create Credential at the top.7. At the top click the link for "API'
+    ' key".8. No application restrictions are needed. Click Create at the bottom.9. You'
+    " now have a key to add to `{prefix}set api youtube api_key`"
 )
 message = (
-    f"1. Go to Google Developers Console and log in with your Google account."
-    f"(https://console.developers.google.com/)"
-    f"2. You should be prompted to create a new project (name does not matter)."
-    f"3. Click on Enable APIs and Services at the top."
-    f"4. In the list of APIs choose or search for YouTube Data API v3 and "
-    f"click on it. Choose Enable."
-    f"5. Click on Credentials on the left navigation bar."
-    f"6. Click on Create Credential at the top."
-    f'7. At the top click the link for "API key".'
-    f"8. No application restrictions are needed. Click Create at the bottom."
-    f"9. You now have a key to add to `{{prefix}}set api youtube api_key`"
+    "1. Go to Google Developers Console and log in with your Google"
+    " account.(https://console.developers.google.com/)2. You should be prompted to"
+    " create a new project (name does not matter).3. Click on Enable APIs and Services"
+    " at the top.4. In the list of APIs choose or search for YouTube Data API v3 and"
+    " click on it. Choose Enable.5. Click on Credentials on the left navigation bar.6."
+    ' Click on Create Credential at the top.7. At the top click the link for "API'
+    ' key".8. No application restrictions are needed. Click Create at the bottom.9. You'
+    " now have a key to add to `{prefix}set api youtube api_key`"
 )
 message = (
     "1. Go to Google Developers Console and log in with your Google account."

--- a/tests/data/preview/long_strings__regression.py
+++ b/tests/data/preview/long_strings__regression.py
@@ -1038,8 +1038,8 @@ class X:
 
 
 temp_msg = (
-    f"{f'{humanize_number(pos)}.': <{pound_len+2}} "
-    f"{balance: <{bal_len + 5}} "
+    f"{f'{humanize_number(pos)}.':<{pound_len+2}} "
+    f"{balance:<{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )
 
@@ -1127,8 +1127,8 @@ message = (
 
 # It shouldn't matter if the string prefixes are capitalized.
 temp_msg = (
-    f"{F'{humanize_number(pos)}.': <{pound_len+2}} "
-    f"{balance: <{bal_len + 5}} "
+    f"{F'{humanize_number(pos)}.':<{pound_len+2}} "
+    f"{balance:<{bal_len + 5}} "
     f"<<{author.display_name}>>\n"
 )
 

--- a/tests/data/preview_36/remove_f_string_trailing_spaces.py
+++ b/tests/data/preview_36/remove_f_string_trailing_spaces.py
@@ -1,0 +1,25 @@
+print(f"there are { 2 } unnecessary spaces in this f string")
+print(f"there are {   3} unnecessary spaces on the left")
+print(f"there are {3   } unnecessary spaces on the right")
+print(f"you should trim { 'me' } and {   'me!'  }")
+print(f"trimming is easy as {  1 + 1   } == {2}")
+print("There should be no trimming if {    f_prefix     } is not present")
+print(f"No {  'trimming' } if we use {{ double_curly_brackets   }} in string")
+print(
+    "We know how to trim strings in any case needed, even when the strings are joined. "
+    f"Just take a look {  'here' } and you'll see that the problem is solved."
+)
+
+# output
+
+print(f"there are {2} unnecessary spaces in this f string")
+print(f"there are {3} unnecessary spaces on the left")
+print(f"there are {3} unnecessary spaces on the right")
+print(f"you should trim {'me'} and {'me!'}")
+print(f"trimming is easy as {1 + 1} == {2}")
+print("There should be no trimming if {    f_prefix     } is not present")
+print(f"No {'trimming'} if we use {{ double_curly_brackets   }} in string")
+print(
+    "We know how to trim strings in any case needed, even when the strings are joined."
+    f" Just take a look {'here'} and you'll see that the problem is solved."
+)

--- a/tests/data/preview_36/remove_f_string_trailing_spaces.py
+++ b/tests/data/preview_36/remove_f_string_trailing_spaces.py
@@ -2,13 +2,15 @@ print(f"there are { 2 } unnecessary spaces in this f string")
 print(f"there are {   3} unnecessary spaces on the left")
 print(f"there are {3   } unnecessary spaces on the right")
 print(f"you should trim { 'me' } and {   'me!'  }")
-print(f"trimming is easy as {  1 + 1   } == {2}")
+print(f"trimming is easy as {  1    +     1   } == {2}")
 print("There should be no trimming if {    f_prefix     } is not present")
 print(f"No {  'trimming' } if we use {{ double_curly_brackets   }} in string")
 print(
     "We know how to trim strings in any case needed, even when the strings are joined. "
     f"Just take a look {  'here' } and you'll see that the problem is solved."
 )
+print(f"{ bar : .{ baz }f }")
+print(f"This expression {   3 =      } can be stripped only to the right")
 
 # output
 
@@ -23,3 +25,5 @@ print(
     "We know how to trim strings in any case needed, even when the strings are joined."
     f" Just take a look {'here'} and you'll see that the problem is solved."
 )
+print(f"{bar:.{baz}f}")
+print(f"This expression {   3 =} can be stripped only to the right")

--- a/tests/data/preview_36/remove_f_string_trailing_spaces.py
+++ b/tests/data/preview_36/remove_f_string_trailing_spaces.py
@@ -10,7 +10,6 @@ print(
     f"Just take a look {  'here' } and you'll see that the problem is solved."
 )
 print(f"{ bar : .{ baz }f }")
-print(f"This expression {   3 =      } can be stripped only to the right")
 
 # output
 
@@ -26,4 +25,3 @@ print(
     f" Just take a look {'here'} and you'll see that the problem is solved."
 )
 print(f"{bar:.{baz}f}")
-print(f"This expression {   3 =} can be stripped only to the right")

--- a/tests/data/preview_38/remove_self_documenting_f_string_trailing_spaces.py
+++ b/tests/data/preview_38/remove_self_documenting_f_string_trailing_spaces.py
@@ -1,0 +1,7 @@
+print(f"This expression {   3 =      } can be stripped only to the right")
+print(f"and {   1 +   7   =      } also!")
+
+# output
+
+print(f"This expression {   3 =} can be stripped only to the right")
+print(f"and {   1 +   7   =} also!")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -79,18 +79,25 @@ def test_preview_format(filename: str) -> None:
     check_file("preview", filename, black.Mode(preview=True))
 
 
-@pytest.mark.parametrize("filename", all_data_cases("preview_39"))
-def test_preview_minimum_python_39_format(filename: str) -> None:
-    source, expected = read_data("preview_39", filename)
-    mode = black.Mode(preview=True)
-    assert_format(source, expected, mode, minimum_version=(3, 9))
-
-
 @pytest.mark.parametrize("filename", all_data_cases("preview_36"))
 def test_preview_minimum_python_36_format(filename: str) -> None:
     source, expected = read_data("preview_36", filename)
     mode = black.Mode(preview=True)
     assert_format(source, expected, mode, minimum_version=(3, 6))
+
+
+@pytest.mark.parametrize("filename", all_data_cases("preview_38"))
+def test_preview_minimum_python_38_format(filename: str) -> None:
+    source, expected = read_data("preview_38", filename)
+    mode = black.Mode(preview=True)
+    assert_format(source, expected, mode, minimum_version=(3, 8))
+
+
+@pytest.mark.parametrize("filename", all_data_cases("preview_39"))
+def test_preview_minimum_python_39_format(filename: str) -> None:
+    source, expected = read_data("preview_39", filename)
+    mode = black.Mode(preview=True)
+    assert_format(source, expected, mode, minimum_version=(3, 9))
 
 
 @pytest.mark.parametrize("filename", all_data_cases("preview_310"))

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -86,6 +86,13 @@ def test_preview_minimum_python_39_format(filename: str) -> None:
     assert_format(source, expected, mode, minimum_version=(3, 9))
 
 
+@pytest.mark.parametrize("filename", all_data_cases("preview_36"))
+def test_preview_minimum_python_36_format(filename: str) -> None:
+    source, expected = read_data("preview_36", filename)
+    mode = black.Mode(preview=True)
+    assert_format(source, expected, mode, minimum_version=(3, 6))
+
+
 @pytest.mark.parametrize("filename", all_data_cases("preview_310"))
 def test_preview_minimum_python_310_format(filename: str) -> None:
     source, expected = read_data("preview_310", filename)

--- a/tests/test_trans.py
+++ b/tests/test_trans.py
@@ -1,12 +1,12 @@
 from typing import List, Tuple
-from black.trans import iter_fexpr_spans
+from black.trans import iterate_f_string
 
 
 def test_fexpr_spans() -> None:
     def check(
         string: str, expected_spans: List[Tuple[int, int]], expected_slices: List[str]
     ) -> None:
-        spans = list(iter_fexpr_spans(string))
+        spans = list(iterate_f_string(string))
 
         # Checking slices isn't strictly necessary, but it's easier to verify at
         # a glance than only spans


### PR DESCRIPTION
### Description

Added a new feature in preview mode: *Black* now knows how to trim trailing whitespaces inside f-strings.

For example the following code:
```python
print(f"there are { 2 } unnecessary spaces in this f string")
print(f"there are {   3} unnecessary spaces on the left")
print(f"there are {3   } unnecessary spaces on the right")
print(f"you should trim { 'me' } and {   'me!'  }")
print(f"trimming is easy as {  1 + 1   } == {2}")
```

will transform to:
```python
print(f"there are {2} unnecessary spaces in this f string")
print(f"there are {3} unnecessary spaces on the left")
print(f"there are {3} unnecessary spaces on the right")
print(f"you should trim {'me'} and {'me!'}")
print(f"trimming is easy as {1 + 1} == {2}")
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
