### PR TITLE
makes install available for all users in docker image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
-- Docker: changes the installation path to be available to non-root users (#3202)
+- Docker: changed to a /opt/venv installation + added to PATH to be available to non-root users (#3202)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
+- Docker: changes the installation path to be available to non-root users (#3202)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,8 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
-- Docker: changed to a /opt/venv installation + added to PATH to be available to non-root users (#3202)
+- Docker: changed to a /opt/venv installation + added to PATH to be available to
+  non-root users (#3202)
 
 ### Output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,19 @@ FROM python:3-slim AS builder
 
 RUN mkdir /src
 COPY . /src/
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
     # Install build tools to compile dependencies that don't have prebuilt wheels
     && apt update && apt install -y git build-essential \
     && cd /src \
-    && pip install --user --no-cache-dir .[colorama,d]
+    && pip install --no-cache-dir .[colorama,d]
 
 FROM python:3-slim
 
 # copy only Python packages to limit the image size
-COPY --from=builder /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 CMD ["black"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN mkdir /src
 COPY . /src/
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setuptools wheel \
     # Install build tools to compile dependencies that don't have prebuilt wheels
     && apt update && apt install -y git build-essential \
     && cd /src \
@@ -17,4 +16,4 @@ FROM python:3-slim
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-CMD ["black"]
+CMD ["/opt/venv/bin/black"]


### PR DESCRIPTION
### Description

Changes the default docker image installation to be made in a virtualenv. This way we get to keep the handy multistage build without excluding non-root users.
fixes #2975 
### Checklist - did you ...

- [ x] Add a CHANGELOG entry if necessary?
- [ x] Add / update tests if necessary?
- [ x] Add new / update outdated documentation?