### PR TITLE
Fix mypyc build errors on newer manylinux2014_x86_64 images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,8 @@ PIP_NO_BUILD_ISOLATION = "no"
 [tool.cibuildwheel.linux]
 before-build = [
     "pip install -r .github/mypyc-requirements.txt",
-    "yum install -y clang",
+    "yum install -y clang gcc",
 ]
-# Newer images break the builds, not sure why. We'll need to investigate more later.
-manylinux-x86_64-image = "quay.io/pypa/manylinux2014_x86_64:2021-11-20-f410d11"
 
 [tool.cibuildwheel.linux.environment]
 BLACK_USE_MYPYC = "1"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
The mypyc build requires `gcc` to be installed even if it's being built with `clang`, otherwise `clang` fails to find `libgcc` and `crtbegin.o`.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

### Tested by

Running this on my windows machine:
```
pipx run cibuildwheel --only cp37-manylinux_x86_64
```
And see it successfully get through the wheel build step

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
