### PR TITLE
Support version specifiers in GH action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Update GitHub action to support use of version specifiers (i.e. `<23`) for Black
+  version (#3265)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,7 +42,7 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
-- Update GitHub action to support use of version specifiers (i.e. `<23`) for Black
+- Update GitHub Action to support use of version specifiers (e.g. `<23`) for Black
   version (#3265)
 
 ### Documentation

--- a/action/main.py
+++ b/action/main.py
@@ -14,9 +14,10 @@ VERSION = os.getenv("INPUT_VERSION", default="")
 
 run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
 
-req = "black[colorama]"
-if VERSION:
-    req += f"=={VERSION}"
+version_specifier = VERSION
+if VERSION and VERSION[0] in "0123456789":
+    version_specifier = f"=={VERSION}"
+req = f"black[colorama]{version_specifier}"
 pip_proc = run(
     [str(ENV_BIN / "python"), "-m", "pip", "install", req],
     stdout=PIPE,

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -32,9 +32,12 @@ We recommend the use of the `@stable` tag, but per version tags also exist if yo
 that. Note that the action's version you select is independent of the version of _Black_
 the action will use.
 
-The version of _Black_ the action will use can be configured via `version`. The action
-defaults to the latest release available on PyPI. Only versions available from PyPI are
-supported, so no commit SHAs or branch names.
+The version of _Black_ the action will use can be configured via `version`. This can be
+any
+[valid version specifier](https://packaging.python.org/en/latest/glossary/#term-Version-Specifier)
+or just the version number if you want an exact version. The action defaults to the
+latest release available on PyPI. Only versions available from PyPI are supported, so no
+commit SHAs or branch names.
 
 You can also configure the arguments passed to _Black_ via `options` (defaults to
 `'--check --diff'`) and `src` (default is `'.'`)
@@ -47,4 +50,16 @@ Here's an example configuration:
     options: "--check --verbose"
     src: "./src"
     version: "21.5b1"
+```
+
+If you want to match versions covered by Black's
+[stability policy](labels/stability-policy), you can use the compatible release operator
+(`~=`):
+
+```yaml
+- uses: psf/black@stable
+  with:
+    options: "--check --verbose"
+    src: "./src"
+    version: "~= 22.0"
 ```


### PR DESCRIPTION
### Description

Addresses the lack of support for version specifiers in GH action that was mentioned in #3264.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
    - I think there aren't any
- [x] Add new / update outdated documentation?
