### PR TITLE
Wordsmith current_style.md

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -464,8 +464,8 @@ AST of the target. There are three limited cases in which the AST does differ:
 1. _Black_ cleans up leading and trailing whitespace of docstrings, re-indenting them if
    needed. It's been one of the most popular user-reported features for the formatter to
    fix whitespace issues with docstrings. While the result is technically an AST
-   difference, due to the various possibilities of forming docstrings, all realtime use
-   of docstrings that we're aware of sanitizes indentation and leading/trailing
+   difference, due to the various possibilities of forming docstrings, all real-world
+   uses of docstrings that we're aware of sanitize indentation and leading/trailing
    whitespace anyway.
 
 1. _Black_ manages optional parentheses for some statements. In the case of the `del`


### PR DESCRIPTION
### Description

Minor tweak to the language in the description of the current style.

In a nutshell, I think the original author meant to say "real-world" rather than "realtime."

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary? -> not necessary
- [x] Add / update tests if necessary? -> not necessary
- [x] Add new / update outdated documentation?

My understanding is that this PR should get the magical label to silence the CHANGELOG entry check.