### PR TITLE
Fix misdetection of project root with `--stdin-filename`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 <!-- Changes to how Black can be configured -->
 
 - Black now uses the presence of debug f-strings to detect target version. (#3215)
+- Fix misdetection of project root and verbose logging of sources in cases involving
+  `--stdin-filename` (#3216)
 
 ### Documentation
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -468,7 +468,13 @@ def main(  # noqa: C901
         out(main.get_usage(ctx) + "\n\nOne of 'SRC' or 'code' is required.")
         ctx.exit(1)
 
-    root, method = find_project_root(src) if code is None else (None, None)
+    if stdin_filename is not None:
+        src_with_stdin_filename = tuple(stdin_filename if s == "-" else s for s in src)
+    else:
+        src_with_stdin_filename = src
+    root, method = (
+        find_project_root(src_with_stdin_filename) if code is None else (None, None)
+    )
     ctx.obj["root"] = root
 
     if verbose:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -469,12 +469,8 @@ def main(  # noqa: C901
         out(main.get_usage(ctx) + "\n\nOne of 'SRC' or 'code' is required.")
         ctx.exit(1)
 
-    if stdin_filename is not None:
-        src_with_stdin_filename = tuple(stdin_filename if s == "-" else s for s in src)
-    else:
-        src_with_stdin_filename = src
     root, method = (
-        find_project_root(src_with_stdin_filename) if code is None else (None, None)
+        find_project_root(src, stdin_filename) if code is None else (None, None)
     )
     ctx.obj["root"] = root
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -485,7 +485,9 @@ def main(  # noqa: C901
             )
 
             normalized = [
-                (normalize_path_maybe_ignore(Path(source), root), source)
+                (source, source)
+                if source == "-"
+                else (normalize_path_maybe_ignore(Path(source), root), source)
                 for source in src
             ]
             srcs_string = ", ".join(

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -39,7 +39,9 @@ if TYPE_CHECKING:
 
 
 @lru_cache()
-def find_project_root(srcs: Sequence[str]) -> Tuple[Path, str]:
+def find_project_root(
+    srcs: Sequence[str], stdin_filename: Optional[str] = None
+) -> Tuple[Path, str]:
     """Return a directory containing .git, .hg, or pyproject.toml.
 
     That directory will be a common parent of all files and directories
@@ -52,6 +54,8 @@ def find_project_root(srcs: Sequence[str]) -> Tuple[Path, str]:
     the second element as a string describing the method by which the
     project root was discovered.
     """
+    if stdin_filename is not None:
+        srcs = tuple(stdin_filename if s == "-" else s for s in srcs)
     if not srcs:
         srcs = [str(Path.cwd().resolve())]
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1398,8 +1398,8 @@ class BlackTestCase(BlackBaseTestCase):
 
             with change_directory(test_dir):
                 self.assertEqual(
-                    black.find_project_root(("-",), stdin_filename="../whatever.py"),
-                    (root.resolve(), "pyproject.toml"),
+                    black.find_project_root(("-",), stdin_filename="../src/a.py"),
+                    (src_dir.resolve(), "pyproject.toml"),
                 )
 
     @patch(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1396,6 +1396,12 @@ class BlackTestCase(BlackBaseTestCase):
                 (src_dir.resolve(), "pyproject.toml"),
             )
 
+            with change_directory(test_dir):
+                self.assertEqual(
+                    black.find_project_root(("-",), stdin_filename="../whatever.py"),
+                    (root.resolve(), "pyproject.toml"),
+                )
+
     @patch(
         "black.files.find_user_pyproject_toml",
     )


### PR DESCRIPTION
There are a number of places this behaviour could be patched, for
instance, it's quite tempting to patch it in `get_sources`. However
I believe we generally have the invariant that project root contains all
files we want to format, in which case it seems prudent to keep that
invariant.

Fixes #3207