### PR TITLE
Remove invalid syntax in test

### DIFF
--- a/tests/data/miscellaneous/docstring_preview_no_string_normalization.py
+++ b/tests/data/miscellaneous/docstring_preview_no_string_normalization.py
@@ -3,8 +3,8 @@ def do_not_touch_this_prefix():
 
 
 def do_not_touch_this_prefix2():
-    F'There was a bug where docstring prefixes would be normalized even with -S.'
+    FR'There was a bug where docstring prefixes would be normalized even with -S.'
 
 
 def do_not_touch_this_prefix3():
-    uR'''There was a bug where docstring prefixes would be normalized even with -S.'''
+    u'''There was a bug where docstring prefixes would be normalized even with -S.'''


### PR DESCRIPTION
### Description

`uR` is not a legal string prefix, so this test breaks (`AssertionError: cannot use --safe with this file; failed to parse source file AST: invalid syntax`) if changed to one in which the file is changed (e.g. in #2885). I've changed the last test to have `u` alone, and added an `R` to the test above instead.

### Checklist - did you ...

- [X] Add a CHANGELOG entry if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?
