### PR TITLE
Fix syntax error in match test

### DIFF
--- a/tests/data/py_310/pattern_matching_extras.py
+++ b/tests/data/py_310/pattern_matching_extras.py
@@ -114,6 +114,6 @@ match bar1:
 
 match bar1:
     case Foo(
-        normal=x, perhaps=[list, {an: d, dict: 1.0}] as y, otherwise=something, q=t as u
+        normal=x, perhaps=[list, {"x": d, "y": 1.0}] as y, otherwise=something, q=t as u
     ):
         pass


### PR DESCRIPTION
Found with a variation on #3423 that runs tests in pyi mode.
