### PR TITLE
Fixing missing trailing commas in dicts when standalone comment is present -  3072

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -852,7 +852,8 @@ def dont_increase_indentation(split_func: Transformer) -> Transformer:
 
 
 @dont_increase_indentation
-def delimiter_split(line: Line, features: Collection[Feature] = ()) -> Iterator[Line]:  # noqa
+def delimiter_split(line: Line,  # noqa: C901
+                    features: Collection[Feature] = ()) -> Iterator[Line]:
     """Split according to delimiters of the highest priority.
 
     If the appropriate Features are given, the split will add trailing commas

--- a/tests/data/simple_cases/function_trailing_comma.py
+++ b/tests/data/simple_cases/function_trailing_comma.py
@@ -13,6 +13,12 @@ def f(a:int=1,):
         "a": 1,
         "b": 2,
     }["a"]
+    test_dict = {
+        "a": call("a", "b"),
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxx": ...,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxx": ...,"yyyyyyy": ...
+        # "comment": ...
+    }
     if a == {"a": 1,"b": 2,"c": 3,"d": 4,"e": 5,"f": 6,"g": 7,"h": 8,}["a"]:
         pass
 
@@ -100,6 +106,13 @@ def f(
         "a": 1,
         "b": 2,
     }["a"]
+    test_dict = {
+        "a": call("a", "b"),
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxx": ...,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxx": ...,
+        "yyyyyyy": ...,
+        # "comment": ...
+    }
     if (
         a
         == {


### PR DESCRIPTION
Fixes #3072 

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
