### PR TITLE
Fail lint CI if the PR doesn't target main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.repository == 'psf/black'
         run: |
           if [ "$GITHUB_BASE_REF" != "main" ]; then
-              echo "::error::PR targeting '$GITHUB_BASE_REF', please refile targeting 'main'."
-              && exit 1
+              echo "::error::PR targeting '$GITHUB_BASE_REF', please refile targeting 'main'." && exit 1
           fi
 
       - name: Set up latest Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Assert PR target is main
+        if: github.event_name == 'pull_request' && github.repository == 'psf/black'
+        run: |
+          if [ "$GITHUB_BASE_REF" != "main" ]; then
+              echo "::error::PR targeting '$GITHUB_BASE_REF', please refile targeting 'main'."
+              && exit 1
+          fi
+
       - name: Set up latest Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
### Description

Let's skip the check if we're running on a fork just in case someone opens a PR against a branch on said fork as part of a PR review upstream.

Example run: https://github.com/ichard26/black/pull/60

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary? -> n/a
- [x] Add / update tests if necessary? -> n/a
- [x] Add new / update outdated documentation? -> n/a

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
