### PR TITLE
Add passing 3.11 CI by exempting blackd tests

### DIFF
--- a/.github/workflows/test-311.yml
+++ b/.github/workflows/test-311.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Partially test 3.11 dev
 
 on:
   push:
@@ -14,32 +14,38 @@ on:
 permissions:
   contents: read
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11-dev"]
-    name: main
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        if: "!endsWith(matrix.python-version, '-dev')"
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: deadsnakes/action@v2.1.1
-        if: endsWith(matrix.python-version, '-dev')
-        with:
-          python-version: ${{ matrix.python-version }}
-          # debug: true  # Optional, to select a Python debug build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
-      - name: Show python version
-        run: python --version --version && which python
+jobs:
+  main:
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. Without this if check, checks are duplicated since
+    # internal PRs match both the push and pull_request events.
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11.0-rc - 3.11"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install tox
         run: |
-          python -m pip install pip --upgrade --disable-pip-version-check
-          python -m pip install . tox
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
 
       - name: Run tests via tox
         run: |

--- a/.github/workflows/test-311.yml
+++ b/.github/workflows/test-311.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11-dev"]
+    name: main
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        if: "!endsWith(matrix.python-version, '-dev')"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: deadsnakes/action@v2.1.1
+        if: endsWith(matrix.python-version, '-dev')
+        with:
+          python-version: ${{ matrix.python-version }}
+          # debug: true  # Optional, to select a Python debug build
+
+      - name: Show python version
+        run: python --version --version && which python
+
+      - name: Install tox
+        run: |
+          python -m pip install pip --upgrade --disable-pip-version-check
+          python -m pip install . tox
+
+      - name: Run tests via tox
+        run: |
+          python -m tox -e 311
+
+      - name: Format ourselves
+        run: python -m black --check src/

--- a/.github/workflows/test-311.yml
+++ b/.github/workflows/test-311.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run tests via tox
         run: |
-          python -m tox -e ci-py311
+          python -m tox -e 311
 
       - name: Format ourselves
         run: |

--- a/.github/workflows/test-311.yml
+++ b/.github/workflows/test-311.yml
@@ -52,4 +52,6 @@ jobs:
           python -m tox -e 311
 
       - name: Format ourselves
-        run: python -m black --check src/
+        run: |
+          python -m pip install .
+          python -m black --check src/

--- a/.github/workflows/test-311.yml
+++ b/.github/workflows/test-311.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run tests via tox
         run: |
