### PR TITLE
Fix a crash when a colon line is marked between `# fmt: off` and `# fmt: on`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix a crash when a colon line is marked between `# fmt: off` and `# fmt: on` (#3439)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -232,7 +232,7 @@ def generate_ignored_nodes(
 
         # fix for fmt: on in children
         if children_contains_fmt_on(container, preview=preview):
-            for child in container.children:
+            for index, child in enumerate(container.children):
                 if isinstance(child, Leaf) and is_fmt_on(child, preview=preview):
                     if child.type in CLOSING_BRACKETS:
                         # This means `# fmt: on` is placed at a different bracket level
@@ -240,6 +240,14 @@ def generate_ignored_nodes(
                         # we include this closing bracket in the ignored nodes.
                         # The alternative is to fail the formatting.
                         yield child
+                    return
+                if (
+                    child.type == token.INDENT
+                    and index < len(container.children) - 1
+                    and children_contains_fmt_on(
+                        container.children[index + 1], preview=preview
+                    )
+                ):
                     return
                 if children_contains_fmt_on(child, preview=preview):
                     return

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -248,6 +248,8 @@ def generate_ignored_nodes(
                         container.children[index + 1], preview=preview
                     )
                 ):
+                    # This means `# fmt: on` is placed right after an indentation
+                    # level, and we shouldn't swallow the previous INDENT token.
                     return
                 if children_contains_fmt_on(child, preview=preview):
                     return

--- a/tests/data/simple_cases/fmtonoff5.py
+++ b/tests/data/simple_cases/fmtonoff5.py
@@ -64,7 +64,7 @@ class A:
         print ( "This will be formatted" )
 
 
-# Regression test for https://github.com/psf/black/issues/2985
+# Regression test for https://github.com/psf/black/issues/2985.
 class Named(t.Protocol):
     # fmt: off
     @property
@@ -73,6 +73,15 @@ class Named(t.Protocol):
 class Factory(t.Protocol):
     def  this_will_be_formatted ( self, **kwargs ) -> Named: ...
     # fmt: on
+
+
+# Regression test for https://github.com/psf/black/issues/3436.
+if x:
+    return x
+# fmt: off
+elif   unformatted:
+# fmt: on
+    will_be_formatted  ()
 
 
 # output
@@ -144,7 +153,7 @@ class A:
         print("This will be formatted")
 
 
-# Regression test for https://github.com/psf/black/issues/2985
+# Regression test for https://github.com/psf/black/issues/2985.
 class Named(t.Protocol):
     # fmt: off
     @property
@@ -156,3 +165,12 @@ class Factory(t.Protocol):
         ...
 
     # fmt: on
+
+
+# Regression test for https://github.com/psf/black/issues/3436.
+if x:
+    return x
+# fmt: off
+elif   unformatted:
+    # fmt: on
+    will_be_formatted()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Fixes #3436.

Note that the `# fmt: on` line is always normalized to the next statement so its indentation is moved in this case. This isn't ideal, but at least it shouldn't crash.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
