### PR TITLE
Use dashes for pycodestyle max line length config

### DIFF
--- a/docs/guides/using_black_with_other_tools.md
+++ b/docs/guides/using_black_with_other_tools.md
@@ -260,7 +260,7 @@ max-line-length = "88"
 #### Configuration
 
 ```
-max_line_length = 88
+max-line-length = 88
 ignore = E203
 ```
 


### PR DESCRIPTION
### Description
Same commit as in PR #3500 but made new PR targeting `main`.

The option is `max-line-length` with dashes, not underscores. The config option name is given in the output of `pycodestyle -h`, which can also be checked on https://pep8.readthedocs.io/en/stable/intro.html#example-usage-and-output:
```
Configuration:
    The project options are read from the [pycodestyle] section of the
    tox.ini file or the setup.cfg file located in any parent folder of the
    path(s) being processed.  Allowed options are: exclude, filename,
    select, ignore, max-line-length, max-doc-length, hang-closing, count,
    format, quiet, show-pep8, show-source, statistics, verbose
```

### Checklist - did you ...

Don't think any of this is necessary to a minor documentation change, but feel free to correct me

- [-] ~~Add an entry in `CHANGES.md` if necessary?~~
- [-] ~~Add / update tests if necessary?~~
- [-] ~~Add new / update outdated documentation?~~