### PR TITLE
Fix an issue where extra empty lines are added.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
   regular and f-strings start with an empty span (#3463)
 - Fix a crash in preview advanced string processing where a standalone comment is placed
   before a dict's value (#3469)
+- Fix an issue where extra empty lines are added when a decorator has `# fmt: skip`
+  applied or there is a standalone comment between decorators (#3470)
 - Do not put the closing quotes in a docstring on a separate line, even if the line is
   too long (#3430)
 - Long values in dict literals are now wrapped in parentheses; correspondingly

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -520,7 +520,8 @@ class EmptyLineTracker:
                 and (self.semantic_leading_comment is None or before)
             ):
                 self.semantic_leading_comment = block
-        elif not current_line.is_decorator:
+        # `or before` means this decorator already has an empty line before
+        elif not current_line.is_decorator or before:
             self.semantic_leading_comment = None
 
         self.previous_line = current_line

--- a/tests/data/preview/comments9.py
+++ b/tests/data/preview/comments9.py
@@ -114,6 +114,30 @@ class MyClass:
         pass
 
 
+# Regression test for https://github.com/psf/black/issues/3454.
+def foo():
+    pass
+    # Trailing comment that belongs to this function
+
+
+@decorator1
+@decorator2  # fmt: skip
+def bar():
+    pass
+
+
+# Regression test for https://github.com/psf/black/issues/3454.
+def foo():
+    pass
+    # Trailing comment that belongs to this function
+
+
+@decorator1
+# A standalone comment
+def bar():
+    pass
+
+
 # output
 
 
@@ -252,3 +276,27 @@ class MyClass:
     # More comments.
     def first_method(self):
         pass
+
+
+# Regression test for https://github.com/psf/black/issues/3454.
+def foo():
+    pass
+    # Trailing comment that belongs to this function
+
+
+@decorator1
+@decorator2  # fmt: skip
+def bar():
+    pass
+
+
+# Regression test for https://github.com/psf/black/issues/3454.
+def foo():
+    pass
+    # Trailing comment that belongs to this function
+
+
+@decorator1
+# A standalone comment
+def bar():
+    pass

--- a/tests/data/preview/comments9.py
+++ b/tests/data/preview/comments9.py
@@ -129,8 +129,9 @@ def bar():
 # Regression test for https://github.com/psf/black/issues/3454.
 def foo():
     pass
-    # Trailing comment that belongs to this function
-
+    # Trailing comment that belongs to this function.
+    # NOTE this comment only has one empty line below, and the formatter
+    # should enforce two blank lines.
 
 @decorator1
 # A standalone comment
@@ -293,7 +294,9 @@ def bar():
 # Regression test for https://github.com/psf/black/issues/3454.
 def foo():
     pass
-    # Trailing comment that belongs to this function
+    # Trailing comment that belongs to this function.
+    # NOTE this comment only has one empty line below, and the formatter
+    # should enforce two blank lines.
 
 
 @decorator1


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Fixes #3454.

This is actually unrelated to `# fmt: skip`, as this also happens when a regular standalone comment is placed between decorators.

This is a regression caused by https://github.com/psf/black/pull/3302 (`Preview.empty_lines_before_class_or_def_with_leading_comments`)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
