### PR TITLE
Remove misleading phrase in Usage and Configuration

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -40,7 +40,8 @@ so style options are deliberately limited and rarely added.
 
 </details>
 
-Note that all command-line options listed above can also be configured using a `pyproject.toml` file (more on that below).
+Note that all command-line options listed above can also be configured using a
+`pyproject.toml` file (more on that below).
 
 ### Code input alternatives
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -40,6 +40,8 @@ so style options are deliberately limited and rarely added.
 
 </details>
 
+Note that all command-line options listed above can also be configured using a `pyproject.toml` file (more on that below).
+
 ### Code input alternatives
 
 #### Standard Input
@@ -286,9 +288,6 @@ look for multiple files, and doesn't compose configuration from different levels
 file hierarchy.
 
 ## Next steps
-
-You've probably noted that not all of the options you can pass to _Black_ have been
-covered. Don't worry, the rest will be covered in a later section.
 
 A good next step would be configuring auto-discovery so `black .` is all you need
 instead of laborously listing every file or directory. You can get started by heading


### PR DESCRIPTION
The CLI options were already shown in the "Command line options" in the same page.

Close #3491