### PR TITLE
Remove redundant 3.6 code and bump mypy's python_version to 3.7

### DIFF
--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -57,8 +57,8 @@ def _get_virtualenv_site_packages(venv_path, pyver):
 
 def _initialize_black_env(upgrade=False):
   pyver = sys.version_info[:3]
-  if pyver < (3, 6, 2):
-    print("Sorry, Black requires Python 3.6.2+ to run.")
+  if pyver < (3, 7):
+    print("Sorry, Black requires Python 3.7+ to run.")
     return False
 
   from pathlib import Path

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 # Specify the target platform details in config, so your developers are
 # free to run mypy on Windows, Linux, or macOS and get consistent
 # results.
-python_version=3.6
+python_version=3.7
 
 mypy_path=src
 
@@ -18,11 +18,6 @@ no_implicit_reexport = False
 # Unreachable blocks have been an issue when compiling mypyc, let's try
 # to avoid 'em in the first place.
 warn_unreachable=True
-
-[mypy-black]
-# The following is because of `patch_click()`. Remove when
-# we drop Python 3.6 support.
-warn_unused_ignores=False
 
 [mypy-blib2to3.driver.*]
 ignore_missing_imports = True

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1382,9 +1382,9 @@ def patch_click() -> None:
 
     for module in modules:
         if hasattr(module, "_verify_python3_env"):
-            module._verify_python3_env = lambda: None  # type: ignore
+            module._verify_python3_env = lambda: None
         if hasattr(module, "_verify_python_env"):
-            module._verify_python_env = lambda: None  # type: ignore
+            module._verify_python_env = lambda: None
 
 
 def patched_main() -> None:

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -47,12 +47,8 @@ def cancel(tasks: Iterable["asyncio.Task[Any]"]) -> None:
 def shutdown(loop: asyncio.AbstractEventLoop) -> None:
     """Cancel all pending tasks on `loop`, wait for them, and close the loop."""
     try:
-        if sys.version_info[:2] >= (3, 7):
-            all_tasks = asyncio.all_tasks
-        else:
-            all_tasks = asyncio.Task.all_tasks
         # This part is borrowed from asyncio/runners.py in Python 3.7b2.
-        to_cancel = [task for task in all_tasks(loop) if not task.done()]
+        to_cancel = [task for task in asyncio.all_tasks(loop) if not task.done()]
         if not to_cancel:
             return
 

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -27,8 +27,7 @@ _IS_PYPY = platform.python_implementation() == "PyPy"
 try:
     from typed_ast import ast3
 except ImportError:
-    # Either our python version is too low, or we're on pypy
-    if sys.version_info < (3, 7) or (sys.version_info < (3, 8) and not _IS_PYPY):
+    if sys.version_info < (3, 8) and not _IS_PYPY:
         print(
             "The typed_ast package is required but not installed.\n"
             "You can upgrade to Python 3.8+ or install typed_ast with\n"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

The https://github.com/psf/black/releases/tag/22.10.0 removed runtime support for EOL Python 3.6. 🚀 

We can remove a few old checks and config.

Updating the mypy config means we can remove a couple of `# type: ignore`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [n/a?] Add an entry in `CHANGES.md` if necessary?
- [n/a] Add / update tests if necessary?
- [n/a] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
