### PR TITLE
comments.py: Fix typo "iff" in docstring

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -321,8 +321,8 @@ def children_contains_fmt_on(container: LN, *, preview: bool) -> bool:
 def contains_pragma_comment(comment_list: List[Leaf]) -> bool:
     """
     Returns:
-        True iff one of the comments in @comment_list is a pragma used by one
-        of the more common static analysis tools for python (e.g. mypy, flake8,
+        True if one of the comments in @comment_list is a pragma used by one of
+        the more common static analysis tools for python (e.g. mypy, flake8,
         pylint).
     """
     for comment in comment_list:


### PR DESCRIPTION
### Description

Fixes a minor typo "iff" -> "if" in the comments docstring

### Checklist - did you ...

- [ ] Add an entry in `CHANGES.md` if necessary? (not necessary)
- [ ] Add / update tests if necessary? (not necessary)
- [ ] Add new / update outdated documentation? (not necessary)
