### PR TITLE
tests: Ignore pkg_resources.declare_namespace warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,4 +214,7 @@ filterwarnings = [
     # aiohttp is using deprecated cgi modules - Safe to remove when fixed:
     # https://github.com/aio-libs/aiohttp/issues/6905
     '''ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning''',
+    # https://github.com/psf/black/issues/3585
+    # for example, zope uses pkg_resources' namespace
+    '''ignore:Deprecated call to `pkg_resources.declare_namespace\('.*'\)`:DeprecationWarning''',
 ]


### PR DESCRIPTION
### Description
https://setuptools.pypa.io/en/stable/history.html#v67-3-0
> Added deprecation warning for pkg_resources.declare_namespace.
  Users that wish to implement namespace packages, are recommended
  to follow the practice described in PEP 420 and omit the
  __init__.py file entirely.

However, projects (for example, `zope`) may use `pkg_resources`'s namespace. This warning can be ignored.

Fixes: https://github.com/psf/black/issues/3585