### PR TITLE
Build mypyc wheels for CPython 3.11

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.10.0
         env:
           CIBW_ARCHS_MACOS: "${{ matrix.macos_arch }}"
           # This isn't supported in pyproject.toml which makes sense (but is annoying).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
+- Faster compiled wheels are now available for CPython 3.11 (#3276)
+
 ### Parser
 
 <!-- Changes to the parser or to version autodetection -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ MYPYC_DEBUG_LEVEL = "0"
 # The dependencies required to build wheels with mypyc aren't specified in
 # [build-system].requires so we'll have to manage the build environment ourselves.
 PIP_NO_BUILD_ISOLATION = "no"
+# CPython 3.11 wheels aren't available for aiohttp and building a Cython extension
+# from source also doesn't work.
+AIOHTTP_NO_EXTENSIONS = "1"
 
 [tool.cibuildwheel.linux]
 before-build = [
@@ -69,6 +72,7 @@ MYPYC_DEBUG_LEVEL = "0"
 PIP_NO_BUILD_ISOLATION = "no"
 # Black needs Clang to compile successfully on Linux.
 CC = "clang"
+AIOHTTP_NO_EXTENSIONS = "1"
 
 [tool.cibuildwheel.windows]
 # For some reason, (compiled) mypyc is failing to start up with "ImportError: DLL load

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -26,7 +26,8 @@ if sys.version_info >= (3, 11):
         import tomllib
     except ImportError:
         # Help users on older alphas
-        import tomli as tomllib
+        if not TYPE_CHECKING:
+            import tomli as tomllib
 else:
     import tomli as tomllib
 


### PR DESCRIPTION
### Description

Bumps cibuildwheel from 2.8.1 to 2.10.0 which has 3.11 building enabled by default. Unfortunately mypyc errors out on 3.11:

```
src/black/files.py:29:9: error: Name "tomllib" already defined (by an import)  [no-redef]
```

... so we have to also hide the fallback import of tomli on older 3.11 alphas from mypy[c].

Closes #3224. Towards #3230.

### Checklist - did you ...

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

### Review notes

To verify this works, I ran a test cibuildwheel run which passed: https://github.com/ichard26/black-mypyc-wheels/actions/runs/3075208256 

I'd appreciate if someone with an ARM mac could check that the ARM mac wheels don't crash. [You can download them here](https://github.com/ichard26/black-mypyc-wheels/suites/8342284497/artifacts/367142266).