### PR TITLE
Fix "# pyright: ignore" comment mobility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Black now avoids breaking up lines containing a comment beginning with "# pyright:
+  ignore". (#3661)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -822,7 +822,7 @@ def is_type_comment(leaf: Leaf, suffix: str = "") -> bool:
     t = leaf.type
     v = leaf.value
     return t in {token.COMMENT, STANDALONE_COMMENT} and (
-        v.startswith(f"# pyright:{suffix}") or v.startswith(f"# type:{suffix}")
+        v.startswith((f"# pyright:{suffix}", f"# type:{suffix}"))
     )
 
 

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -821,7 +821,9 @@ def is_type_comment(leaf: Leaf, suffix: str = "") -> bool:
     Only returns true for type comments for now."""
     t = leaf.type
     v = leaf.value
-    return t in {token.COMMENT, STANDALONE_COMMENT} and v.startswith("# type:" + suffix)
+    return t in {token.COMMENT, STANDALONE_COMMENT} and (
+        v.startswith(f"# pyright:{suffix}") or v.startswith(f"# type:{suffix}")
+    )
 
 
 def wrap_in_parentheses(parent: Node, child: LN, *, visible: bool = True) -> None:

--- a/tests/data/preview/comments7.py
+++ b/tests/data/preview/comments7.py
@@ -187,6 +187,7 @@ def func():
         0.0789,
         a[-1],  # type: ignore
     )
+    c = call(0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1])  # pyright: ignore[reportGeneralTypeIssues]
     c = call(0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1])  # type: ignore
     c = call(
         0.0123,

--- a/tests/data/preview/prefer_rhs_split.py
+++ b/tests/data/preview/prefer_rhs_split.py
@@ -55,6 +55,20 @@ first_item, second_item = some_looooooooong_module.some_loooooog_function_name(
 )
 
 
+# Make sure unsplittable pyright: ignore comments won't be moved.
+some_kind_of_table[some_key] = util.some_function(  # pyright: ignore[reportGeneralTypeIssues]  # noqa: E501
+    some_arg
+).intersection(pk_cols)
+
+some_kind_of_table[
+    some_key
+] = lambda obj: obj.some_long_named_method()  # pyright: ignore[reportGeneralTypeIssues]  # noqa: E501
+
+some_kind_of_table[
+    some_key  # pyright: ignore[reportGeneralTypeIssues]  # noqa: E501
+] = lambda obj: obj.some_long_named_method()
+
+
 # Make sure unsplittable type ignore won't be moved.
 some_kind_of_table[some_key] = util.some_function(  # type: ignore  # noqa: E501
     some_arg

--- a/tests/data/simple_cases/comments6.py
+++ b/tests/data/simple_cases/comments6.py
@@ -96,7 +96,24 @@ def func(
         0.0123,
         0.0456,
         0.0789,
+        a[-1],  # pyright: ignore[reportGeneralTypeIssues]
+    )
+
+    c = call(
+        0.0123,
+        0.0456,
+        0.0789,
+        0.0123,
+        0.0456,
+        0.0789,
+        0.0123,
+        0.0456,
+        0.0789,
         a[-1],  # type: ignore
+    )
+
+    c = call(
+        "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa", "aaaaaaaa"  # pyright: ignore[reportGeneralTypeIssues]
     )
 
     c = call(
@@ -108,11 +125,20 @@ result = (  # aaa
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 )
 
+AAAAAAAAAAAAA = [AAAAAAAAAAAAA] + SHARED_AAAAAAAAAAAAA + USER_AAAAAAAAAAAAA + AAAAAAAAAAAAA  # pyright: ignore[reportGeneralTypeIssues]
+
 AAAAAAAAAAAAA = [AAAAAAAAAAAAA] + SHARED_AAAAAAAAAAAAA + USER_AAAAAAAAAAAAA + AAAAAAAAAAAAA  # type: ignore
+
+call_to_some_function_asdf(
+    foo,
+    [AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBB],  # pyright: ignore[reportGeneralTypeIssues]
+)
 
 call_to_some_function_asdf(
     foo,
     [AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBB],  # type: ignore
 )
+
+aaaaaaaaaaaaa, bbbbbbbbb = map(list, map(itertools.chain.from_iterable, zip(*items)))  # pyright: ignore[reportGeneralTypeIssues]
 
 aaaaaaaaaaaaa, bbbbbbbbb = map(list, map(itertools.chain.from_iterable, zip(*items)))  # type: ignore[arg-type]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Closes #3946

Hi! It looks like you have some special handling for `# type: ignore` comments to avoid moving said comments around due to positional meaning. I think this same special handling should also apply to [`# pyright: ignore` comments](https://microsoft.github.io/pyright/#/comments?id=line-level-diagnostic-suppression).

The use case for `# pyright: ignore` comments is being able to ignore Pyright-specific diagnostic rules that might not make sense in the context of more generic `# type: ignore` comments.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
