### PR TITLE
Don't (ever) put a single-char closing docstring quote on a new line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 <!-- Changes that affect Black's preview style -->
 
 - Single-character closing docstring quotes are no longer moved to their own line as
-  this is invalid. This was a bug introduced in version 22.6.0. (#3165)
+  this is invalid. This was a bug introduced in version 22.6.0. (#3166)
 
 ### _Blackd_
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Single-character closing docstring quotes are no longer moved to their own line as
+  this is invalid. This was a bug introduced in version 22.6.0. (#3165)
+
 ### _Blackd_
 
 <!-- Changes to blackd -->

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -330,13 +330,14 @@ class LineGenerator(Visitor[Line]):
             # We could enforce triple quotes at this point.
             quote = quote_char * quote_len
 
-            if Preview.long_docstring_quotes_on_newline in self.mode:
+            # It's invalid to put closing single-character quotes on a new line.
+            if Preview.long_docstring_quotes_on_newline in self.mode and quote_len == 3:
                 # We need to find the length of the last line of the docstring
                 # to find if we can add the closing quotes to the line without
                 # exceeding the maximum line length.
                 # If docstring is one line, then we need to add the length
-                # of the indent, prefix, and starting quotes. Ending quote are
-                # handled later
+                # of the indent, prefix, and starting quotes. Ending quotes are
+                # handled later.
                 lines = docstring.splitlines()
                 last_line_length = len(lines[-1]) if docstring else 0
 

--- a/tests/data/preview/docstring_preview.py
+++ b/tests/data/preview/docstring_preview.py
@@ -42,6 +42,14 @@ def multiline_docstring_at_line_limit_with_prefix():
     second line----------------------------------------------------------------------"""
 
 
+def single_quote_docstring_over_line_limit():
+    "We do not want to put the closing quote on a new line as that is invalid (see GH-3141)."
+
+
+def single_quote_docstring_over_line_limit2():
+    'We do not want to put the closing quote on a new line as that is invalid (see GH-3141).'
+
+
 # output
 
 
@@ -87,3 +95,11 @@ def multiline_docstring_at_line_limit_with_prefix():
     f"""first line----------------------------------------------------------------------
 
     second line----------------------------------------------------------------------"""
+
+
+def single_quote_docstring_over_line_limit():
+    "We do not want to put the closing quote on a new line as that is invalid (see GH-3141)."
+
+
+def single_quote_docstring_over_line_limit2():
+    "We do not want to put the closing quote on a new line as that is invalid (see GH-3141)."


### PR DESCRIPTION
### Description

... as doing so is invalid. Note this only fixes the preview style since the logic putting closing docstring quotes on their own line if they violate the line length limit is quite new.

Fixes #3141.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
