### PR TITLE
add \.ipynb_checkpoints to DEFAULT_EXCLUDES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 
 <!-- Changes to how Black can be configured -->
 
-- Files in \.ipynb_checkpoints are excluded by default. (#3293)
+\.ipynb_checkpoints
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 
 <!-- Changes to how Black can be configured -->
 
-\.ipynb_checkpoints
+- `.ipynb_checkpoints` directories are now excluded by default (#3293)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 <!-- Changes to how Black can be configured -->
 
+- Files in \.ipynb_checkpoints are excluded by default. (#3293)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/const.py
+++ b/src/black/const.py
@@ -1,4 +1,4 @@
 DEFAULT_LINE_LENGTH = 88
-DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/"  # noqa: B950
+DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|\.ipynb_checkpoints|_build|buck-out|build|dist|__pypackages__)/"  # noqa: B950
 DEFAULT_INCLUDES = r"(\.pyi?|\.ipynb)$"
 STDIN_PLACEHOLDER = "__BLACK_STDIN_FILENAME__"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

I believe most users would not want to run black[jupyter] on files in .ipynb_checkpoints/.

This PR adds .ipynb_checkpoints/ to DEFAULT_EXCLUDES in src/black/const.py

I did a quick issue search and couldn't see if a PR like this is outside of scope or has been rejected in the past (https://github.com/psf/black/issues?q=is%3Aissue+ipynb_checkpoints)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add a CHANGELOG entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
