### PR TITLE
Fix this import, it's blib2to3.pgen2.driver, not blib2to3.driver.

### DIFF
--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -32,7 +32,7 @@ from blib2to3.pgen2.grammar import Grammar
 from blib2to3.pytree import convert, NL, Context, RawNode, Leaf, Node
 
 if TYPE_CHECKING:
-    from blib2to3.driver import TokenProxy
+    from blib2to3.pgen2.driver import TokenProxy
 
 
 Results = Dict[Text, NL]


### PR DESCRIPTION
I'm not sure why mypy doesn't complain.

This was found while I was playing with Pytype on blib2to3.