### PR TITLE
Use .gitignore files in the initial source directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@
 - Black now uses the presence of debug f-strings to detect target version. (#3215)
 - Fix misdetection of project root and verbose logging of sources in cases involving
   `--stdin-filename` (#3216)
+- Immediate `.gitignore` files in source directories given on the command line are now
+  also respected, previously only `.gitignore` files in the project root and
+  automatically discovered directories were respected (#3237)
 
 ### Documentation
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -652,7 +652,12 @@ def get_sources(
         elif p.is_dir():
             if exclude is None:
                 exclude = re_compile_maybe_verbose(DEFAULT_EXCLUDES)
-                gitignore = get_gitignore(root) + get_gitignore(p)
+                gitignore = get_gitignore(root)
+                p_gitignore = get_gitignore(p)
+                # No need to use p's gitignore if it is identical to root's gitignore
+                # (i.e. root and p point to the same directory).
+                if gitignore != p_gitignore:
+                    gitignore += p_gitignore
             else:
                 gitignore = None
             sources.update(

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -652,7 +652,7 @@ def get_sources(
         elif p.is_dir():
             if exclude is None:
                 exclude = re_compile_maybe_verbose(DEFAULT_EXCLUDES)
-                gitignore = get_gitignore(root)
+                gitignore = get_gitignore(root) + get_gitignore(p)
             else:
                 gitignore = None
             sources.update(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1990,6 +1990,13 @@ class TestFileCollection:
         )
         assert sorted(expected) == sorted(sources)
 
+    def test_nested_gitignore_directly_in_source_directory(self) -> None:
+        # https://github.com/psf/black/issues/2598
+        path = Path(DATA_DIR / "nested_gitignore_tests")
+        src = Path(path / "root" / "child")
+        expected = [src / "a.py", src / "c.py"]
+        assert_collected_sources([src], expected)
+
     def test_invalid_gitignore(self) -> None:
         path = THIS_DIR / "data" / "invalid_gitignore_tests"
         empty_config = path / "pyproject.toml"


### PR DESCRIPTION
Fixes https://github.com/psf/black/issues/2598

### Description

At the moment the `.gitignore` file in the initial target directory provided as first argument is ignored (see  https://github.com/psf/black/issues/2598). 

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
