### PR TITLE
[FIX] migrate-black.py: don't fail on binary files

### DIFF
--- a/scripts/migrate-black.py
+++ b/scripts/migrate-black.py
@@ -49,6 +49,7 @@ def blackify(base_branch: str, black_command: str, logger: logging.Logger) -> in
             [
                 "git",
                 "diff",
+                "--binary",
                 "--find-copies",
                 "%s-black..%s-black" % (last_commit, commit),
             ],


### PR DESCRIPTION
without this, the script fails if any commit contains non-text files

[docs](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---binary)