### PR TITLE
docs: update note on GitHub .git-blame-ignore-revs support

### DIFF
--- a/docs/guides/introducing_black_to_your_project.md
+++ b/docs/guides/introducing_black_to_your_project.md
@@ -46,7 +46,5 @@ $ git config blame.ignoreRevsFile .git-blame-ignore-revs
 **The one caveat is that some online Git-repositories like GitLab do not yet support
 ignoring revisions using their native blame UI.** So blame information will be cluttered
 with a reformatting commit on those platforms. (If you'd like this feature, there's an
-open issue for [GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/31423)). This is
-however supported by
-[GitHub](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view),
-currently in beta.
+open issue for [GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/31423)). 
+[GitHub supports `.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) by default in blame views however.


### PR DESCRIPTION
### Description

Minor doc update for https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html:

>  some online Git-repositories like ... do not yet support ignoring revisions ...  This is however supported by GitHub currently in beta.

I think this feature is generally available and  not beta anymore


### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary? not necessary
- [x] Add / update tests if necessary? not necessary 
- [x] Add new / update outdated documentation?
