### PR TITLE
Leave alone Quarto-style comments ("#|")

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -29,7 +29,7 @@ FMT_SKIP: Final = {"# fmt: skip", "# fmt:skip"}
 FMT_PASS: Final = {*FMT_OFF, *FMT_SKIP}
 FMT_ON: Final = {"# fmt: on", "# fmt:on", "# yapf: enable"}
 
-COMMENT_EXCEPTIONS = " !:#'"
+COMMENT_EXCEPTIONS = " !:#'|"
 
 
 @dataclass


### PR DESCRIPTION
### Description

Extended `COMMENT_EXCEPTIONS` to leave alone [Quarto][] metadata comments (`#|`), cf #3557.

[Quarto]: https://github.com/quarto-dev/quarto-cli

### Checklist - did you ...

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
