### PR TITLE
Fix bug introduced in #3564.

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -598,7 +598,7 @@ class EmptyLineTracker:
                     before = 1
                 elif (
                     not depth
-                    and self.previous_defs[-1]
+                    and self.previous_defs[-1].depth
                     and current_line.leaves[-1].type == token.COLON
                     and (
                         current_line.leaves[0].value


### PR DESCRIPTION
Missed in #3564, `self.previous_defs[-1]` is now a `Line` not the `int` depth.