### PR TITLE
docs: adds ExitStack alternative to future_style.md

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ make_pypi_svg(release)
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "3.0"
+needs_sphinx = "4.4"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,6 +34,17 @@ with \
 Although when the target version is Python 3.9 or higher, _Black_ will use parentheses
 instead since they're allowed in Python 3.9 and higher.
 
+An alternative to consider if the backslashes in the above formatting is undesirable is to use [`contextlib.ExitStack`](https://docs.python.org/3.9/library/contextlib.html#contextlib.ExitStack) to combine context managers in the following way:
+
+```python
+with contextlib.ExitStack() as exit_stack:
+    cm1 = exit_stack.enter_context(make_context_manager(1))
+    cm2 = exit_stack.enter_context(make_context_manager(2))
+    cm3 = exit_stack.enter_context(make_context_manager(3))
+    cm4 = exit_stack.enter_context(make_context_manager(4))
+    ...
+```
+
 ## Preview style
 
 Experimental, potentially disruptive style changes are gathered under the `--preview`

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,7 +34,7 @@ with \
 Although when the target version is Python 3.9 or higher, _Black_ will use parentheses
 instead since they're allowed in Python 3.9 and higher.
 
-An alternative to consider if the backslashes in the above formatting is undesirable is
+An alternative to consider if the backslashes in the above formatting are undesirable is
 to use {external:py:obj}`contextlib.ExitStack` to combine context managers in the
 following way:
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -35,9 +35,8 @@ Although when the target version is Python 3.9 or higher, _Black_ will use paren
 instead since they're allowed in Python 3.9 and higher.
 
 An alternative to consider if the backslashes in the above formatting is undesirable is
-to use
-[`contextlib.ExitStack`](https://docs.python.org/3.9/library/contextlib.html#contextlib.ExitStack)
-to combine context managers in the following way:
+to use {external:py:obj}`contextlib.ExitStack` to combine context managers in the
+following way:
 
 ```python
 with contextlib.ExitStack() as exit_stack:

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,7 +34,10 @@ with \
 Although when the target version is Python 3.9 or higher, _Black_ will use parentheses
 instead since they're allowed in Python 3.9 and higher.
 
-An alternative to consider if the backslashes in the above formatting is undesirable is to use [`contextlib.ExitStack`](https://docs.python.org/3.9/library/contextlib.html#contextlib.ExitStack) to combine context managers in the following way:
+An alternative to consider if the backslashes in the above formatting is undesirable is
+to use
+[`contextlib.ExitStack`](https://docs.python.org/3.9/library/contextlib.html#contextlib.ExitStack)
+to combine context managers in the following way:
 
 ```python
 with contextlib.ExitStack() as exit_stack:


### PR DESCRIPTION
### Description

Closes #2560.  
**This should get a label to silence the CHANGELOG entry check.**

--- 

Adds documentation to the Future Style guide which advises the user to consider using `contextlib.ExitStack()` as opposed to large number of context managers following the `with` statement.  For example, as in the Issue,

```python
with contextlib.ExitStack() as exit_stack:
    cm1 = exit_stack.enter_context(make_context_manager(1))
    cm2 = exit_stack.enter_context(make_context_manager(2))
    cm3 = exit_stack.enter_context(make_context_manager(3))
    cm4 = exit_stack.enter_context(make_context_manager(4))
    ...
```

Feel free to make suggestions in wording, syntax, etc., in this PR.

#### What I did to check this

1. Checked that the (pseudo)-code was valid, and was a valid alternative.
2. Rebuilt the documentation to make sure links worked, things were correctly formatted, etc.

For 1, I made a small sample to make sure that the following two code samples produced the same results:

```python
with contextlib.ExitStack() as exit_stack:
    cm1 = exit_stack.enter_context(open("test1.txt", "w+"))
    cm2 = exit_stack.enter_context(open("test2.txt", "w+"))

    cm1.write("Hello!")
    cm2.write("World!")

# Works the same way as ...

with open("test1.txt", "w+") as cm1, open("test2.txt", "w+") as cm2:
    cm1.write("Hello!")
    cm2.write("World!")
```

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

EDIT: Whoops, first time I forgot to...
- [x] Run `pre-commit run --all-files`.

No additional changes, tests, or updated documentation was necessary in this PR.