-          python -m tox -e 311
+          python -m tox -e ci-py311
 
       - name: Format ourselves
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,7 +69,7 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
-- Add 3.11 CI + declare 3.11 supported minus blackd (#3234)
+- Python 3.11 is now supported, except for `blackd` (#3234)
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
+- Add 3.11 CI + declare 3.11 supported minus blackd (#3234)
+
 ### Parser
 
 <!-- Changes to the parser or to version autodetection -->

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import Any
 from unittest.mock import patch
 
@@ -7,195 +8,199 @@ from click.testing import CliRunner
 
 from tests.util import DETERMINISTIC_HEADER, read_data
 
-try:
-    from aiohttp import web
-    from aiohttp.test_utils import AioHTTPTestCase
+if sys.version_info < (3, 11):
+    try:
+        from aiohttp import web
+        from aiohttp.test_utils import AioHTTPTestCase
 
-    import blackd
-except ImportError as e:
-    raise RuntimeError("Please install Black with the 'd' extra") from e
+        import blackd
+    except ImportError as e:
+        raise RuntimeError("Please install Black with the 'd' extra") from e
 
-try:
-    from aiohttp.test_utils import unittest_run_loop
-except ImportError:
-    # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
-    # removed it. To maintain compatibility we can make our own no-op decorator.
-    def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
-        return func
+    try:
+        from aiohttp.test_utils import unittest_run_loop
+    except ImportError:
+        # unittest_run_loop is unnecessary and a no-op since aiohttp 3.8, and aiohttp 4
+        # removed it. To maintain compatibility we can make our own no-op decorator.
+        def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
+            return func
 
+    @pytest.mark.blackd
+    class BlackDTestCase(AioHTTPTestCase):
+        def test_blackd_main(self) -> None:
+            with patch("blackd.web.run_app"):
+                result = CliRunner().invoke(blackd.main, [])
+                if result.exception is not None:
+                    raise result.exception
+                self.assertEqual(result.exit_code, 0)
 
-@pytest.mark.blackd
-class BlackDTestCase(AioHTTPTestCase):
-    def test_blackd_main(self) -> None:
-        with patch("blackd.web.run_app"):
-            result = CliRunner().invoke(blackd.main, [])
-            if result.exception is not None:
-                raise result.exception
-            self.assertEqual(result.exit_code, 0)
+        async def get_application(self) -> web.Application:
+            return blackd.make_app()
 
-    async def get_application(self) -> web.Application:
-        return blackd.make_app()
+        @unittest_run_loop
+        async def test_blackd_request_needs_formatting(self) -> None:
+            response = await self.client.post("/", data=b"print('hello world')")
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.charset, "utf8")
+            self.assertEqual(await response.read(), b'print("hello world")\n')
 
-    @unittest_run_loop
-    async def test_blackd_request_needs_formatting(self) -> None:
-        response = await self.client.post("/", data=b"print('hello world')")
-        self.assertEqual(response.status, 200)
-        self.assertEqual(response.charset, "utf8")
-        self.assertEqual(await response.read(), b'print("hello world")\n')
+        @unittest_run_loop
+        async def test_blackd_request_no_change(self) -> None:
+            response = await self.client.post("/", data=b'print("hello world")\n')
+            self.assertEqual(response.status, 204)
+            self.assertEqual(await response.read(), b"")
 
-    @unittest_run_loop
-    async def test_blackd_request_no_change(self) -> None:
-        response = await self.client.post("/", data=b'print("hello world")\n')
-        self.assertEqual(response.status, 204)
-        self.assertEqual(await response.read(), b"")
+        @unittest_run_loop
+        async def test_blackd_request_syntax_error(self) -> None:
+            response = await self.client.post("/", data=b"what even ( is")
+            self.assertEqual(response.status, 400)
+            content = await response.text()
+            self.assertTrue(
+                content.startswith("Cannot parse"),
+                msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
+            )
 
-    @unittest_run_loop
-    async def test_blackd_request_syntax_error(self) -> None:
-        response = await self.client.post("/", data=b"what even ( is")
-        self.assertEqual(response.status, 400)
-        content = await response.text()
-        self.assertTrue(
-            content.startswith("Cannot parse"),
-            msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
-        )
-
-    @unittest_run_loop
-    async def test_blackd_unsupported_version(self) -> None:
-        response = await self.client.post(
-            "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "2"}
-        )
-        self.assertEqual(response.status, 501)
-
-    @unittest_run_loop
-    async def test_blackd_supported_version(self) -> None:
-        response = await self.client.post(
-            "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "1"}
-        )
-        self.assertEqual(response.status, 200)
-
-    @unittest_run_loop
-    async def test_blackd_invalid_python_variant(self) -> None:
-        async def check(header_value: str, expected_status: int = 400) -> None:
+        @unittest_run_loop
+        async def test_blackd_unsupported_version(self) -> None:
             response = await self.client.post(
-                "/", data=b"what", headers={blackd.PYTHON_VARIANT_HEADER: header_value}
+                "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "2"}
             )
-            self.assertEqual(response.status, expected_status)
+            self.assertEqual(response.status, 501)
 
-        await check("lol")
-        await check("ruby3.5")
-        await check("pyi3.6")
-        await check("py1.5")
-        await check("2")
-        await check("2.7")
-        await check("py2.7")
-        await check("2.8")
-        await check("py2.8")
-        await check("3.0")
-        await check("pypy3.0")
-        await check("jython3.4")
-
-    @unittest_run_loop
-    async def test_blackd_pyi(self) -> None:
-        source, expected = read_data("miscellaneous", "stub.pyi")
-        response = await self.client.post(
-            "/", data=source, headers={blackd.PYTHON_VARIANT_HEADER: "pyi"}
-        )
-        self.assertEqual(response.status, 200)
-        self.assertEqual(await response.text(), expected)
-
-    @unittest_run_loop
-    async def test_blackd_diff(self) -> None:
-        diff_header = re.compile(
-            r"(In|Out)\t\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d\d\d\d \+\d\d\d\d"
-        )
-
-        source, _ = read_data("miscellaneous", "blackd_diff")
-        expected, _ = read_data("miscellaneous", "blackd_diff.diff")
-
-        response = await self.client.post(
-            "/", data=source, headers={blackd.DIFF_HEADER: "true"}
-        )
-        self.assertEqual(response.status, 200)
-
-        actual = await response.text()
-        actual = diff_header.sub(DETERMINISTIC_HEADER, actual)
-        self.assertEqual(actual, expected)
-
-    @unittest_run_loop
-    async def test_blackd_python_variant(self) -> None:
-        code = (
-            "def f(\n"
-            "    and_has_a_bunch_of,\n"
-            "    very_long_arguments_too,\n"
-            "    and_lots_of_them_as_well_lol,\n"
-            "    **and_very_long_keyword_arguments\n"
-            "):\n"
-            "    pass\n"
-        )
-
-        async def check(header_value: str, expected_status: int) -> None:
+        @unittest_run_loop
+        async def test_blackd_supported_version(self) -> None:
             response = await self.client.post(
-                "/", data=code, headers={blackd.PYTHON_VARIANT_HEADER: header_value}
+                "/", data=b"what", headers={blackd.PROTOCOL_VERSION_HEADER: "1"}
             )
-            self.assertEqual(
-                response.status, expected_status, msg=await response.text()
+            self.assertEqual(response.status, 200)
+
+        @unittest_run_loop
+        async def test_blackd_invalid_python_variant(self) -> None:
+            async def check(header_value: str, expected_status: int = 400) -> None:
+                response = await self.client.post(
+                    "/",
+                    data=b"what",
+                    headers={blackd.PYTHON_VARIANT_HEADER: header_value},
+                )
+                self.assertEqual(response.status, expected_status)
+
+            await check("lol")
+            await check("ruby3.5")
+            await check("pyi3.6")
+            await check("py1.5")
+            await check("2")
+            await check("2.7")
+            await check("py2.7")
+            await check("2.8")
+            await check("py2.8")
+            await check("3.0")
+            await check("pypy3.0")
+            await check("jython3.4")
+
+        @unittest_run_loop
+        async def test_blackd_pyi(self) -> None:
+            source, expected = read_data("miscellaneous", "stub.pyi")
+            response = await self.client.post(
+                "/", data=source, headers={blackd.PYTHON_VARIANT_HEADER: "pyi"}
+            )
+            self.assertEqual(response.status, 200)
+            self.assertEqual(await response.text(), expected)
+
+        @unittest_run_loop
+        async def test_blackd_diff(self) -> None:
+            diff_header = re.compile(
+                r"(In|Out)\t\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d\d\d\d \+\d\d\d\d"
             )
 
-        await check("3.6", 200)
-        await check("py3.6", 200)
-        await check("3.6,3.7", 200)
-        await check("3.6,py3.7", 200)
-        await check("py36,py37", 200)
-        await check("36", 200)
-        await check("3.6.4", 200)
-        await check("3.4", 204)
-        await check("py3.4", 204)
-        await check("py34,py36", 204)
-        await check("34", 204)
+            source, _ = read_data("miscellaneous", "blackd_diff")
+            expected, _ = read_data("miscellaneous", "blackd_diff.diff")
 
-    @unittest_run_loop
-    async def test_blackd_line_length(self) -> None:
-        response = await self.client.post(
-            "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "7"}
-        )
-        self.assertEqual(response.status, 200)
+            response = await self.client.post(
+                "/", data=source, headers={blackd.DIFF_HEADER: "true"}
+            )
+            self.assertEqual(response.status, 200)
 
-    @unittest_run_loop
-    async def test_blackd_invalid_line_length(self) -> None:
-        response = await self.client.post(
-            "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "NaN"}
-        )
-        self.assertEqual(response.status, 400)
+            actual = await response.text()
+            actual = diff_header.sub(DETERMINISTIC_HEADER, actual)
+            self.assertEqual(actual, expected)
 
-    @unittest_run_loop
-    async def test_blackd_preview(self) -> None:
-        response = await self.client.post(
-            "/", data=b'print("hello")\n', headers={blackd.PREVIEW: "true"}
-        )
-        self.assertEqual(response.status, 204)
+        @unittest_run_loop
+        async def test_blackd_python_variant(self) -> None:
+            code = (
+                "def f(\n"
+                "    and_has_a_bunch_of,\n"
+                "    very_long_arguments_too,\n"
+                "    and_lots_of_them_as_well_lol,\n"
+                "    **and_very_long_keyword_arguments\n"
+                "):\n"
+                "    pass\n"
+            )
 
-    @unittest_run_loop
-    async def test_blackd_response_black_version_header(self) -> None:
-        response = await self.client.post("/")
-        self.assertIsNotNone(response.headers.get(blackd.BLACK_VERSION_HEADER))
+            async def check(header_value: str, expected_status: int) -> None:
+                response = await self.client.post(
+                    "/", data=code, headers={blackd.PYTHON_VARIANT_HEADER: header_value}
+                )
+                self.assertEqual(
+                    response.status, expected_status, msg=await response.text()
+                )
 
-    @unittest_run_loop
-    async def test_cors_preflight(self) -> None:
-        response = await self.client.options(
-            "/",
-            headers={
-                "Access-Control-Request-Method": "POST",
-                "Origin": "*",
-                "Access-Control-Request-Headers": "Content-Type",
-            },
-        )
-        self.assertEqual(response.status, 200)
-        self.assertIsNotNone(response.headers.get("Access-Control-Allow-Origin"))
-        self.assertIsNotNone(response.headers.get("Access-Control-Allow-Headers"))
-        self.assertIsNotNone(response.headers.get("Access-Control-Allow-Methods"))
+            await check("3.6", 200)
+            await check("py3.6", 200)
+            await check("3.6,3.7", 200)
+            await check("3.6,py3.7", 200)
+            await check("py36,py37", 200)
+            await check("36", 200)
+            await check("3.6.4", 200)
+            await check("3.4", 204)
+            await check("py3.4", 204)
+            await check("py34,py36", 204)
+            await check("34", 204)
 
-    @unittest_run_loop
-    async def test_cors_headers_present(self) -> None:
-        response = await self.client.post("/", headers={"Origin": "*"})
-        self.assertIsNotNone(response.headers.get("Access-Control-Allow-Origin"))
-        self.assertIsNotNone(response.headers.get("Access-Control-Expose-Headers"))
+        @unittest_run_loop
+        async def test_blackd_line_length(self) -> None:
+            response = await self.client.post(
+                "/", data=b'print("hello")\n', headers={blackd.LINE_LENGTH_HEADER: "7"}
+            )
+            self.assertEqual(response.status, 200)
+
+        @unittest_run_loop
+        async def test_blackd_invalid_line_length(self) -> None:
+            response = await self.client.post(
+                "/",
+                data=b'print("hello")\n',
+                headers={blackd.LINE_LENGTH_HEADER: "NaN"},
+            )
+            self.assertEqual(response.status, 400)
+
+        @unittest_run_loop
+        async def test_blackd_preview(self) -> None:
+            response = await self.client.post(
+                "/", data=b'print("hello")\n', headers={blackd.PREVIEW: "true"}
+            )
+            self.assertEqual(response.status, 204)
+
+        @unittest_run_loop
+        async def test_blackd_response_black_version_header(self) -> None:
+            response = await self.client.post("/")
+            self.assertIsNotNone(response.headers.get(blackd.BLACK_VERSION_HEADER))
+
+        @unittest_run_loop
+        async def test_cors_preflight(self) -> None:
+            response = await self.client.options(
+                "/",
+                headers={
+                    "Access-Control-Request-Method": "POST",
+                    "Origin": "*",
+                    "Access-Control-Request-Headers": "Content-Type",
+                },
+            )
+            self.assertEqual(response.status, 200)
+            self.assertIsNotNone(response.headers.get("Access-Control-Allow-Origin"))
+            self.assertIsNotNone(response.headers.get("Access-Control-Allow-Headers"))
+            self.assertIsNotNone(response.headers.get("Access-Control-Allow-Methods"))
+
+        @unittest_run_loop
+        async def test_cors_headers_present(self) -> None:
+            response = await self.client.post("/", headers={"Origin": "*"})
+            self.assertIsNotNone(response.headers.get("Access-Control-Allow-Origin"))
+            self.assertIsNotNone(response.headers.get("Access-Control-Expose-Headers"))

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 
 from tests.util import DETERMINISTIC_HEADER, read_data
 
-if sys.version_info < (3, 11):
+if sys.version_info < (3, 11):  # noqa: C901
     try:
         from aiohttp import web
         from aiohttp.test_utils import AioHTTPTestCase

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -8,7 +8,9 @@ from click.testing import CliRunner
 
 from tests.util import DETERMINISTIC_HEADER, read_data
 
-if sys.version_info < (3, 11):  # noqa: C901
+LESS_THAN_311 = sys.version_info < (3, 11)
+
+if LESS_THAN_311:
     try:
         from aiohttp import web
         from aiohttp.test_utils import AioHTTPTestCase

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -10,7 +10,7 @@ from tests.util import DETERMINISTIC_HEADER, read_data
 
 LESS_THAN_311 = sys.version_info < (3, 11)
 
-if LESS_THAN_311:
+if LESS_THAN_311:  # noqa: C901
     try:
         from aiohttp import web
         from aiohttp.test_utils import AioHTTPTestCase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {,ci-}py{36,37,38,39,310,py3},fuzz,run_self
+envlist = {,ci-}py{36,37,38,39,310,311,py3},fuzz,run_self
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}/src
@@ -36,6 +36,31 @@ deps =
 ; remove this when pypy releases the bugfix
 commands =
     pip install -e .[d]
+    coverage erase
+    pytest tests \
+        --run-optional no_jupyter \
+        !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
+        --cov {posargs}
+    pip install -e .[jupyter]
+    pytest tests --run-optional jupyter \
+        -m jupyter \
+        !ci: --numprocesses auto \
+        ci: --numprocesses 1 \
+        --cov --cov-append {posargs}
+    coverage report
+
+[testenv:{,ci-}311]
+setenv = PYTHONPATH = {toxinidir}/src
+skip_install = True
+recreate = True
+deps =
+    -r{toxinidir}/test_requirements.txt
+; a separate worker is required in ci due to https://foss.heptapod.net/pypy/pypy/-/issues/3317
+; this seems to cause tox to wait forever
+; remove this when pypy releases the bugfix
+commands =
+    pip install -e .
     coverage erase
     pytest tests \
         --run-optional no_jupyter \


### PR DESCRIPTION
- Had to exempt blackd tests for now due to aiohttp
  - Skip by using `sys.version_info` tuple
  - aiohttp does not compile in 3.11 yet - refer to #3230
- Add a deadsnakes ubuntu workflow to run 3.11-dev to ensure we don't regress
  - Have it also format ourselves

Test:
- `tox -e 311`

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
