### PR TITLE
Fix license metadata to follow PEP 621

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,6 +24,7 @@ Multiple contributions by:
 - [Alex Vandiver](mailto:github@chmrr.net)
 - [Allan Simon](mailto:allan.simon@supinfo.com)
 - Anders-Petter Ljungquist
+- [Amethyst Reese](mailto:amy@n7.gg)
 - [Andrew Thorp](mailto:andrew.thorp.dev@gmail.com)
 - [Andrew Zhou](mailto:andrewfzhou@gmail.com)
 - [Andrey](mailto:dyuuus@yandex.ru)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "hatchling.build"
 [project]
 name = "black"
 description = "The uncompromising code formatter."
-license = "MIT"
+license = { text = "MIT" }
 requires-python = ">=3.7"
 authors = [
   { name = "Łukasz Langa", email = "lukasz@langa.pl" },


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

PEP 621 requires the `license` field to be a table with either a `file` or `text` key: https://peps.python.org/pep-0621/#license

The current value of `license = "MIT"` is not PEP 621 compliant, even though hatchling allows it.
