### PR TITLE
Add lean flag to supress tempting cake emoji

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -384,6 +384,14 @@ def validate_regex(
     ),
 )
 @click.option(
+    "-l",
+    "--lean",
+    is_flag=True,
+    help=(
+        "Do not use the cake emoji on successful run"
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -441,6 +449,7 @@ def main(  # noqa: C901
     experimental_string_processing: bool,
     preview: bool,
     quiet: bool,
+    lean: bool,
     verbose: bool,
     required_version: Optional[str],
     include: Pattern[str],
@@ -602,10 +611,15 @@ def main(  # noqa: C901
                 workers=workers,
             )
 
+    if lean:
+        done_message = "✨ All done! ✨"
+    else:
+        done_message = "All done! ✨ 🍰 ✨"
+
     if verbose or not quiet:
         if code is None and (verbose or report.change_count or report.failure_count):
             out()
-        out(error_msg if report.return_code else "All done! ✨ 🍰 ✨")
+        out(error_msg if report.return_code else done_message)
         if code is None:
             click.echo(str(report), err=True)
     ctx.exit(report.return_code)


### PR DESCRIPTION
### Description

I wanted to start taking good care of quality of code in my project. In order to achieve this, obviously I had to implement black. When black corrected all my formatting mistakes and then I run it again (just in case) I saw following message (**TRIGGER WARNING**):  

`All done! ✨ 🍰 ✨`

And I was schocked. I did not even realise how hungry I was, and the cake looked to delicious. I should add that I'm trying to loose weight. This delightful piece of confectionery art woke my deepest and darkest instincts. I relapsed and went to the corner store to buy chocolate.  

I do not want anyone else to suffer as I did. So I added `--lean` flag which you can use to remove the cake from output.

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?