### PR TITLE
Add sanity check to executable CD + more

### DIFF
--- a/.github/workflows/upload_binary.yml
+++ b/.github/workflows/upload_binary.yml
@@ -1,16 +1,14 @@
-name: Upload self-contained binaries
+name: Publish executables
 
 on:
   release:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write # actions/upload-release-asset needs this.
 
 jobs:
   build:
-    permissions:
-      contents: write # for actions/upload-release-asset to upload release asset
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -38,15 +36,21 @@ jobs:
         with:
           python-version: "*"
 
-      - name: Install dependencies
+      - name: Install Black and PyInstaller
         run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install .
+          python -m pip install --upgrade pip wheel
+          python -m pip install .[colorama]
           python -m pip install pyinstaller
 
-      - name: Build binary
+      - name: Build executable with PyInstaller
+        run: >
+          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data
+          'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+
+      - name: Quickly test executable
         run: |
-          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+          ./dist/${{ matrix.asset_name }} --version
+          ./dist/${{ matrix.asset_name }} src --verbose
 
       - name: Upload binary as release asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
### Description

Building executables without any testing is quite sketchy, let's at least verify they won't crash on startup and can format Black's own codebase.

- Also replaced "binaries" with "executables" since it's clearer and won't be confused with mypyc.
- Finally, I added colorama so all Windows users can get colour.

Similar to #3189, this is not required for the upcoming 22.7.0 release, this is 2nd easiest part of https://github.com/psf/black/pull/3017 to file separately. There's no rush to merge this.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a

### Review notes:

See https://github.com/ichard26/black/releases/tag/0.1.2a2 and https://github.com/ichard26/black/actions/runs/2750422995 that show this works