### PR TITLE
Removed need for subprocess call in `action.yml`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,6 +79,7 @@ Multiple contributions by:
 - [Hugo Barrera](mailto::hugo@barrera.io)
 - Hugo van Kemenade
 - [Hynek Schlawack](mailto:hs@ox.cx)
+- [Ionite](mailto:dev@ionite.io)
 - [Ivan Katanić](mailto:ivan.katanic@gmail.com)
 - [Jakub Kadlubiec](mailto:jakub.kadlubiec@skyscanner.net)
 - [Jakub Warczarek](mailto:jakub.warczarek@gmail.com)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,8 @@
 - Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
 - Docker: changed to a /opt/venv installation + added to PATH to be available to
   non-root users (#3202)
+- GitHub Action: Updated usage of $GITHUB_ACTION_PATH to remove the nested python 
+  subprocess call for actions/main.py (#3226)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,8 +55,6 @@
 - Vim plugin: prefix messages with `Black: ` so it's clear they come from Black (#3194)
 - Docker: changed to a /opt/venv installation + added to PATH to be available to
   non-root users (#3202)
-- GitHub Action: Updated usage of $GITHUB_ACTION_PATH to remove the nested python 
-  subprocess call for actions/main.py (#3226)
 
 ### Output
 

--- a/action.yml
+++ b/action.yml
@@ -29,25 +29,10 @@ runs:
   using: composite
   steps:
     - run: |
-        # Exists since using github.action_path + path to main script doesn't work because bash
-        # interprets the backslashes in github.action_path (which are used when the runner OS
-        # is Windows) destroying the path to the target file.
-        #
-        # Also semicolons are necessary because I can't get the newlines to work
-        entrypoint="import sys;
-        import subprocess;
-        from pathlib import Path;
-
-        MAIN_SCRIPT = Path(r'${GITHUB_ACTION_PATH}') / 'action' / 'main.py';
-
-        proc = subprocess.run([sys.executable, str(MAIN_SCRIPT)]);
-        sys.exit(proc.returncode)
-        "
-
         if [ "$RUNNER_OS" == "Windows" ]; then
-          echo $entrypoint | python
+          python $GITHUB_ACTION_PATH/action/main.py
         else
-          echo $entrypoint | python3
+          python3 $GITHUB_ACTION_PATH/action/main.py
         fi
       env:
         # TODO: Remove once https://github.com/actions/runner/issues/665 is fixed.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Updated `actions.yml` to use the alternative `$GITHUB_ACTION_PATH` variable as documented [here](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun) instead of the original `github.action_path` which caused issues with bash on the Windows runners. This removes the need for a python subprocess to call the `main.py` script.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
