### PR TITLE
Added an option for number of spaces before inline comments

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -36,6 +36,7 @@ from _black_version import version as __version__
 from black.cache import Cache, get_cache_info, read_cache, write_cache
 from black.comments import normalize_fmt_off
 from black.const import (
+    DEFAULT_COMMENT_SPACES,
     DEFAULT_EXCLUDES,
     DEFAULT_INCLUDES,
     DEFAULT_LINE_LENGTH,
@@ -209,6 +210,14 @@ def validate_regex(
     type=int,
     default=DEFAULT_LINE_LENGTH,
     help="How many characters per line to allow.",
+    show_default=True,
+)
+@click.option(
+    "-l",
+    "--comment-spaces",
+    type=int,
+    default=DEFAULT_COMMENT_SPACES,
+    help="How many spaces to use before inline comments.",
     show_default=True,
 )
 @click.option(
@@ -420,6 +429,7 @@ def main(  # noqa: C901
     ctx: click.Context,
     code: Optional[str],
     line_length: int,
+    comment_spaces: int,
     target_version: List[TargetVersion],
     check: bool,
     diff: bool,
@@ -526,6 +536,7 @@ def main(  # noqa: C901
     mode = Mode(
         target_versions=versions,
         line_length=line_length,
+        comment_spaces=comment_spaces,
         is_pyi=pyi,
         is_ipynb=ipynb,
         string_normalization=not skip_string_normalization,
@@ -1069,7 +1080,7 @@ def _format_str_once(src_contents: str, *, mode: Mode) -> str:
         future_imports = get_future_imports(src_node)
         versions = detect_target_versions(src_node, future_imports=future_imports)
 
-    normalize_fmt_off(src_node, preview=mode.preview)
+    normalize_fmt_off(src_node, mode=mode, preview=mode.preview)
     lines = LineGenerator(mode=mode)
     elt = EmptyLineTracker(is_pyi=mode.is_pyi)
     empty_line = Line(mode=mode)

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -9,6 +9,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Final
 
+from black.mode import Mode
 from black.nodes import (
     CLOSING_BRACKETS,
     STANDALONE_COMMENT,
@@ -139,14 +140,14 @@ def make_comment(content: str, *, preview: bool) -> str:
     return "#" + content
 
 
-def normalize_fmt_off(node: Node, *, preview: bool) -> None:
+def normalize_fmt_off(node: Node, *, mode: Mode, preview: bool) -> None:
     """Convert content between `# fmt: off`/`# fmt: on` into standalone comments."""
     try_again = True
     while try_again:
-        try_again = convert_one_fmt_off_pair(node, preview=preview)
+        try_again = convert_one_fmt_off_pair(node, mode=mode, preview=preview)
 
 
-def convert_one_fmt_off_pair(node: Node, *, preview: bool) -> bool:
+def convert_one_fmt_off_pair(node: Node, *, mode: Mode, preview: bool) -> bool:
     """Convert content of a single `# fmt: off`/`# fmt: on` into a standalone comment.
 
     Returns True if a pair was converted.
@@ -188,7 +189,7 @@ def convert_one_fmt_off_pair(node: Node, *, preview: bool) -> bool:
             if comment.value in FMT_OFF:
                 hidden_value = comment.value + "\n" + hidden_value
             if comment.value in FMT_SKIP:
-                hidden_value += "  " + comment.value
+                hidden_value += " " * mode.comment_spaces + comment.value
             if hidden_value.endswith("\n"):
                 # That happens when one of the `ignored_nodes` ended with a NEWLINE
                 # leaf (possibly followed by a DEDENT).

--- a/src/black/const.py
+++ b/src/black/const.py
@@ -1,4 +1,5 @@
 DEFAULT_LINE_LENGTH = 88
+DEFAULT_COMMENT_SPACES = 2
 DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/"  # noqa: B950
 DEFAULT_INCLUDES = r"(\.pyi?|\.ipynb)$"
 STDIN_PLACEHOLDER = "__BLACK_STDIN_FILENAME__"

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -73,7 +73,7 @@ class Line:
             # Note: at this point leaf.prefix should be empty except for
             # imports, for which we only preserve newlines.
             leaf.prefix += whitespace(
-                leaf, complex_subscript=self.is_complex_subscript(leaf)
+                leaf, mode=self.mode, complex_subscript=self.is_complex_subscript(leaf)
             )
         if self.inside_brackets or not preformatted:
             self.bracket_tracker.mark(leaf)

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -17,7 +17,7 @@ if sys.version_info < (3, 8):
 else:
     from typing import Final
 
-from black.const import DEFAULT_LINE_LENGTH
+from black.const import DEFAULT_COMMENT_SPACES, DEFAULT_LINE_LENGTH
 
 
 class TargetVersion(Enum):
@@ -167,6 +167,7 @@ class Deprecated(UserWarning):
 class Mode:
     target_versions: Set[TargetVersion] = field(default_factory=set)
     line_length: int = DEFAULT_LINE_LENGTH
+    comment_spaces: int = DEFAULT_COMMENT_SPACES
     string_normalization: bool = True
     is_pyi: bool = False
     is_ipynb: bool = False

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -17,6 +17,7 @@ else:
 from mypy_extensions import mypyc_attr
 
 from black.cache import CACHE_DIR
+from black.mode import Mode
 from black.strings import has_triple_quotes
 from blib2to3 import pygram
 from blib2to3.pgen2 import token
@@ -175,7 +176,7 @@ class Visitor(Generic[T]):
                 yield from self.visit(child)
 
 
-def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
+def whitespace(leaf: Leaf, *, mode: Mode, complex_subscript: bool) -> str:  # noqa: C901
     """Return whitespace prefix if needed for the given `leaf`.
 
     `complex_subscript` signals whether the given leaf is part of a subscription
@@ -183,7 +184,7 @@ def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
     """
     NO: Final = ""
     SPACE: Final = " "
-    DOUBLESPACE: Final = "  "
+    DOUBLESPACE: Final = " " * mode.comment_spaces
     t = leaf.type
     p = leaf.parent
     v = leaf.value


### PR DESCRIPTION
### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Well this is most obvious thing that shall be tuned after the length of line.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add a CHANGELOG entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
