### PR TITLE
Add option to format Jupyter Notebooks files in GitHub Actions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@ Multiple contributions by:
 - [Andrey](mailto:dyuuus@yandex.ru)
 - [Andy Freeland](mailto:andy@andyfreeland.net)
 - [Anthony Sottile](mailto:asottile@umich.edu)
+- [Antonio Ossa Guerra](mailto:aaossa+black@uc.cl)
 - [Arjaan Buijk](mailto:arjaan.buijk@gmail.com)
 - [Arnav Borbornah](mailto:arnavborborah11@gmail.com)
 - [Artem Malyshev](mailto:proofit404@gmail.com)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Update GitHub Action to support formatting of Jupyter Notebook files (#3282)
 - Update GitHub Action to support use of version specifiers (e.g. `<23`) for Black
   version (#3265)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,8 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
-- Update GitHub Action to support formatting of Jupyter Notebook files (#3282)
+- Update GitHub Action to support formatting of Jupyter Notebook files via a `jupyter`
+  option (#3282)
 - Update GitHub Action to support use of version specifiers (e.g. `<23`) for Black
   version (#3265)
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,11 @@ inputs:
     description: "Source to run Black. Default: '.'"
     required: false
     default: "."
+  jupyter:
+    description:
+      "Set this option to true to include Jupyter Notebooks files. Default: false"
+    required: false
+    default: false
   black_args:
     description: "[DEPRECATED] Black input arguments."
     required: false
@@ -38,6 +43,7 @@ runs:
         # TODO: Remove once https://github.com/actions/runner/issues/665 is fixed.
         INPUT_OPTIONS: ${{ inputs.options }}
         INPUT_SRC: ${{ inputs.src }}
+        INPUT_JUPYTER: ${{ inputs.jupyter }}
         INPUT_BLACK_ARGS: ${{ inputs.black_args }}
         INPUT_VERSION: ${{ inputs.version }}
         pythonioencoding: utf-8

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: "."
   jupyter:
     description:
-      "Set this option to true to include Jupyter Notebooks files. Default: false"
+      "Set this option to true to include Jupyter Notebook files. Default: false"
     required: false
     default: false
   black_args:

--- a/action/main.py
+++ b/action/main.py
@@ -9,6 +9,7 @@ ENV_PATH = ACTION_PATH / ".black-env"
 ENV_BIN = ENV_PATH / ("Scripts" if sys.platform == "win32" else "bin")
 OPTIONS = os.getenv("INPUT_OPTIONS", default="")
 SRC = os.getenv("INPUT_SRC", default="")
+JUPYTER = os.getenv("INPUT_JUPYTER") == "true"
 BLACK_ARGS = os.getenv("INPUT_BLACK_ARGS", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 
@@ -17,7 +18,11 @@ run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
 version_specifier = VERSION
 if VERSION and VERSION[0] in "0123456789":
     version_specifier = f"=={VERSION}"
-req = f"black[colorama]{version_specifier}"
+if JUPYTER:
+    extra_deps = "[colorama,jupyter]"
+else:
+    extra_deps = "[colorama]"
+req = f"black{extra_deps}{version_specifier}"
 pip_proc = run(
     [str(ENV_BIN / "python"), "-m", "pip", "install", req],
     stdout=PIPE,

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -39,6 +39,10 @@ or just the version number if you want an exact version. The action defaults to 
 latest release available on PyPI. Only versions available from PyPI are supported, so no
 commit SHAs or branch names.
 
+If you want to include Jupyter Notebooks, _Black_ must be installed with the `jupyter`
+extra. Installing the extra and including Jupyter Notebook files can be configured via
+`jupyter` (default is `false`).
+
 You can also configure the arguments passed to _Black_ via `options` (defaults to
 `'--check --diff'`) and `src` (default is `'.'`)
 
@@ -49,6 +53,7 @@ Here's an example configuration:
   with:
     options: "--check --verbose"
     src: "./src"
+    jupyter: true
     version: "21.5b1"
 ```
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Adds support to enable formatting of Jupyter Notebook files in the GitHub Action integration. See https://github.com/psf/black/issues/3280 for more information.

Closes #3280 

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [X] Add a CHANGELOG entry if necessary?
- [X] ~Add / update tests if necessary?~ No relevant tests found
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
