### PR TITLE
Check if variable is already a bool before converting it

### DIFF
--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -3,7 +3,7 @@ import collections
 import os
 import sys
 import vim
-from distutils.util import strtobool
+from configparser import ConfigParser
 
 
 class Flag(collections.namedtuple("FlagBase", "name, cast")):
@@ -19,11 +19,18 @@ class Flag(collections.namedtuple("FlagBase", "name, cast")):
     return "g:black_" + name
 
 
+def to_bool(v):
+    return ConfigParser.BOOLEAN_STATES.get(
+        v.lower() if isinstance(v, str) else v,
+        False
+    )
+
+
 FLAGS = [
   Flag(name="line_length", cast=int),
-  Flag(name="fast", cast=strtobool),
-  Flag(name="string_normalization", cast=strtobool),
-  Flag(name="quiet", cast=strtobool),
+  Flag(name="fast", cast=to_bool),
+  Flag(name="string_normalization", cast=to_bool),
+  Flag(name="quiet", cast=to_bool),
 ]
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

I had issue running Black in vim after recent updates (notably using vim > 9, linked against python 3.10.4), getting error:

TypeError: bool object expected; got int

after some tinkering i found that the values defined (or not) in pyproject.toml were the culprit. But even adding
```
string_normalization = false                                    
fast = true
quiet = false
```
in the black block of pyproject.toml, didn't help, as it was trying to convert a bool to a bool, as if it was a string,

AttributeError: 'bool' object has no attribute 'lower'

but even adding quotes around the values still got me the original "bool object expected; got int", error.

So i replaced the usage of `strtobool` with something more robust, using `ConfigParser.BOOLEAN_STATES.get` and falling back on False.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

Not sure any of these are necessary, for the vim plugin.