### PR TITLE
Add compatible `indentexpr` to Vim plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Vim plugin: can now indent while editing according to the _Black_ code style, which
+  can be enabled with the `g:black_indent` flag (#3332)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -137,8 +137,8 @@ $ git checkout origin/stable -b stable
 
 or you can copy the plugin files from
 [plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim),
-[autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim),
-and [indent/python.vim](https://github.com/psf/black/blob/stable/indent/python.vim).
+[autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim), and
+[indent/python.vim](https://github.com/psf/black/blob/stable/indent/python.vim).
 
 ```
 mkdir -p ~/.vim/pack/python/start/black/plugin

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -114,6 +114,7 @@ Configuration:
 - `g:black_virtualenv` (defaults to `~/.vim/black` or `~/.local/share/nvim/black`)
 - `g:black_quiet` (defaults to `0`)
 - `g:black_preview` (defaults to `0`)
+- `g:black_indent` (defaults to `0`)
 
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
@@ -135,14 +136,17 @@ $ git checkout origin/stable -b stable
 ```
 
 or you can copy the plugin files from
-[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim) and
-[autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim).
+[plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim),
+[autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim),
+and [indent/python.vim](https://github.com/psf/black/blob/stable/indent/python.vim).
 
 ```
 mkdir -p ~/.vim/pack/python/start/black/plugin
 mkdir -p ~/.vim/pack/python/start/black/autoload
+mkdir -p ~/.vim/pack/python/start/black/indent
 curl https://raw.githubusercontent.com/psf/black/stable/plugin/black.vim -o ~/.vim/pack/python/start/black/plugin/black.vim
 curl https://raw.githubusercontent.com/psf/black/stable/autoload/black.vim -o ~/.vim/pack/python/start/black/autoload/black.vim
+curl https://raw.githubusercontent.com/psf/black/stable/indent/python.vim -o ~/.vim/pack/python/start/black/indent/python.vim
 ```
 
 Let me know if this requires any changes to work with Vim 8's builtin `packadd`, or
@@ -159,6 +163,9 @@ restarting Vim.
 If you need to do anything special to make your virtualenv work and install _Black_ (for
 example you want to run a version from main), create a virtualenv manually and point
 `g:black_virtualenv` to it. The plugin will use it.
+
+The plugin can make Vim itself indent files according to the _Black_ code style. To
+enable this, set `g:black_indent` to `1`.
 
 To run _Black_ on save, add the following lines to `.vimrc` or `init.vim`:
 

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -1,62 +1,107 @@
-if exists("b:did_indent")
+if exists("b:did_indent") || !exists("g:black_indent") || g:black_indent == 0
     finish
 endif
-" Don't actually set b:did_indent, need to source indent/python.vim first.
+let b:did_indent = 1
 
-if !get(g:, "black_indent", 0)
-    finish
-endif
-
-" shiftwidth() does not exist on older Vim versions. BlackIndent should use s:sw
-" for indentation to be correct regardless of the set shiftwidth (even if it
-" should be 4), and Vim sets the shiftwidth for Python files to 4 by default
-" anyway. If the user changes shiftwidth from 4, not our fault; at least it will
-" still indent reasonably.
-let s:sw = exists("*shiftwidth") ? "shiftwidth()" : "&sw"
-
-let s:has_paren_patch = has("nvim-0.8.0") || has("patch-9.0.259")
-if s:has_paren_patch
-    let g:python_indent = get(g:, "python_indent", {})
-    let g:python_indent.open_paren = s:sw
-    let g:python_indent.nested_paren = s:sw
-    " +1 is for with statements.
-    let g:python_indent.continue = s:sw .. " + 1"
-    let g:python_indent.closed_paren_align_last_line = v:false
-else
-    let g:pyindent_open_paren = s:sw
-    let g:pyindent_nested_paren = s:sw
-    " +1 is for with statements.
-    let g:pyindent_continue = s:sw .. " + 1"
-endif
-
-if filereadable($VIMRUNTIME .. "/indent/python.vim")
-    source $VIMRUNTIME/indent/python.vim
-endif
-
-if !exists("*GetPythonIndent")
-    finish
-endif
-
+setlocal nolisp
+setlocal autoindent
 setlocal indentexpr=BlackIndent()
+setlocal indentkeys+=<:>,=elif,=except
+
+" Four-space indentation no matter what.
+setlocal shiftwidth=4
+setlocal expandtab
+
+let b:undo_indent = "setl ai< inde< lisp< sw< et<"
 
 if exists("*BlackIndent")
     finish
 endif
 
-function BlackIndent()
-    let original_indent = GetPythonIndent(v:lnum)
-    let syntax_name = synIDattr(
-        \ synIDtrans(synID(v:lnum, match(getline(v:lnum), '\S') + 1, 1)),
-        \ "name")
-    if syntax_name !=# "String"
-        if !s:has_paren_patch && getline(v:lnum) =~# '^\s*\%(]\|}\|)\)'
-            " Closing parens should be dedented from preceding line once.
-            return original_indent - eval(s:sw)
-        elseif getline(v:lnum) =~# '^\s*:' && getline(v:lnum - 1) =~# '\\$'
-            " Lone colons (in the case of with statements) should be aligned
-            " with the "with".
-            return original_indent - (eval(s:sw) + 1)
+function s:SyntaxName(lnum, cnum)
+    return synIDattr(synID(a:lnum, a:cnum, 1), "name")
+endfunction
+
+function s:NoComment(lnum)
+    let line = getline(a:lnum)
+    let len = strlen(line)
+    while s:SyntaxName(a:lnum, len) =~# '\(Comment\|Todo\)$'
+        let len = len - 1
+    endwhile
+    return strpart(line, 0, len)
+endfunction
+
+" prevnonblank() doesn't ignore entirely comment lines.
+function s:PrevNonBlankOrComment(lnum)
+    let l = prevnonblank(a:lnum)
+    while getline(l) =~# '^\s*#'
+        let l = prevnonblank(l - 1)
+    endwhile
+    return l
+endfunction
+
+function s:ForceDedent(lnum)
+    if indent(a:lnum) <= indent(s:PrevNonBlankOrComment(a:lnum - 1)) - &sw
+        return -1
+    else
+        return indent(a:lnum - 1) - &sw
+    endif
+endfunction
+
+function! BlackIndent()
+    " First line gets no indent.
+    if v:lnum == 1
+        return 0
+    endif
+
+    " Strings and doctests should not be touched.
+    if s:SyntaxName(v:lnum, 1) =~# '\(String\|Quotes\)$\|Doctest'
+        return -1
+    endif
+
+    " Lines after a line ending in an open paren or a colon should be indented.
+    if s:NoComment(v:lnum - 1) =~# '[[({:]\s*$'
+        return indent(v:lnum - 1) + &sw
+    endif
+
+    " Lines beginning with a closing paren should be dedented.
+    if getline(v:lnum) =~# '^\s*[])}]'
+        return indent(v:lnum - 1) - &sw
+    endif
+
+    " Backslash-continued lines are only used in the case of `with` statements.
+    if getline(v:lnum - 1) =~# '\\$'
+        if getline(v:lnum - 2) !~# '\\$'
+            " The first line after a backslash line should be indented 5.
+            return indent(v:lnum - 1) + &sw + 1
+        elseif getline(v:lnum) =~# '^\s*:'
+            " The final colon after a continued line should be dedented.
+            return indent(v:lnum - 1) - &sw - 1
+        else
+            return -1
         endif
     endif
-    return original_indent
+
+    " Lines after ones using these keywords are unreachable, so dedent.
+    if getline(v:lnum - 1) =~# '^\s*\(break\|continue\|pass\|raise\|return\)\>'
+        return s:ForceDedent(v:lnum)
+    endif
+
+    " Lines starting with these always have less indent than the line before.
+    if getline(v:lnum) =~# '^\s*\(elif\|except\|finally\)\>'
+        return s:ForceDedent(v:lnum)
+    endif
+
+    " `else` is special because it can be used in `x if y else z` expressions
+    " that span multiple lines, and can come after a single line `if` clause.
+    if getline(v:lnum) =~# '^\s*else\>'
+        if getline(v:lnum - 1) '^\s*if\>'
+            return -1
+        else
+            return s:ForceDedent(v:lnum)
+        endif
+    endif
+
+    " Otherwise, keep the current indent.
+    return -1
 endfunction

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -1,0 +1,62 @@
+if exists("b:did_indent")
+    finish
+endif
+" Don't actually set b:did_indent, need to source indent/python.vim first.
+
+if !get(g:, "black_indent", 0)
+    finish
+endif
+
+" shiftwidth() does not exist on older Vim versions. BlackIndent should use s:sw
+" for indentation to be correct regardless of the set shiftwidth (even if it
+" should be 4), and Vim sets the shiftwidth for Python files to 4 by default
+" anyway. If the user changes shiftwidth from 4, not our fault; at least it will
+" still indent reasonably.
+let s:sw = exists("*shiftwidth") ? "shiftwidth()" : "&sw"
+
+let s:has_paren_patch = has("nvim-0.8.0") || has("patch-9.0.259")
+if s:has_paren_patch
+    let g:python_indent = get(g:, "python_indent", {})
+    let g:python_indent.open_paren = s:sw
+    let g:python_indent.nested_paren = s:sw
+    " +1 is for with statements.
+    let g:python_indent.continue = s:sw .. " + 1"
+    let g:python_indent.closed_paren_align_last_line = v:false
+else
+    let g:pyindent_open_paren = s:sw
+    let g:pyindent_nested_paren = s:sw
+    " +1 is for with statements.
+    let g:pyindent_continue = s:sw .. " + 1"
+endif
+
+if filereadable($VIMRUNTIME .. "/indent/python.vim")
+    source $VIMRUNTIME/indent/python.vim
+endif
+
+if !exists("*GetPythonIndent")
+    finish
+endif
+
+setlocal indentexpr=BlackIndent()
+
+if exists("*BlackIndent")
+    finish
+endif
+
+function BlackIndent()
+    let original_indent = GetPythonIndent(v:lnum)
+    let syntax_name = synID(v:lnum, match(getline(v:lnum), '\S') + 1, 1)
+        \ ->synIDtrans()
+        \ ->synIDattr("name")
+    if syntax_name !=# "String"
+        if !s:has_paren_patch && getline(v:lnum) =~# '^\s*\%(]\|}\|)\)'
+            " Closing parens should be dedented from preceding line once.
+            return original_indent - eval(s:sw)
+        elseif getline(v:lnum) =~# '^\s*:' && getline(v:lnum - 1) =~# '\\$'
+            " Lone colons (in the case of with statements) should be aligned
+            " with the "with".
+            return original_indent - (eval(s:sw) + 1)
+        endif
+    endif
+    return original_indent
+endfunction

--- a/indent/python.vim
+++ b/indent/python.vim
@@ -45,9 +45,9 @@ endif
 
 function BlackIndent()
     let original_indent = GetPythonIndent(v:lnum)
-    let syntax_name = synID(v:lnum, match(getline(v:lnum), '\S') + 1, 1)
-        \ ->synIDtrans()
-        \ ->synIDattr("name")
+    let syntax_name = synIDattr(
+        \ synIDtrans(synID(v:lnum, match(getline(v:lnum), '\S') + 1, 1)),
+        \ "name")
     if syntax_name !=# "String"
         if !s:has_paren_patch && getline(v:lnum) =~# '^\s*\%(]\|}\|)\)'
             " Closing parens should be dedented from preceding line once.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Fixes #3151

Before a patch that was made a few months ago in Vim ([9.0.259](https://github.com/vim/vim/commit/fd999452adaf529a30d78844b5fbee355943da29#diff-082e8db8a25bfef894eb32a5af1a1ad965b90c4a164fc33276e69f3522401cb8)), and less than a month ago in Neovim ([0.8.0](https://github.com/neovim/neovim/commit/d3cd79709b6491a5806c67ea52c19f244164954e#diff-082e8db8a25bfef894eb32a5af1a1ad965b90c4a164fc33276e69f3522401cb8)), the built in Python indent script poorly indented multiple lines within parenthesis by default and didn't even have an option to make closing parenthesis that start a line line up with the start of the statement, instead always being the same indent as the line before it. It is also still inconsistent with how `with` statements are proposed to be formatted in the future.

This adds to the Vim plugin its own indent script that can be run when the `g:black_indent` flag is enabled. It uses Vim's own Python indent except for cases where it is inconsistent, and sets the configs itself to be as consistent with Black as possible.

The flag is disabled by default since I think it's reasonable to assume that many Vim users probably already have a plugin to do this. I know I did.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
