### PR TITLE
[github action] display black result in job summary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-- Update GitHub Action to display black output in the job summary
+- Update GitHub Action to display black output in the job summary (#3688)
 
 
 ### Documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,8 +44,8 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-- Update GitHub Action to display black output in the job summary (#3688)
 
+- Update GitHub Action to display black output in the job summary (#3688)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Update GitHub Action to display black output in the job summary
+
 
 ### Documentation
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: black
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          python $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY 
+          python $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY
         else
           python3 $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY
         fi

--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,12 @@ branding:
 runs:
   using: composite
   steps:
-    - run: |
+    - name: black
+      run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          python $GITHUB_ACTION_PATH/action/main.py
+          python $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY 
         else
-          python3 $GITHUB_ACTION_PATH/action/main.py
+          python3 $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY
         fi
       env:
         # TODO: Remove once https://github.com/actions/runner/issues/665 is fixed.

--- a/action/main.py
+++ b/action/main.py
@@ -32,7 +32,7 @@ else:
                 describe_name = line[len("describe-name: ") :].rstrip()
                 break
     if not describe_name:
-        sys.stderr.write("::error::Failed to detect action version.")
+        print("::error::Failed to detect action version.", file=sys.stderr, flush=True)
         sys.exit(1)
     # expected format is one of:
     # - 23.1.0
@@ -53,7 +53,7 @@ pip_proc = run(
 )
 if pip_proc.returncode:
     print(pip_proc.stdout)
-    sys.stderr.write("::error::Failed to install Black.")
+    print("::error::Failed to install Black.", file=sys.stderr, flush=True)
     sys.exit(pip_proc.returncode)
 
 

--- a/action/main.py
+++ b/action/main.py
@@ -32,7 +32,7 @@ else:
                 describe_name = line[len("describe-name: ") :].rstrip()
                 break
     if not describe_name:
-        print("::error::Failed to detect action version.", flush=True)
+        sys.stderr.write("::error::Failed to detect action version.")
         sys.exit(1)
     # expected format is one of:
     # - 23.1.0
@@ -53,15 +53,25 @@ pip_proc = run(
 )
 if pip_proc.returncode:
     print(pip_proc.stdout)
-    print("::error::Failed to install Black.", flush=True)
+    sys.stderr.write("::error::Failed to install Black.")
     sys.exit(pip_proc.returncode)
 
 
 base_cmd = [str(ENV_BIN / "black")]
 if BLACK_ARGS:
     # TODO: remove after a while since this is deprecated in favour of SRC + OPTIONS.
-    proc = run([*base_cmd, *shlex.split(BLACK_ARGS)])
+    proc = run(
+        [*base_cmd, *shlex.split(BLACK_ARGS)],
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+    )
 else:
-    proc = run([*base_cmd, *shlex.split(OPTIONS), *shlex.split(SRC)])
-
+    proc = run(
+        [*base_cmd, *shlex.split(OPTIONS), *shlex.split(SRC)],
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+    )
+print(proc.stdout)
 sys.exit(proc.returncode)


### PR DESCRIPTION
### Description

This PR updates the black github action to display the output of black in the [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary)

### Checklist

- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?


### Result looks like this:
#### - erroring with verbosity on
<img width="871" alt="screenshot-2023-05-13-1727" src="https://github.com/psf/black/assets/814931/09fd636a-28f2-4786-ba5e-a62408239726">

#### - success with verbosity off
<img width="471" alt="screenshot-2023-05-13-1741" src="https://github.com/psf/black/assets/814931/f523c46c-e946-4826-90b3-cda84653cb7b">
