### PR TITLE
Vim plugin docs improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,8 @@
 <!-- Major changes to documentation and policies. Small docs changes
      don't need a changelog entry. -->
 
+- Expand `vim-plug` installation instructions to offer more explicit options (#3468)
+
 ## 22.12.0
 
 ### Preview style

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -111,7 +111,10 @@ Configuration:
 - `g:black_fast` (defaults to `0`)
 - `g:black_linelength` (defaults to `88`)
 - `g:black_skip_string_normalization` (defaults to `0`)
+- `g:black_skip_magic_trailing_comma` (defaults to `0`)
 - `g:black_virtualenv` (defaults to `~/.vim/black` or `~/.local/share/nvim/black`)
+- `g:black_use_virtualenv` (defaults to `1`)
+- `g:black_target_version` (defaults to `""`)
 - `g:black_quiet` (defaults to `0`)
 - `g:black_preview` (defaults to `0`)
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -164,19 +164,6 @@ curl https://raw.githubusercontent.com/psf/black/stable/autoload/black.vim -o ~/
 Let me know if this requires any changes to work with Vim 8's builtin `packadd`, or
 Pathogen, and so on.
 
-##### With ALE
-
-1. Install [`ale`](https://github.com/dense-analysis/ale)
-
-1. Install `black`
-
-1. Add this to your vimrc:
-
-   ```vim
-   let g:ale_fixers = {}
-   let g:ale_fixers.python = ['black']
-   ```
-
 #### Usage
 
 This plugin **requires Vim 7.0+ built with Python 3.7+ support**. It needs Python 3.7 to
@@ -271,6 +258,19 @@ If you later want to update _Black_, you should do it like this:
 ```console
 $ pip install -U black --no-binary typed-ast
 ```
+
+### With ALE
+
+1. Install [`ale`](https://github.com/dense-analysis/ale)
+
+1. Install `black`
+
+1. Add this to your vimrc:
+
+   ```vim
+   let g:ale_fixers = {}
+   let g:ale_fixers.python = ['black']
+   ```
 
 ## Gedit
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -120,6 +120,10 @@ Configuration:
 
 #### Installation
 
+This plugin **requires Vim 7.0+ built with Python 3.7+ support**. It needs Python 3.7 to
+be able to run _Black_ inside the Vim process which is much faster than calling an
+external command.
+
 ##### `vim-plug`
 
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
@@ -137,14 +141,14 @@ which matches the given pattern.
 
 The following matches all stable versions (see the
 [Release Process](../contributing/release_process.md) section for documentation of
-version scheme used by Black),
+version scheme used by Black):
 
 ```
 Plug 'psf/black', { 'tag': '*.*.*' }
 ```
 
 and the following demonstrates pinning to a specific year's stable style (2022 in this
-case).
+case):
 
 ```
 Plug 'psf/black', { 'tag': '22.*.*' }
@@ -188,10 +192,6 @@ Let me know if this requires any changes to work with Vim 8's builtin `packadd`,
 Pathogen, and so on.
 
 #### Usage
-
-This plugin **requires Vim 7.0+ built with Python 3.7+ support**. It needs Python 3.7 to
-be able to run _Black_ inside the Vim process which is much faster than calling an
-external command.
 
 On first run, the plugin creates its own virtualenv using the right Python version and
 automatically installs _Black_. You can upgrade it later by calling `:BlackUpgrade` and

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -145,8 +145,9 @@ $ git checkout origin/stable -b stable
 
 ##### Arch Linux
 
-On Arch Linux, the plugin is shipped with the [`python-black`](https://archlinux.org/packages/community/any/python-black/)
-package, so you can start using it in Vim after install with no additional setup.
+On Arch Linux, the plugin is shipped with the
+[`python-black`](https://archlinux.org/packages/community/any/python-black/) package, so
+you can start using it in Vim after install with no additional setup.
 
 ##### Vim 8 Native Plugin Management
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -115,11 +115,17 @@ Configuration:
 - `g:black_quiet` (defaults to `0`)
 - `g:black_preview` (defaults to `0`)
 
+#### Installation
+
+##### `vim-plug`
+
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
 Plug 'psf/black', { 'branch': 'stable' }
 ```
