### PR TITLE
Do not put the closing quotes in a docstring on a separate line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 <!-- Changes that affect Black's preview style -->
 
 - Fix a crash in preview style with assert + parenthesized string (#3415)
+- Do not put the closing quotes in a docstring on a separate line, even if the line is
+  too long (#3430)
 
 ### Configuration
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -389,19 +389,18 @@ class LineGenerator(Visitor[Line]):
                 # We need to find the length of the last line of the docstring
                 # to find if we can add the closing quotes to the line without
                 # exceeding the maximum line length.
-                # If docstring is one line, then we need to add the length
-                # of the indent, prefix, and starting quotes. Ending quotes are
-                # handled later.
+                # If docstring is one line, we don't put the closing quotes on a
+                # separate line because it looks ugly (#3320).
                 lines = docstring.splitlines()
                 last_line_length = len(lines[-1]) if docstring else 0
-
-                if len(lines) == 1:
-                    last_line_length += len(indent) + len(prefix) + quote_len
 
                 # If adding closing quotes would cause the last line to exceed
                 # the maximum line length then put a line break before the
                 # closing quotes
-                if last_line_length + quote_len > self.mode.line_length:
+                if (
+                    len(lines) > 1
+                    and last_line_length + quote_len > self.mode.line_length
+                ):
                     leaf.value = prefix + quote + docstring + "\n" + indent + quote
                 else:
                     leaf.value = prefix + quote + docstring + quote

--- a/tests/data/preview/docstring_preview.py
+++ b/tests/data/preview/docstring_preview.py
@@ -54,13 +54,11 @@ def single_quote_docstring_over_line_limit2():
 
 
 def docstring_almost_at_line_limit():
-    """long docstring.................................................................
-    """
+    """long docstring................................................................."""
 
 
 def docstring_almost_at_line_limit_with_prefix():
-    f"""long docstring................................................................
-    """
+    f"""long docstring................................................................"""
 
 
 def mulitline_docstring_almost_at_line_limit():


### PR DESCRIPTION
Fixes #3320. Followup from #3044.

