### PR TITLE
Mitigate deprecation of aiohttp's `@middleware` decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ filterwarnings = [
     # this is mitigated by a try/catch in https://github.com/psf/black/pull/2974/
     # this ignore can be removed when support for aiohttp 3.7 is dropped.
     '''ignore:Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+:DeprecationWarning''',
+    # this is mitigated by a try/catch in https://github.com/psf/black/pull/3198/
+    # this ignore can be removed when support for aiohttp 3.x is dropped.
+    '''ignore:Middleware decorator is deprecated since 4\.0 and its behaviour is default, you can simply remove this decorator:DeprecationWarning''',
     # this is mitigated by https://github.com/python/cpython/issues/79071 in python 3.8+
     # this ignore can be removed when support for 3.7 is dropped.
     '''ignore:Bare functions are deprecated, use async ones:DeprecationWarning''',

--- a/src/blackd/middlewares.py
+++ b/src/blackd/middlewares.py
@@ -1,15 +1,25 @@
-from typing import Awaitable, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar
 
-from aiohttp.web_middlewares import middleware
 from aiohttp.web_request import Request
 from aiohttp.web_response import StreamResponse
+
+if TYPE_CHECKING:
+    F = TypeVar("F", bound=Callable[..., Any])
+    middleware: Callable[[F], F]
+else:
+    try:
+        from aiohttp.web_middlewares import middleware
+    except ImportError:
+        # @middleware is deprecated and its behaviour is the default since aiohttp 4.0
+        # so if it doesn't exist anymore, define a no-op for forward compatibility.
+        middleware = lambda x: x  # noqa: E731
 
 Handler = Callable[[Request], Awaitable[StreamResponse]]
 Middleware = Callable[[Request, Handler], Awaitable[StreamResponse]]
 
 
 def cors(allow_headers: Iterable[str]) -> Middleware:
-    @middleware  # type: ignore[misc]
+    @middleware
     async def impl(request: Request, handler: Handler) -> StreamResponse:
         is_options = request.method == "OPTIONS"
         is_preflight = is_options and "Access-Control-Request-Method" in request.headers
@@ -32,4 +42,4 @@ def cors(allow_headers: Iterable[str]) -> Middleware:
 
         return resp
 
-    return impl  # type: ignore[no-any-return]
+    return impl


### PR DESCRIPTION
### Description

This is deprecated since aiohttp 4.0. If it doesn't exist just define a no-op decorator that does nothing (after the other aiohttp imports though!). By doing this, it's safe to ignore the DeprecationWarning without needing to require the latest aiohttp once they remove `@middleware`.

Resolves GH-3176. Closes GH-3198.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary? -> n/a
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
