### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,7 @@ warn_no_return=True
 warn_redundant_casts=True
 warn_unused_ignores=True
 disallow_any_generics=True
+no_implicit_optional=True
 
 # Unreachable blocks have been an issue when compiling mypyc, let's try
 # to avoid 'em in the first place.

--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -114,7 +114,7 @@ class Recorder:
                     args.insert(0, ilabel)
                 func(*args)
 
-    def determine_route(self, value: Text = None, force: bool = False) -> Optional[int]:
+    def determine_route(self, value: Optional[Text] = None, force: bool = False) -> Optional[int]:
         alive_ilabels = self.ilabels
         if len(alive_ilabels) == 0:
             *_, most_successful_ilabel = self._dead_ilabels


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401