### PR TITLE
Vim: prefix messages with "Black:"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@
 
 - Change from deprecated `asyncio.get_event_loop()` to create our event loop which
   removes DeprecationWarning (#3164)
+- Prefix Black messages in Vim with `Black: ` (#3194)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,13 +46,14 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
+
 ### Output
 
 <!-- Changes to Black's terminal output and error messages -->
 
 - Change from deprecated `asyncio.get_event_loop()` to create our event loop which
   removes DeprecationWarning (#3164)
-- Prefix Black messages in Vim with `Black: ` (#3194)
 
 ### Packaging
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -158,9 +158,9 @@ def Black(**kwargs):
     )
   except black.NothingChanged:
     if not quiet:
-      print(f'Already well formatted, good job. (took {time.time() - start:.4f}s)')
+      print(f'Black: already well formatted, good job. (took {time.time() - start:.4f}s)')
   except Exception as exc:
-    print(exc)
+    print(f'Black: {exc}')
   else:
     current_buffer = vim.current.window.buffer
     cursors = []
@@ -177,7 +177,7 @@ def Black(**kwargs):
       except vim.error:
         window.cursor = (len(window.buffer), 0)
     if not quiet:
-      print(f'Reformatted in {time.time() - start:.4f}s.')
+      print(f'Black: reformatted in {time.time() - start:.4f}s.')
 
 def get_configs():
   filename = vim.eval("@%")


### PR DESCRIPTION
### Description

As mentioned in #3185, when using Black as a Vim plugin, especially automatically on save, the plugin's messages can be confusing, as nothing indicates that they come from Black.

This PR simply prefixes the messages with "Black: ".

### Checklist - did you ...

- [X] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?  [no changes needed]
- [X] Add new / update outdated documentation?  [no changes needed]