+
+##### Vundle
 
 or with [Vundle](https://github.com/VundleVim/Vundle.vim):
 
@@ -134,6 +140,8 @@ $ cd ~/.vim/bundle/black
 $ git checkout origin/stable -b stable
 ```
 
+##### Vim 8 Native Plugin Management
+
 or you can copy the plugin files from
 [plugin/black.vim](https://github.com/psf/black/blob/stable/plugin/black.vim) and
 [autoload/black.vim](https://github.com/psf/black/blob/stable/autoload/black.vim).
@@ -147,6 +155,21 @@ curl https://raw.githubusercontent.com/psf/black/stable/autoload/black.vim -o ~/
 
 Let me know if this requires any changes to work with Vim 8's builtin `packadd`, or
 Pathogen, and so on.
+
+##### With ALE
+
+1. Install [`ale`](https://github.com/dense-analysis/ale)
+
+1. Install `black`
+
+1. Add this to your vimrc:
+
+   ```vim
+   let g:ale_fixers = {}
+   let g:ale_fixers.python = ['black']
+   ```
+
+#### Usage
 
 This plugin **requires Vim 7.0+ built with Python 3.7+ support**. It needs Python 3.7 to
 be able to run _Black_ inside the Vim process which is much faster than calling an
@@ -186,6 +209,8 @@ To run _Black_ on a key press (e.g. F9 below), add this:
 ```
 nnoremap <F9> :Black<CR>
 ```
+
+#### Troubleshooting
 
 **How to get Vim with Python 3.6?** On Ubuntu 17.10 Vim comes with Python 3.6 by
 default. On macOS with Homebrew run: `brew install vim`. When building Vim from source,
@@ -238,19 +263,6 @@ If you later want to update _Black_, you should do it like this:
 ```console
 $ pip install -U black --no-binary typed-ast
 ```
-
-### With ALE
-
-1. Install [`ale`](https://github.com/dense-analysis/ale)
-
-1. Install `black`
-
-1. Add this to your vimrc:
-
-   ```vim
-   let g:ale_fixers = {}
-   let g:ale_fixers.python = ['black']
-   ```
 
 ## Gedit
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -143,6 +143,11 @@ $ cd ~/.vim/bundle/black
 $ git checkout origin/stable -b stable
 ```
 
+##### Arch Linux
+
+On Arch Linux, the plugin is shipped with the [`python-black`](https://archlinux.org/packages/community/any/python-black/)
+package, so you can start using it in Vim after install with no additional setup.
+
 ##### Vim 8 Native Plugin Management
 
 or you can copy the plugin files from

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -125,7 +125,7 @@ Configuration:
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'psf/black', { 'branch': 'stable' }
+Plug 'psf/black', { 'tag': '*.*.*' }
 ```
 
 ##### Vundle

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -136,7 +136,7 @@ Another option which is a bit more explicit and offers more control is to use
 which matches the given pattern.
 
 The following matches all stable versions (see the
-[Release Process](./contributing/release_process.md) section for documentation of
+[Release Process](../contributing/release_process.md) section for documentation of
 version scheme used by Black),
 
 ```

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -124,8 +124,30 @@ Configuration:
 
 To install with [vim-plug](https://github.com/junegunn/vim-plug):
 
+_Black_'s `stable` branch tracks official version updates, and can be used to simply
+follow the most recent stable version.
+
+```
+Plug 'psf/black', { 'branch': 'stable' }
+```
+
+Another option which is a bit more explicit and offers more control is to use
+`vim-plug`'s `tag` option with a shell wildcard. This will resolve to the latest tag
+which matches the given pattern.
+
+The following matches all stable versions (see the
+[Release Process](./contributing/release_process.md) section for documentation of
+version scheme used by Black),
+
 ```
 Plug 'psf/black', { 'tag': '*.*.*' }
+```
+
+and the following demonstrates pinning to a specific year's stable style (2022 in this
+case).
+
+```
+Plug 'psf/black', { 'tag': '22.*.*' }
 ```
 
 ##### Vundle


### PR DESCRIPTION
### Description

This is a few documentation changes for the Vim plugin. I included them in the same PR to avoid clutter and because they're all pretty minor and easily reviewed together. I also made a commit for each thematic change, so feel free to look at specific commits if you want to see the changes in isolation. I didn't think this was a substantial enough change to warrant a `CHANGES.md` entry, but am happy to add one if maintainers disagree.

There are 4 main changes in here:

#### Formatting and Organization

Commit: https://github.com/psf/black/pull/3468/commits/26c56f2a902dc59690a6526d9fd7e5d369f57b5b and https://github.com/psf/black/pull/3468/commits/197edbd58a55b8e9446a61bd8e1ff2d8b26b32bd

Currently there are no sub-headers under the Official Plugin section, which can make it a bit tough to read and especially to hyperlink to. Organized it into Installation, Usage, and Troubleshooting as felt appropriate.

#### Add missing configuration options

Commit: https://github.com/psf/black/pull/3468/commits/9929893e57154e4b4d4707feeba7376039286056

A few configuration options exist but weren't mentioned with their defaults at the top of the Vim plugin documentation section, so I added those.

#### Add plugin documentation for Arch Linux

Commit: https://github.com/psf/black/pull/3468/commits/bb0f44602edb0215159cb232ea4fede4f84d14ce

Refer to this issue on the Arch Linux `python-black` package: https://bugs.archlinux.org/task/73024

Since earlier this calendar year, the Black package distributed on Arch Linux ([`python-black`](https://archlinux.org/packages/community/any/python-black/)) also ships the Vim plugin, so I added a section to the Installation section mentioning that Arch Linux users need no further steps to use the plugin than installing Black.

#### Fix the vim-plug installation recommendation

Commit: https://github.com/psf/black/pull/3468/commits/1a73b724677ebf54894a238172b6074d950ea8cc

Refer to this discussion on the `vim-plug` repo: https://github.com/junegunn/vim-plug/pull/720#issuecomment-1105829356

Using the `stable` tag as a `branch` in `vim-plug` is a bit of an antipattern that doesn't work correctly, as it doesn't always re-resolve the SHA when the `stable` tag is moved. According to the maintainer, using the `tag` key with a shell wildcard is the better way to go. I selected `'*.*.*'` as the wildcard since it matches [Black's documented versioning scheme](https://black.readthedocs.io/en/latest/contributing/release_process.html\#cutting-a-release) and will not match on the current standard for Alpha versions (which only have one dot). You can see how this works in the image below; it matches on `22.12.0` (the latest stable release) even though the latest version overall at time of writing is `23.1a1`.

![image](https://user-images.githubusercontent.com/4631191/208765802-0671e82c-c230-4e1d-85d1-6efe0c0eca5b.png)

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary? (Seems a small enough change to not need an entry, do maintainers agree?)
- [X] Add / update tests if necessary? (just docs, not necessary)
- [X] Add new / update outdated documentation?