### PR TITLE
Fix two more mypyc issues with mypyc v1.2.0.

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -790,7 +790,7 @@ def is_line_short_enough(  # noqa: C901
     # store the leaves that contain parts of the MLS
     multiline_string_contexts: List[LN] = []
 
-    max_level_to_update = math.inf  # track the depth of the MLS
+    max_level_to_update: Union[int, float] = math.inf  # track the depth of the MLS
     for i, leaf in enumerate(line.leaves):
         if max_level_to_update == math.inf:
             had_comma: Optional[int] = None

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -181,9 +181,9 @@ def whitespace(leaf: Leaf, *, complex_subscript: bool) -> str:  # noqa: C901
     `complex_subscript` signals whether the given leaf is part of a subscription
     which has non-trivial arguments, like arithmetic expressions or function calls.
     """
-    NO: Final = ""
-    SPACE: Final = " "
-    DOUBLESPACE: Final = "  "
+    NO: Final[str] = ""
+    SPACE: Final[str] = " "
+    DOUBLESPACE: Final[str] = "  "
     t = leaf.type
     p = leaf.parent
     v = leaf.value


### PR DESCRIPTION
1. `math.inf` is a `float`, but `bracket_depth` is `int`. Alternatively we could use a really large int for maximum.
1. The `Final` in `nodes.py` is the same as #3645

Btw, any instructions how to build the mypyc wheels locally in the same way as CI? I only manually compiled the files excluding the ones excluded in pyproject.toml.