### PR TITLE
Clarify that black runs with --safe by default

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -457,9 +457,9 @@ the latter are treated as true raw strings with no special semantics.
 
 ### AST before and after formatting
 
-When run with `--safe` (the default), _Black_ checks that the code before and after is semantically
-equivalent. This check is done by comparing the AST of the source with the AST of the
-target. There are three limited cases in which the AST does differ:
+When run with `--safe` (the default), _Black_ checks that the code before and after is
+semantically equivalent. This check is done by comparing the AST of the source with the
+AST of the target. There are three limited cases in which the AST does differ:
 
 1. _Black_ cleans up leading and trailing whitespace of docstrings, re-indenting them if
    needed. It's been one of the most popular user-reported features for the formatter to

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -457,7 +457,7 @@ the latter are treated as true raw strings with no special semantics.
 
 ### AST before and after formatting
 
-When run with `--safe`, _Black_ checks that the code before and after is semantically
+When run with `--safe` (the default), _Black_ checks that the code before and after is semantically
 equivalent. This check is done by comparing the AST of the source with the AST of the
 target. There are three limited cases in which the AST does differ:
 


### PR DESCRIPTION
fixes #3375

### Description

The docs had ambiguity about the `--safe` flag as pointed out in #3375. This PR improves the clarity of the docs.

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?

I don't think this needs to be noted in `CHANGES.md`. Of course, I can if it is desired.