### PR TITLE
Exclude string type annotations from ESP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 - Long values in dict literals are now wrapped in parentheses; correspondingly
   unnecessary parentheses around short values in dict literals are now removed; long
   string lambda values are now wrapped in parentheses (#3440)
+- Exclude string type annotations from improved string processing; fix crash when return
+  the type annotation is stringified and spans across multiple lines (#3462)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,8 @@
 - Long values in dict literals are now wrapped in parentheses; correspondingly
   unnecessary parentheses around short values in dict literals are now removed; long
   string lambda values are now wrapped in parentheses (#3440)
-- Exclude string type annotations from improved string processing; fix crash when return
-  the type annotation is stringified and spans across multiple lines (#3462)
+- Exclude string type annotations from improved string processing; fix crash when the
+  return type annotation is stringified and spans across multiple lines (#3462)
 
 ### Configuration
 

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -77,7 +77,7 @@ class BracketTracker:
         that started on this line.
 
         If a leaf is itself a closing bracket and there is a matching opening
-        bracket earlier, it receives an `opening_bracket` field that it forms a
+        bracket earlier, it receives an `opening_bracket` field with which it forms a
         pair. This is a one-directional link to avoid reference cycles. Closing
         bracket without opening happens on lines continued from previous
         breaks, e.g. `) -> "ReturnType":` as part of a funcdef where we place

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -57,6 +57,10 @@ MATH_PRIORITIES: Final = {
 DOT_PRIORITY: Final = 1
 
 
+class BracketMatchError(Exception):
+    """Raised when an opening bracket is unable to be matched to a closing bracket."""
+
+
 @dataclass
 class BracketTracker:
     """Keeps track of brackets on a line."""
@@ -101,7 +105,13 @@ class BracketTracker:
         self.maybe_decrement_after_lambda_arguments(leaf)
         if leaf.type in CLOSING_BRACKETS:
             self.depth -= 1
-            opening_bracket = self.bracket_match.pop((self.depth, leaf.type))
+            try:
+                opening_bracket = self.bracket_match.pop((self.depth, leaf.type))
+            except KeyError as e:
+                raise BracketMatchError(
+                    "Unable to match a closing bracket to the following opening"
+                    f" bracket: {leaf}"
+                ) from e
             leaf.opening_bracket = opening_bracket
             if not leaf.value:
                 self.invisible.append(leaf)

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -848,3 +848,18 @@ def is_string_token(nl: NL) -> TypeGuard[Leaf]:
 
 def is_number_token(nl: NL) -> TypeGuard[Leaf]:
     return nl.type == token.NUMBER
+
+
+def is_part_of_annotation(leaf: Leaf) -> bool:
+    """Returns whether this leaf is part of type annotations."""
+    ancestor = leaf.parent
+    while ancestor is not None:
+        if (
+            ancestor.prev_sibling
+            and ancestor.prev_sibling.type == token.RARROW
+        ):
+            return True
+        if ancestor.parent and ancestor.parent.type == syms.tname:
+            return True
+        ancestor = ancestor.parent
+    return False

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -854,10 +854,7 @@ def is_part_of_annotation(leaf: Leaf) -> bool:
     """Returns whether this leaf is part of type annotations."""
     ancestor = leaf.parent
     while ancestor is not None:
-        if (
-            ancestor.prev_sibling
-            and ancestor.prev_sibling.type == token.RARROW
-        ):
+        if ancestor.prev_sibling and ancestor.prev_sibling.type == token.RARROW:
             return True
         if ancestor.parent and ancestor.parent.type == syms.tname:
             return True

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -628,7 +628,7 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
                   process stringified type annotations since pyright doesn't support
                   them spanning multiple string values. (NOTE: mypy, pytype, pyre do
                   support them, so we can change if pyright also gains support in the
-                  future.)
+                  future. See https://github.com/microsoft/pyright/issues/4359.)
         """
         # We first check for "inner" stand-alone comments (i.e. stand-alone
         # comments that have a string leaf before them AND after them).

--- a/tests/data/preview/long_strings__type_annotations.py
+++ b/tests/data/preview/long_strings__type_annotations.py
@@ -1,0 +1,59 @@
+def func(
+    arg1,
+    arg2,
+) -> Set["this_is_a_very_long_module_name.AndAVeryLongClasName"
+         ".WithAVeryVeryVeryVeryVeryLongSubClassName"]:
+  pass
+
+
+def func(
+    argument: (
+        "VeryLongClassNameWithAwkwardGenericSubtype[int] |"
+        "VeryLongClassNameWithAwkwardGenericSubtype[str]"
+    ),
+) -> (
+    "VeryLongClassNameWithAwkwardGenericSubtype[int] |"
+    "VeryLongClassNameWithAwkwardGenericSubtype[str]"
+):
+  pass
+
+
+def func(
+    argument: (
+        "int |"
+        "str"
+    ),
+) -> Set["int |"
+         " str"]:
+  pass
+
+
+# output
+
+
+def func(
+    arg1,
+    arg2,
+) -> Set[
+    "this_is_a_very_long_module_name.AndAVeryLongClasName"
+    ".WithAVeryVeryVeryVeryVeryLongSubClassName"
+]:
+    pass
+
+
+def func(
+    argument: (
+        "VeryLongClassNameWithAwkwardGenericSubtype[int] |"
+        "VeryLongClassNameWithAwkwardGenericSubtype[str]"
+    ),
+) -> (
+    "VeryLongClassNameWithAwkwardGenericSubtype[int] |"
+    "VeryLongClassNameWithAwkwardGenericSubtype[str]"
+):
+    pass
+
+
+def func(
+    argument: ("int |" "str"),
+) -> Set["int |" " str"]:
+    pass


### PR DESCRIPTION

### Description

This PR excludes string type annotations from ESP, and also fixes crash on mismatched brackets from ESP.

1. Unfortunately pyright doesn't support stringified annotations that span multiple lines, e.g.:

```python
def something(
    arg,
) -> (
    "VeryLongClassNameWithAwkwardGenericSubtype[int] |"
    "VeryLongClassNameWithAwkwardGenericSubtype[str]"
):
    ...
```

Even though other type checkers (mypy, pytype, pyre) do support them. To be safe, we can choose to exclude them from ESP for now. Note we _could_ technically choose to try merging them into a single string when the result fits in the line-length, but this would be more complicated than simply excluding them from ESP.

2. The crash is because of unmatched brackets. In ESP, it can process lines continued from earlier line breaks, e.g.:

```python
def something(
    arg,
) -> "VeryLongClassNameWithAwkwardGenericSubtype[int] | VeryLongClassNameWithAwkwardGenericSubtype[str]":
    ...
```

The line can be `) -> "VeryLongClassNameWithAwkwardGenericSubtype[int] |VeryLongClassNameWithAwkwardGenericSubtype[str]":` while processing. This PR makes `BracketTracker.mark` accept unmatched closing brackets. 

Fixes #3435. Fixes #3457.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
