### PR TITLE
Enforce a blank line after a nested class in stubs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,15 +10,14 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- For stubs, enforce one blank line after a nested class with a body other than just
-  `...` (#3564)
-
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
 
 - Add trailing commas to collection literals even if there's a comment after the last
   entry (#3393)
+- For stubs, enforce one blank line after a nested class with a body other than just
+  `...` (#3564)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- For stubs, enforce one blank line after a nested class with a body other than just
+  `...` (#3564)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -481,7 +481,7 @@ class EmptyLineTracker:
     mode: Mode
     previous_line: Optional[Line] = None
     previous_block: Optional[LinesBlock] = None
-    previous_defs: List[int] = field(default_factory=list)
+    previous_defs: List[Line] = field(default_factory=list)
     semantic_leading_comment: Optional[LinesBlock] = None
 
     def maybe_empty_lines(self, current_line: Line) -> LinesBlock:
@@ -537,13 +537,13 @@ class EmptyLineTracker:
         else:
             before = 0
         depth = current_line.depth
-        while self.previous_defs and self.previous_defs[-1] >= depth:
+        while self.previous_defs and self.previous_defs[-1].depth >= depth:
             if self.mode.is_pyi:
                 assert self.previous_line is not None
                 if depth and not current_line.is_def and self.previous_line.is_def:
                     # Empty lines between attributes and methods should be preserved.
                     before = min(1, before)
-                elif depth:
+                elif depth and not self.previous_defs[-1].is_class:
                     before = 0
                 else:
                     before = 1
@@ -596,7 +596,7 @@ class EmptyLineTracker:
         self, current_line: Line, before: int
     ) -> Tuple[int, int]:
         if not current_line.is_decorator:
-            self.previous_defs.append(current_line.depth)
+            self.previous_defs.append(current_line)
         if self.previous_line is None:
             # Don't insert empty lines before the first line in the file.
             return 0, 0

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -543,7 +543,12 @@ class EmptyLineTracker:
                 if depth and not current_line.is_def and self.previous_line.is_def:
                     # Empty lines between attributes and methods should be preserved.
                     before = min(1, before)
-                elif depth and not self.previous_defs[-1].is_class:
+                elif (
+                    self.previous_defs[-1].is_class
+                    and not self.previous_defs[-1].is_stub_class
+                ):
+                    before = 1
+                elif depth:
                     before = 0
                 else:
                     before = 1

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 from black.brackets import DOT_PRIORITY, BracketTracker
-from black.mode import Mode
+from black.mode import Mode, Preview
 from black.nodes import (
     BRACKETS,
     CLOSING_BRACKETS,
@@ -544,7 +544,8 @@ class EmptyLineTracker:
                     # Empty lines between attributes and methods should be preserved.
                     before = min(1, before)
                 elif (
-                    self.previous_defs[-1].is_class
+                    Preview.blank_line_after_nested_stub_class in self.mode
+                    and self.previous_defs[-1].is_class
                     and not self.previous_defs[-1].is_stub_class
                 ):
                     before = 1

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -154,6 +154,7 @@ class Preview(Enum):
     """Individual preview style features."""
 
     add_trailing_comma_consistently = auto()
+    blank_line_after_nested_stub_class = auto()
     hex_codes_in_unicode_sequences = auto()
     prefer_splitting_right_hand_side_of_assignments = auto()
     # NOTE: string_processing requires wrap_long_dict_values_in_parens

--- a/tests/data/miscellaneous/nested_class_stub.pyi
+++ b/tests/data/miscellaneous/nested_class_stub.pyi
@@ -1,0 +1,16 @@
+class Outer:
+    class InnerStub: ...
+    outer_attr_after_inner_stub: int
+    class Inner:
+        inner_attr: int
+    outer_attr: int
+
+# output
+class Outer:
+    class InnerStub: ...
+    outer_attr_after_inner_stub: int
+
+    class Inner:
+        inner_attr: int
+
+    outer_attr: int

--- a/tests/data/miscellaneous/stub.pyi
+++ b/tests/data/miscellaneous/stub.pyi
@@ -56,13 +56,6 @@ class Nested:
         def who_has_to_know(self): ...
     def verse(self): ...
 
-class Outer:
-    class InnerStub: ...
-    outer_attr_after_inner_stub: int
-    class Inner:
-        inner_attr: int
-    outer_attr: int
-
 class Conditional:
     def f(self): ...
     if sys.version_info >= (3, 8):
@@ -135,15 +128,6 @@ class Nested:
         def who_has_to_know(self): ...
 
     def verse(self): ...
-
-class Outer:
-    class InnerStub: ...
-    outer_attr_after_inner_stub: int
-
-    class Inner:
-        inner_attr: int
-
-    outer_attr: int
 
 class Conditional:
     def f(self): ...

--- a/tests/data/miscellaneous/stub.pyi
+++ b/tests/data/miscellaneous/stub.pyi
@@ -57,6 +57,8 @@ class Nested:
     def verse(self): ...
 
 class Outer:
+    class InnerStub: ...
+    outer_attr_after_inner_stub: int
     class Inner:
         inner_attr: int
     outer_attr: int
@@ -135,6 +137,9 @@ class Nested:
     def verse(self): ...
 
 class Outer:
+    class InnerStub: ...
+    outer_attr_after_inner_stub: int
+
     class Inner:
         inner_attr: int
 

--- a/tests/data/miscellaneous/stub.pyi
+++ b/tests/data/miscellaneous/stub.pyi
@@ -56,6 +56,11 @@ class Nested:
         def who_has_to_know(self): ...
     def verse(self): ...
 
+class Outer:
+    class Inner:
+        inner_attr: int
+    outer_attr: int
+
 class Conditional:
     def f(self): ...
     if sys.version_info >= (3, 8):
@@ -128,6 +133,12 @@ class Nested:
         def who_has_to_know(self): ...
 
     def verse(self): ...
+
+class Outer:
+    class Inner:
+        inner_attr: int
+
+    outer_attr: int
 
 class Conditional:
     def f(self): ...

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -186,6 +186,12 @@ def test_stub() -> None:
     assert_format(source, expected, mode)
 
 
+def test_nested_class_stub() -> None:
+    mode = replace(DEFAULT_MODE, is_pyi=True, preview=True)
+    source, expected = read_data("miscellaneous", "nested_class_stub.pyi")
+    assert_format(source, expected, mode)
+
+
 def test_power_op_newline() -> None:
     # requires line_length=0
     source, expected = read_data("miscellaneous", "power_op_newline")


### PR DESCRIPTION
### Description

Resolves #2783

The issue was partially resolved by #2820, but only for cases where the inner class body ends with a definition (`class` or `def`) and is followed by another definition. This change enforces a blank line after any nested class with a body (other than just `...`) in stubs, particularly those ending with or followed by an annotation for an attribute.

I had to make a slight change to `EmptyLineTracker.previous_defs` in order to not put a blank line after the indented block of an `if` statement or function `def`: while typeshed doesn't include anything in function bodies, some of the stubs I'm maintaining include a docstring, and I wouldn't want a blank line added after each method that has one.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
