### PR TITLE
added python version to parse error message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -148,6 +148,7 @@
 
 ### Output
 
+- Add python version to parse error message
 - Change from deprecated `asyncio.get_event_loop()` to create our event loop which
   removes DeprecationWarning (#3164)
 - Remove logging from internal `blib2to3` library since it regularly emits error logs

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -133,7 +133,7 @@ plus a short summary.
 
 ```console
 $ black src/
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
+error: cannot format src/black_primer/cli.py: Cannot parse (python 3.10): 5:6: mport asyncio
 reformatted src/black_primer/lib.py
 reformatted src/blackd/__init__.py
 reformatted src/black/__init__.py
@@ -151,7 +151,7 @@ Using configuration from /tmp/pyproject.toml.
 src/blib2to3 ignored: matches the --extend-exclude regular expression
 src/_black_version.py wasn't modified on disk since last run.
 src/black/__main__.py wasn't modified on disk since last run.
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
+error: cannot format src/black_primer/cli.py: Cannot parse (python 3.10): 5:6: mport asyncio
 reformatted src/black_primer/lib.py
 reformatted src/blackd/__init__.py
 reformatted src/black/__init__.py
@@ -164,7 +164,7 @@ Error messages will still be emitted (which can silenced by `2>/dev/null`).
 
 ```console
 $ black src/ -q
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
+error: cannot format src/black_primer/cli.py: Cannot parse (python 3.10): 5:6: mport asyncio
 ```
 
 ### Versions

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -99,8 +99,10 @@ def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -
                 faulty_line = lines[lineno - 1]
             except IndexError:
                 faulty_line = "<line number missing in source>"
+            pretty_version = ".".join(str(number) for number in grammar.version)
             errors[grammar.version] = InvalidInput(
-                f"Cannot parse: {lineno}:{column}: {faulty_line}"
+                f"Cannot parse (python {pretty_version}): {lineno}:{column}:"
+                f" {faulty_line}"
             )
 
         except TokenError as te:

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -108,8 +108,10 @@ def lib2to3_parse(src_txt: str, target_versions: Iterable[TargetVersion] = ()) -
         except TokenError as te:
             # In edge cases these are raised; and typically don't have a "faulty_line".
             lineno, column = te.args[1]
+            pretty_version = ".".join(str(number) for number in grammar.version)
             errors[grammar.version] = InvalidInput(
-                f"Cannot parse: {lineno}:{column}: {te.args[0]}"
+                f"Cannot parse (python {pretty_version}): {lineno}:{column}:"
+                f" {te.args[0]}"
             )
 
     else:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -946,7 +946,7 @@ class BlackTestCase(BlackBaseTestCase):
         invalid = "return if you can"
         with self.assertRaises(black.InvalidInput) as e:
             black.format_file_contents(invalid, mode=mode, fast=False)
-        self.assertEqual(str(e.exception), "Cannot parse: 1:7: return if you can")
+        self.assertIn("1:7: return if you can", str(e.exception))
 
     def test_endmarker(self) -> None:
         n = black.lib2to3_parse("\n")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -116,7 +116,7 @@ def test_patma_invalid() -> None:
     with pytest.raises(black.parsing.InvalidInput) as exc_info:
         assert_format(source, expected, mode, minimum_version=(3, 10))
 
-    exc_info.match("Cannot parse: 10:11")
+    exc_info.match("Cannot parse (python 3.10): 10:11")
 
 
 @pytest.mark.parametrize("filename", all_data_cases("py_311"))


### PR DESCRIPTION
### Description
improve parsing error message to make sure users know which version it was run on (fixes #3294).

### Checklist - did you ...
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?