### PR TITLE
Format type hints after comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Stop type hints after comments from wrapping unnecessarily. (#3362)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/docs/contributing/reference/reference_functions.rst
+++ b/docs/contributing/reference/reference_functions.rst
@@ -83,6 +83,8 @@ Split functions
 
 .. autofunction:: black.linegen.delimiter_split
 
+.. autofunction:: black.linegen.comma_split
+
 .. autofunction:: black.linegen.left_hand_split
 
 .. autofunction:: black.linegen.right_hand_split

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -538,7 +538,12 @@ def transform_line(
                 ]
         else:
             if line.inside_brackets:
-                transformers = [delimiter_split, standalone_comment_split, rhs]
+                transformers = [
+                    comma_split,
+                    delimiter_split,
+                    standalone_comment_split,
+                    rhs,
+                ]
             else:
                 transformers = [rhs]
     # It's always safe to attempt hugging of power operations and pretty much every line
@@ -784,6 +789,79 @@ def dont_increase_indentation(split_func: Transformer) -> Transformer:
             yield split_line
 
     return split_wrapper
+
+
+@dont_increase_indentation
+def comma_split(line: Line, features: Collection[Feature] = ()) -> Iterator[Line]:
+    """Split on commas
+
+    It works the same as delimiter_split(), but it only splits on commas.
+    """
+    try:
+        last_leaf = line.leaves[-1]
+    except IndexError:
+        raise CannotSplit("Line empty") from None
+
+    bt = line.bracket_tracker
+    try:
+        max_delimiter_priority = bt.max_delimiter_priority(
+            exclude={id(last_leaf)}
+        )
+        trailing_comma_safe = max_delimiter_priority == COMMA_PRIORITY
+    except ValueError:
+        trailing_comma_safe = False
+
+    current_line = Line(
+        mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+    )
+    lowest_depth = sys.maxsize
+
+    def append_to_line(leaf: Leaf) -> Iterator[Line]:
+        """Append `leaf` to current line or to new line if appending impossible."""
+        nonlocal current_line
+        try:
+            current_line.append_safe(leaf, preformatted=True)
+        except ValueError:
+            yield current_line
+
+            current_line = Line(
+                mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+            )
+            current_line.append(leaf)
+
+    for leaf in line.leaves:
+        yield from append_to_line(leaf)
+
+        for comment_after in line.comments_after(leaf):
+            yield from append_to_line(comment_after)
+
+        lowest_depth = min(lowest_depth, leaf.bracket_depth)
+        if leaf.bracket_depth == lowest_depth:
+            if is_vararg(leaf, within={syms.typedargslist}):
+                trailing_comma_safe = (
+                    trailing_comma_safe and Feature.TRAILING_COMMA_IN_DEF in features
+                )
+            elif is_vararg(leaf, within={syms.arglist, syms.argument}):
+                trailing_comma_safe = (
+                    trailing_comma_safe and Feature.TRAILING_COMMA_IN_CALL in features
+                )
+
+        leaf_priority = bt.delimiters.get(id(leaf))
+        if leaf_priority == COMMA_PRIORITY:
+            yield current_line
+
+            current_line = Line(
+                mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+            )
+    if current_line:
+        if (
+                trailing_comma_safe
+                and current_line.leaves[-1].type != token.COMMA
+                and current_line.leaves[-1].type != STANDALONE_COMMENT
+        ):
+            new_comma = Leaf(token.COMMA, ",")
+            current_line.append(new_comma)
+        yield current_line
 
 
 @dont_increase_indentation

--- a/tests/data/simple_cases/type_hint_after_comment.py
+++ b/tests/data/simple_cases/type_hint_after_comment.py
@@ -1,0 +1,5 @@
+def get_requires_for_build_sdist(
+    # pylint: disable-next=unused-argument
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> list[str]:
+    return ["pathspec", "pyproject_metadata"]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This fixes #3350.

The problem is that when Black encounters standalone comments on one line inside brackets, it splits the line using delimiter_split. This will split on the comment, but it will also split the line on the highest priority delimiter, which isn't always necessary.

I've added a comma_split function, which is the same as delimiter_split, but `delimiter_priority = COMMA_PRIORITY`. Black will now try comment_split before it tries delimiter_split. This means it will first split on standalone comments and commas, and only split on other delimiters if the lines are still too long after that.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick theTm so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
