### PR TITLE
Fix a string merging/split issue caused by standalone comments.

### DIFF
--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -155,4 +155,3 @@ jobs:
         if: always()
         run: >
           diff-shades show-failed --check --show-log ${{ matrix.target-analysis }}
-          --check-allow 'sqlalchemy:test/orm/test_relationship_criteria.py'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
   normalized as expected (#3168)
 - When using `--skip-magic-trailing-comma` or `-C`, trailing commas are stripped from
   subscript expressions with more than 1 element (#3209)
+- Fix a string merging/split issue when a comment is present in the middle of
+  implicitly concatenated strings on its own line (#3227)
 
 ### _Blackd_
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,8 +26,8 @@
   normalized as expected (#3168)
 - When using `--skip-magic-trailing-comma` or `-C`, trailing commas are stripped from
   subscript expressions with more than 1 element (#3209)
-- Fix a string merging/split issue when a comment is present in the middle of
-  implicitly concatenated strings on its own line (#3227)
+- Fix a string merging/split issue when a comment is present in the middle of implicitly
+  concatenated strings on its own line (#3227)
 
 ### _Blackd_
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -579,11 +579,9 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
             # when there is a standalone comment in the middle) ...
             if non_string_idx - string_idx < len(atom_node.children):
                 # We need to replace the old STRING leaves with the new string leaf.
-                first_child_idx: Optional[int] = None
-                for idx in range(string_idx, non_string_idx):
-                    child_idx = LL[idx].remove()
-                    if first_child_idx is None:
-                        first_child_idx = child_idx
+                first_child_idx = LL[string_idx].remove()
+                for idx in range(string_idx + 1, non_string_idx):
+                    LL[idx].remove()
                 if first_child_idx is not None:
                     atom_node.insert_child(first_child_idx, string_leaf)
             else:

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -575,7 +575,8 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
         string_leaf = Leaf(token.STRING, S_leaf.value.replace(BREAK_MARK, ""))
 
         if atom_node is not None:
-            # If not all children of the atom node are merged...
+            # If not all children of the atom node are merged (this can happen
+            # when there is a standalone comment in the middle) ...
             if non_string_idx - string_idx < len(atom_node.children):
                 # We need to replace the old STRING leaves with the new string leaf.
                 first_child_idx = None

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -579,7 +579,7 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
             # when there is a standalone comment in the middle) ...
             if non_string_idx - string_idx < len(atom_node.children):
                 # We need to replace the old STRING leaves with the new string leaf.
-                first_child_idx = None
+                first_child_idx: Optional[int] = None
                 for idx in range(string_idx, non_string_idx):
                     child_idx = LL[idx].remove()
                     if first_child_idx is None:

--- a/tests/data/preview/long_strings.py
+++ b/tests/data/preview/long_strings.py
@@ -72,6 +72,25 @@ bad_split_func3(
     zzz,
 )
 
+inline_comments_func1(
+    "if there are inline "
+    "comments in the middle "
+    # Here is the standard alone comment.
+    "of the implicitly concatenated "
+    "string, we should handle "
+    "them correctly",
+    xxx,
+)
+
+inline_comments_func2(
+    "what if the string is very very very very very very very very very very long and this part does "
+    "not fit into a single line? "
+    # Here is the standard alone comment.
+    "then the string should still be properly handled by merging and splitting "
+    "it into parts that fit in line length.",
+    xxx,
+)
+
 raw_string = r"This is a long raw string. When re-formatting this string, black needs to make sure it prepends the 'r' onto the new string."
 
 fmt_string1 = "We also need to be sure to preserve any and all {} which may or may not be attached to the string in question.".format("method calls")
@@ -393,6 +412,22 @@ bad_split_func3(
     xxx,
     yyy,
     zzz,
+)
+
+inline_comments_func1(
+    "if there are inline comments in the middle "
+    # Here is the standard alone comment.
+    "of the implicitly concatenated string, we should handle them correctly",
+    xxx,
+)
+
+inline_comments_func2(
+    "what if the string is very very very very very very very very very very long and"
+    " this part does not fit into a single line? "
+    # Here is the standard alone comment.
+    "then the string should still be properly handled by merging and splitting "
+    "it into parts that fit in line length.",
+    xxx,
 )
 
 raw_string = (


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This PR fixes the issue where a standalone comment causes strings to be merged into one far too long (and requiring two passes to do so). (Fixes #2734.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
