### PR TITLE
Do not move docker `latest_release` tag for Pre-Releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,9 @@ jobs:
           tags: pyfound/black:latest,pyfound/black:${{ env.GIT_TAG }}
 
       - name: Build and push latest_release tag
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease }}
+        if:
+          ${{ github.event_name == 'release' && github.event.action == 'published' &&
+          !github.event.release.prerelease }}
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
           tags: pyfound/black:latest,pyfound/black:${{ env.GIT_TAG }}
 
       - name: Build and push latest_release tag
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease }}
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
- When we do a pre-release lets not move the latest_release tag
  - This tag should only move on official real releases

Fixes #3453

*Would love any ideas on how to test this ...*