### PR TITLE
Reenable macOS mypyc wheel build

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -47,13 +47,12 @@ jobs:
           - os: macos-11
             name: macos-x86_64
             macos_arch: "x86_64"
-          # Only build x86_64 wheels on macos until #3312 is fixed
-          # - os: macos-11
-          #   name: macos-arm64
-          #   macos_arch: "arm64"
-          # - os: macos-11
-          #   name: macos-universal2
-          #   macos_arch: "universal2"
+          - os: macos-11
+            name: macos-arm64
+            macos_arch: "arm64"
+          - os: macos-11
+            name: macos-universal2
+            macos_arch: "universal2"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Hatchling implemented a workaround for the 'technically right tag but no one understands it, including pip' issue so this should work now.

https://github.com/ichard26/black-mypyc-wheels/actions/runs/3971519300