### PR TITLE
Update stable branch after publishing to PyPI

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -74,3 +74,22 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: pipx run twine upload --verbose -u '__token__' wheelhouse/*.whl
+
+  update-stable-branch:
+    name: Update stable branch
+    needs: [main, mypyc]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout stable branch
+        uses: actions/checkout@v3
+        with:
+          ref: stable
+          fetch-depth: 0
+
+      - name: Update stable branch to release tag & push
+        run: |
+          git reset --hard ${{ github.event.release.tag_name }}
+          git push --force

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -92,4 +92,4 @@ jobs:
       - name: Update stable branch to release tag & push
         run: |
           git reset --hard ${{ github.event.release.tag_name }}
-          git push --force
+          git push


### PR DESCRIPTION
### Description

We've decided to a) convert stable back into a branch and b) to update it immediately as part of the release process. We may as well automate it.

Test run: https://github.com/ichard26/black/runs/7831041412?check_suite_focus=true (note that in that run the job runs after the sdist/pure wheel job passes, while in this PR, it runs after all the PyPI jobs finish, I changed it in the test run because I didn't want to wait several minutes for the mypyc jobs to finish)

**This is a draft PR because the stable ref is currently a tag in this repository so things will break**. I'll have to convert the ref manually before landing this.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> will be done in a separate PR

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
