### PR TITLE
Return pip install black[jupyter] hint with syntax to match platform

### DIFF
--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -3,6 +3,7 @@
 import ast
 import collections
 import dataclasses
+import platform
 import secrets
 import sys
 from functools import lru_cache
@@ -62,9 +63,14 @@ def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
         import tokenize_rt  # noqa:F401
     except ModuleNotFoundError:
         if verbose or not quiet:
+            # Check platform to provide the correct pip hint
+            if "linux" in platform.platform().lower():
+                pip_command_hint = "``pip install 'black[jupyter]'``"
+            else:
+                pip_command_hint = "``pip install black[jupyter]``"
             msg = (
                 "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
-                "You can fix this by running ``pip install black[jupyter]``"
+                f"You can fix this by running {pip_command_hint}"
             )
             out(msg)
         return False

--- a/tests/test_no_ipynb.py
+++ b/tests/test_no_ipynb.py
@@ -5,13 +5,29 @@ from click.testing import CliRunner
 
 from black import jupyter_dependencies_are_installed, main
 from tests.util import get_case_path
+from unittest.mock import patch
 
 pytestmark = pytest.mark.no_jupyter
 
 runner = CliRunner()
 
 
-def test_ipynb_diff_with_no_change_single() -> None:
+@patch("platform.platform")
+def test_ipynb_diff_with_no_change_single_on_linux(platform_platform) -> None:
+    platform_platform.return_value = "some-linux-distro-v0.1.2"
+    jupyter_dependencies_are_installed.cache_clear()
+    path = get_case_path("jupyter", "notebook_trailing_newline.ipynb")
+    result = runner.invoke(main, [str(path)])
+    expected_output = (
+        "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
+        "You can fix this by running ``pip install 'black[jupyter]'``\n"
+    )
+    assert expected_output in result.output
+
+
+@patch("platform.platform")
+def test_ipynb_diff_with_no_change_single_not_linux(platform_platform) -> None:
+    platform_platform.return_value = "windows-or-mac-etc"
     jupyter_dependencies_are_installed.cache_clear()
     path = get_case_path("jupyter", "notebook_trailing_newline.ipynb")
     result = runner.invoke(main, [str(path)])
@@ -22,7 +38,30 @@ def test_ipynb_diff_with_no_change_single() -> None:
     assert expected_output in result.output
 
 
-def test_ipynb_diff_with_no_change_dir(tmp_path: pathlib.Path) -> None:
+@patch("platform.platform")
+def test_ipynb_diff_with_no_change_dir_on_linux(
+    platform_platform, tmp_path: pathlib.Path
+) -> None:
+    platform_platform.return_value = "some-linux-distro-v0.1.2"
+    jupyter_dependencies_are_installed.cache_clear()
+    runner = CliRunner()
+    nb = get_case_path("jupyter", "notebook_trailing_newline.ipynb")
+    tmp_nb = tmp_path / "notebook.ipynb"
+    with open(nb) as src, open(tmp_nb, "w") as dst:
+        dst.write(src.read())
+    result = runner.invoke(main, [str(tmp_path)])
+    expected_output = (
+        "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
+        "You can fix this by running ``pip install 'black[jupyter]'``\n"
+    )
+    assert expected_output in result.output
+
+
+@patch("platform.platform")
+def test_ipynb_diff_with_no_change_dir_not_linux(
+    platform_platform, tmp_path: pathlib.Path
+) -> None:
+    platform_platform.return_value = "windows-or-mac-etc"
     jupyter_dependencies_are_installed.cache_clear()
     runner = CliRunner()
     nb = get_case_path("jupyter", "notebook_trailing_newline.ipynb")


### PR DESCRIPTION
### Description

This change updates the message returned when Jupyter dependencies are not installed, so that it contains syntax corresponding to the platform.

Previously, attempting to apply black formatting to an ipynb notebook without black[jupyter] installed always returned the hint to run `pip install black[jupyter]`. This command does not work on Ubuntu with python3.

With this change, in the same scenario, the hint is `pip install 'black[jupyter]'` if `"linux"` is in the platform name, and the old hint `pip install black[jupyter]` otherwise.

The only function changed in the main codebase was `black.handle_ipynb_magics.jupyter_dependencies_are_installed`

I updated `tests/test_no_ipynb.py` to mock linux and non-linux versions of the existing tests.

Because this PR does not impact formatter rules or behavior, I did not update the CHANGELOG or documentation. However if I skipped any steps or missed anything please let me know, and I will take care of it :)

### Checklist - did you ...

- [X] Add a CHANGELOG entry if necessary? -> Not sure if applicable
- [X] Add / update tests if necessary? -> Yes (`tests/test_no_ipynb.py`)
- [X] Add new / update outdated documentation? -> N/A