### PR TITLE
Use GH action version when version argument not specified

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Update GitHub Action to use the version of Black equivalent to action's version if
+  version input is not specified (#3543)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes


### PR DESCRIPTION
### Description

Resolves #3382 

There are 2 things going on here:
- addition of `.git_archival.txt` set with `export-subst` git attribute so that black can be installed from a git archive, see: https://github.com/pypa/setuptools_scm#git-archives
- update to GH action changing it to use GH action version when the version argument is not specified; this means:
    - when the action's commit is tagged, install Black from PyPI using that tag's name as the pinned version
    - when the action's commit is not tagged, install Black from the action's local directory

A couple of tests:
- `Jackenmen/black@22.12.0` - 22.12.0 on my repo is not the real commit of 22.12.0 as then it wouldn't have this feature; however it does allow you to see that the code gets 2022 formatting:
    - https://github.com/Jackenmen/black/actions/runs/4076830464/jobs/7025089166
- `Jackenmen/black@e29e12c973d0e294a0a905b1fb4d8f4962bfa408` - the exact same commit that you get with 22.12.0, just confirming that it still correctly detects it as a tagged release in such a case:
    - https://github.com/Jackenmen/black/actions/runs/4076898146/jobs/7025240425
- `Jackenmen/black@9a168472de3144674dd7db3c6b514b7e5f5d5c20` - an untagged commit *after* the fake 22.12.0 tag, this causes the action to install Black from the local source; you can see that this causes it to use 2023 formatting:
    - https://github.com/Jackenmen/black/actions/runs/4076901054/jobs/7025246892
- `Jackenmen/black@stable` - the exact same commit that you get with 22.12.0, just confirming that it correctly fetches 22.12.0:
    - https://github.com/Jackenmen/black/actions/runs/4077049374/jobs/7025578668


### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
