### PR TITLE
Exclude pytest-xdist 3.0.2

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage >= 5.3
 pre-commit
 pytest >= 6.1.1
-pytest-xdist >= 2.2.1
+pytest-xdist >= 2.2.1, < 3.0.2
 pytest-cov >= 2.11.1
 tox


### PR DESCRIPTION
We're getting warnings like https://github.com/psf/black/actions/runs/3325521041/jobs/5498291478 and I'm not sure how to fix them. I'll open an issue for a long-term solution, but for now avoid 3.0.2 to unbreak CI.
