### PR TITLE
Move to explicitly creating a new loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
 
 <!-- Changes to Black's terminal output and error messages -->
 
-- Change from deprecated `asyncio.get_event_loop()` to create out event loop which
+- Change from deprecated `asyncio.get_event_loop()` to create our event loop which
   removes DesprecationWarning (#3164)
 
 ### Packaging

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 <!-- Changes to Black's terminal output and error messages -->
 
 - Change from deprecated `asyncio.get_event_loop()` to create our event loop which
-  removes DesprecationWarning (#3164)
+  removes DeprecationWarning (#3164)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
 
 <!-- Changes to Black's terminal output and error messages -->
 
+- Change from deprecated `asyncio.get_event_loop()` to create out event loop which
+  removes DesprecationWarning (#3164)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -773,7 +773,6 @@ def reformat_many(
     from concurrent.futures import Executor, ThreadPoolExecutor, ProcessPoolExecutor
 
     executor: Executor
-    loop = asyncio.get_event_loop()
     worker_count = workers if workers is not None else DEFAULT_WORKERS
     if sys.platform == "win32":
         # Work around https://bugs.python.org/issue26903
@@ -788,6 +787,7 @@ def reformat_many(
         # any good due to the Global Interpreter Lock)
         executor = ThreadPoolExecutor(max_workers=1)
 
+    loop = asyncio.new_event_loop()
     try:
         loop.run_until_complete(
             schedule_formatting(

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -788,6 +788,7 @@ def reformat_many(
         executor = ThreadPoolExecutor(max_workers=1)
 
     loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
         loop.run_until_complete(
             schedule_formatting(
@@ -801,7 +802,10 @@ def reformat_many(
             )
         )
     finally:
-        shutdown(loop)
+        try:
+            shutdown(loop)
+        finally:
+            asyncio.set_event_loop(None)
         if executor is not None:
             executor.shutdown()
 


### PR DESCRIPTION
- `>= 3.10` add a warning that `get_event_loop` will not automatically create a loop
- Move to explicit API to create en event loop

Test:
- `python3.11 -m venv --upgrade-deps /tmp/tb`
  - `/tmp/tb/bin/pip install -e .`
  - Install deps and no blackd as aiohttp + yarl can't build still with 3.11
  - https://github.com/aio-libs/aiohttp/issues/6600
- `export PYTHONWARNINGS=error`
```
cooper@l33t:~/repos/black$ /tmp/tb/bin/black .
All done! ✨ 🍰 ✨
44 files left unchanged.
```

Fixes #3110