### PR TITLE
Use strict mypy checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,8 @@ repos:
           - types-typed-ast >= 1.4.1
           - click >= 8.1.0
           - platformdirs >= 2.1.0
+          - pytest
+          - hypothesis
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ ignore_missing_imports = True
 
 [mypy-tokenize_rt.*]
 ignore_missing_imports = True
+
+[mypy-uvloop.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,3 +23,18 @@ warn_unreachable=True
 # The following is because of `patch_click()`. Remove when
 # we drop Python 3.6 support.
 warn_unused_ignores=False
+
+[mypy-blib2to3.driver.*]
+ignore_missing_imports = True
+
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+[mypy-colorama.*]
+ignore_missing_imports = True
+
+[mypy-pathspec.*]
+ignore_missing_imports = True
+
+[mypy-tokenize_rt.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,3 +41,6 @@ ignore_missing_imports = True
 
 [mypy-uvloop.*]
 ignore_missing_imports = True
+
+[mypy-_black_version.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,31 +7,17 @@ python_version=3.6
 mypy_path=src
 
 show_column_numbers=True
-
-# show error messages from unrelated files
-follow_imports=normal
-
-# suppress errors about unsatisfied imports
-ignore_missing_imports=True
+show_error_codes=True
 
 # be strict
-disallow_untyped_calls=True
-warn_return_any=True
-strict_optional=True
-warn_no_return=True
-warn_redundant_casts=True
-warn_unused_ignores=True
-disallow_any_generics=True
-no_implicit_optional=True
+strict=True
+
+# except for...
+no_implicit_reexport = False
 
 # Unreachable blocks have been an issue when compiling mypyc, let's try
 # to avoid 'em in the first place.
 warn_unreachable=True
-
-# The following are off by default.  Flip them on if you feel
-# adventurous.
-disallow_untyped_defs=True
-check_untyped_defs=True
 
 [mypy-black]
 # The following is because of `patch_click()`. Remove when

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -85,5 +85,8 @@ if __name__ == "__main__":
         pass
     else:
         test = test_idempotent_any_syntatically_valid_python
-        atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)  # type: ignore[attr-defined]
+        atheris.Setup(
+            sys.argv,
+            test.hypothesis.fuzz_one_input,  # type: ignore[attr-defined]
+        )
         atheris.Fuzz()

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -85,5 +85,5 @@ if __name__ == "__main__":
         pass
     else:
         test = test_idempotent_any_syntatically_valid_python
-        atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)
+        atheris.Setup(sys.argv, test.hypothesis.fuzz_one_input)  # type: ignore[attr-defined]
         atheris.Fuzz()

--- a/src/blackd/middlewares.py
+++ b/src/blackd/middlewares.py
@@ -9,7 +9,7 @@ Middleware = Callable[[Request, Handler], Awaitable[StreamResponse]]
 
 
 def cors(allow_headers: Iterable[str]) -> Middleware:
-    @middleware
+    @middleware  # type: ignore[misc]
     async def impl(request: Request, handler: Handler) -> StreamResponse:
         is_options = request.method == "OPTIONS"
         is_preflight = is_options and "Access-Control-Request-Method" in request.headers
@@ -32,4 +32,4 @@ def cors(allow_headers: Iterable[str]) -> Middleware:
 
         return resp
 
-    return impl  # type: ignore
+    return impl  # type: ignore[no-any-return]

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -931,7 +931,7 @@ class NegatedPattern(BasePattern):
         """
         if content is not None:
             assert isinstance(content, BasePattern), repr(content)
-        self.content: Optional[BasePattern] = content
+        self.content = content
 
     def match(self, node, results=None) -> bool:
         # We never match a node in its entirety

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -10,7 +10,7 @@ even the comments and whitespace between tokens.
 There's also a pattern matching implementation here.
 """
 
-# mypy: allow-untyped-defs
+# mypy: allow-untyped-defs, allow-incomplete-defs
 
 from typing import (
     Any,
@@ -291,7 +291,7 @@ class Node(Base):
         """
         return "".join(map(str, self.children))
 
-    def _eq(self, other) -> bool:
+    def _eq(self, other: Base) -> bool:
         """Compare two nodes for equality."""
         return (self.type, self.children) == (other.type, other.children)
 
@@ -326,7 +326,7 @@ class Node(Base):
         return self.children[0].prefix
 
     @prefix.setter
-    def prefix(self, prefix) -> None:
+    def prefix(self, prefix: Text) -> None:
         if self.children:
             self.children[0].prefix = prefix
 
@@ -439,7 +439,7 @@ class Leaf(Base):
         """
         return self._prefix + str(self.value)
 
-    def _eq(self, other) -> bool:
+    def _eq(self, other: "Leaf") -> bool:
         """Compare two nodes for equality."""
         return (self.type, self.value) == (other.type, other.value)
 
@@ -472,7 +472,7 @@ class Leaf(Base):
         return self._prefix
 
     @prefix.setter
-    def prefix(self, prefix) -> None:
+    def prefix(self, prefix: Text) -> None:
         self.changed()
         self._prefix = prefix
 
@@ -618,7 +618,7 @@ class LeafPattern(BasePattern):
         self.content = content
         self.name = name
 
-    def match(self, node: NL, results=None):
+    def match(self, node: NL, results=None) -> bool:
         """Override match() to insist on a leaf node."""
         if not isinstance(node, Leaf):
             return False
@@ -678,7 +678,7 @@ class NodePattern(BasePattern):
                 if isinstance(item, WildcardPattern):  # type: ignore[unreachable]
                     self.wildcards = True  # type: ignore[unreachable]
         self.type = type
-        self.content = newcontent
+        self.content = newcontent  # TODO: this is unbound when content is None
         self.name = name
 
     def _submatch(self, node, results=None) -> bool:
@@ -920,7 +920,7 @@ class WildcardPattern(BasePattern):
 
 
 class NegatedPattern(BasePattern):
-    def __init__(self, content: Optional[Any] = None) -> None:
+    def __init__(self, content: Optional[BasePattern] = None) -> None:
         """
         Initializer.
 
@@ -931,7 +931,7 @@ class NegatedPattern(BasePattern):
         """
         if content is not None:
             assert isinstance(content, BasePattern), repr(content)
-        self.content = content
+        self.content: Optional[BasePattern] = content
 
     def match(self, node, results=None) -> bool:
         # We never match a node in its entirety
@@ -941,7 +941,7 @@ class NegatedPattern(BasePattern):
         # We only match an empty sequence of nodes in its entirety
         return len(nodes) == 0
 
-    def generate_matches(self, nodes) -> Iterator[Tuple[int, _Results]]:
+    def generate_matches(self, nodes: List[NL]) -> Iterator[Tuple[int, _Results]]:
         if self.content is None:
             # Return a match if there is an empty sequence
             if len(nodes) == 0:

--- a/tests/optional.py
+++ b/tests/optional.py
@@ -26,7 +26,7 @@ try:
     from pytest import StashKey
 except ImportError:
     # pytest < 7
-    from _pytest.store import StoreKey as StashKey
+    from _pytest.store import StoreKey as StashKey  # type: ignore[no-redef]
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -27,8 +27,9 @@ if LESS_THAN_311:  # noqa: C901
         try:
             from aiohttp.test_utils import unittest_run_loop
         except ImportError:
-            # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
-            # removed it. To maintain compatibility we can make our own no-op decorator.
+            # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and
+            # aiohttp 4 removed it. To maintain compatibility we can make our own
+            # no-op decorator.
             def unittest_run_loop(func, *args, **kwargs):
                 return func
 

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 from unittest.mock import patch
 
 import pytest
@@ -19,16 +19,21 @@ if LESS_THAN_311:  # noqa: C901
     except ImportError as e:
         raise RuntimeError("Please install Black with the 'd' extra") from e
 
-    try:
-        from aiohttp.test_utils import unittest_run_loop
-    except ImportError:
-        # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
-        # removed it. To maintain compatibility we can make our own no-op decorator.
-        def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
-            return func
+    if TYPE_CHECKING:
+        F = TypeVar("F", bound=Callable[..., Any])
+
+        unittest_run_loop: Callable[[F], F] = lambda x: x
+    else:
+        try:
+            from aiohttp.test_utils import unittest_run_loop
+        except ImportError:
+            # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
+            # removed it. To maintain compatibility we can make our own no-op decorator.
+            def unittest_run_loop(func, *args, **kwargs):
+                return func
 
     @pytest.mark.blackd
-    class BlackDTestCase(AioHTTPTestCase):
+    class BlackDTestCase(AioHTTPTestCase):  # type: ignore[misc]
         def test_blackd_main(self) -> None:
             with patch("blackd.web.run_app"):
                 result = CliRunner().invoke(blackd.main, [])

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, Callable, TypeVar, TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -15,17 +15,22 @@ try:
 except ImportError as e:
     raise RuntimeError("Please install Black with the 'd' extra") from e
 
-try:
-    from aiohttp.test_utils import unittest_run_loop
-except ImportError:
-    # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
-    # removed it. To maintain compatibility we can make our own no-op decorator.
-    def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
-        return func
+if TYPE_CHECKING:
+    F = TypeVar("F", bound=Callable[..., Any])
+
+    unittest_run_loop: Callable[[F], F] = lambda x: x
+else:
+    try:
+        from aiohttp.test_utils import unittest_run_loop
+    except ImportError:
+        # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
+        # removed it. To maintain compatibility we can make our own no-op decorator.
+        def unittest_run_loop(func, *args, **kwargs):
+            return func
 
 
 @pytest.mark.blackd
-class BlackDTestCase(AioHTTPTestCase):
+class BlackDTestCase(AioHTTPTestCase):  # type: ignore[misc]
     def test_blackd_main(self) -> None:
         with patch("blackd.web.run_app"):
             result = CliRunner().invoke(blackd.main, [])


### PR DESCRIPTION
Note that we still have:
```
src/blib2to3/pytree.py
13:# mypy: allow-untyped-defs, allow-incomplete-defs

src/blib2to3/pgen2/tokenize.py
4:# mypy: allow-untyped-defs, allow-untyped-calls

src/blib2to3/pgen2/conv.py
4:# mypy: ignore-errors
```

I took a solid look at removing those from pytree, but it seems like some of the existing type annotations are lies (e.g. things annotated as `_Results` can have list values).