### PR TITLE
"stable" branch changed to "stable" tag

### DIFF
--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -117,7 +117,7 @@ Configuration:
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'psf/black', { 'branch': 'stable' }
+Plug 'psf/black', { 'tag': 'stable' }
 ```
 
 or with [Vundle](https://github.com/VundleVim/Vundle.vim):
@@ -130,7 +130,7 @@ and execute the following in a terminal:
 
 ```console
 $ cd ~/.vim/bundle/black
-$ git checkout origin/stable -b stable
+$ git checkout stable
 ```
 
 or you can copy the plugin files from


### PR DESCRIPTION
### Description

Issue #2503.

**Documentation only.**

Updates the "vim-plug" and "Vundle" instructions to reflect that the "origin/stable" branch was replaced with a "stable" tag.


### Checklist

**Documentation only.**

- [ x ] Add a CHANGELOG entry if necessary? - not applicable
- [ x ] Add / update tests if necessary? - not applicable
- [ x ] Add new / update outdated documentation?
