### PR TITLE
Add latest_prerelease Docker Hub tag for following the latest alpha release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,5 +54,16 @@ jobs:
           push: true
           tags: pyfound/black:latest_release
 
+      - name: Build and push latest_prerelease tag
+        if:
+          ${{ github.event_name == 'release' && github.event.action == 'published' &&
+          github.event.release.prerelease }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: pyfound/black:latest_prerelease
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,8 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Move 3.11 CI to normal flow now all dependencies support 3.11 (#3446)
+- Docker: Add new `latest_prerelease` tag automation to follow latest black alpha release
+  on docker images
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,7 +66,7 @@
 
 - Move 3.11 CI to normal flow now all dependencies support 3.11 (#3446)
 - Docker: Add new `latest_prerelease` tag automation to follow latest black alpha release
-  on docker images
+  on docker images (#3465)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,8 +65,8 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Move 3.11 CI to normal flow now all dependencies support 3.11 (#3446)
-- Docker: Add new `latest_prerelease` tag automation to follow latest black alpha release
-  on docker images (#3465)
+- Docker: Add new `latest_prerelease` tag automation to follow latest black alpha
+  release on docker images (#3465)
 
 ### Documentation
 

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -13,7 +13,8 @@ _Black_ images with the following tags are available:
 - `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is
   released.\
   ℹ Recommended for users who want to preview or test alpha versions of _Black_. Note that
-  the most recent release may be newer than any prerelease.
+  the most recent release may be newer than any prerelease, because no prereleases
+  are created before most releases.
 - `latest` - tag used for the newest image of _Black_.\
   ℹ Recommended for users who always want to use the latest version of _Black_, even before
   it is released.

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -13,8 +13,8 @@ _Black_ images with the following tags are available:
 - `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is
   released.\
   ℹ Recommended for users who want to preview or test alpha versions of _Black_. Note that
-  the most recent release may be newer than any prerelease, because no prereleases
-  are created before most releases.
+  the most recent release may be newer than any prerelease, because no prereleases are created
+  before most releases.
 - `latest` - tag used for the newest image of _Black_.\
   ℹ Recommended for users who always want to use the latest version of _Black_, even before
   it is released.

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -10,7 +10,8 @@ _Black_ images with the following tags are available:
 - `latest_release` - tag created when a new version of _Black_ is released.\
   ℹ Recommended for users who want to use released versions of _Black_. It maps to [the latest release](https://github.com/psf/black/releases/latest)
   of _Black_.
-- `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is released.\
+- `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is
+  released.\
   ℹ Recommended for users who want to preview or test alpha versions of _Black_.
 - `latest` - tag used for the newest image of _Black_.\
   ℹ Recommended for users who always want to use the latest version of _Black_, even before

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -12,7 +12,8 @@ _Black_ images with the following tags are available:
   of _Black_.
 - `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is
   released.\
-  ℹ Recommended for users who want to preview or test alpha versions of _Black_.
+  ℹ Recommended for users who want to preview or test alpha versions of _Black_. Note that
+  the most recent release may be newer than any prerelease.
 - `latest` - tag used for the newest image of _Black_.\
   ℹ Recommended for users who always want to use the latest version of _Black_, even before
   it is released.

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -10,6 +10,8 @@ _Black_ images with the following tags are available:
 - `latest_release` - tag created when a new version of _Black_ is released.\
   ℹ Recommended for users who want to use released versions of _Black_. It maps to [the latest release](https://github.com/psf/black/releases/latest)
   of _Black_.
+- `latest_prerelease` - tag created when a new alpha (prerelease) version of _Black_ is released.\
+  ℹ Recommended for users who want to preview or test alpha versions of _Black_.
 - `latest` - tag used for the newest image of _Black_.\
   ℹ Recommended for users who always want to use the latest version of _Black_, even before
   it is released.


### PR DESCRIPTION
### Description

Over here, https://github.com/psf/black/issues/3453#issuecomment-1357988758 while fixing an issue with the Docker image publishing workflow, it seemed there's a legitimate desire for a docker tag which follows alpha (prerelease) releases of Black. This PR creates a new tag to be pushed to Docker Hub going forward (`latest_prerelease` which will be updated with every alpha version release.

**I do have another change to request along with this...**

If someone comes across the official Black image on Docker Hub, the description is a shortened version of the README with a link to the full docs. There isn't an obvious pointer to the documentation of which Docker image tags are in use and for what purpose. I don't think duplicating the information there is necessarily the right way to go (unless it's sourced in this repository), but having another explicit link to that specific docs page would grease the wheels just a bit for folks discovering it on Docker Hub.

I don't see where in the source code that Description on DockerHub is maintained, and so I think it's probably been manually set by a maintainer. Linking to Black's Full Documentation still makes sense to me, but I think an additional line just above that would be helpful, something like the following:

> Official Docker Image Documentation: https://black.readthedocs.io/en/latest/usage_and_configuration/black_docker_image.html

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary? (not necessary)
- [X] Add new / update outdated documentation?