### PR TITLE
Fix misdetection of project root when `--stdin-filename` filepath is outside the current working directory

### DIFF
--- a/src/black/files.py
+++ b/src/black/files.py
@@ -161,7 +161,10 @@ def normalize_path_maybe_ignore(
         abspath = path if path.is_absolute() else Path.cwd() / path
         normalized_path = abspath.resolve()
         try:
-            root_relative_path = normalized_path.relative_to(root).as_posix()
+            if not str(normalized_path).startswith(str(root)):
+                root_relative_path = os.path.join(Path.cwd(), path)
+            else:
+                root_relative_path = normalized_path.relative_to(root).as_posix()
         except ValueError:
             if report:
                 report.path_ignored(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1455,6 +1455,18 @@ class BlackTestCase(BlackBaseTestCase):
 
             self.assertEqual(normalized_path, None)
 
+    def test_normalize_path_outside_of_root(self) -> None:
+
+        with TemporaryDirectory() as workspace:
+            root = Path(workspace)
+            target_path = root / ".."
+            report = black.Report(verbose=True)
+            normalized_path = black.normalize_path_maybe_ignore(
+                target_path, root, report
+            )
+
+            self.assertNotEqual(normalized_path, None)
+
     def test_newline_comment_interaction(self) -> None:
         source = "class A:\\\r\n# type: ignore\n pass\n"
         output = black.format_str(source, mode=DEFAULT_MODE)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
Fixes behaviour that prevented formatting for files outside the current working directory (#3207). 

```console
# before the fix
❯ cat ../script.py | python -m black --stdin-filename '../script.py' -
No Python files are present to be formatted. Nothing to do 😴

# after the fix 
❯ cat ../test.py | python -m black --stdin-filename '../test.py' -   
print("hello world")
All done! ✨ 🍰 ✨
1 file left unchanged.
```

Let me know what you think! Not sure about how elegant the solution is, but I would be happy to refactor it based on your suggestions.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
