### PR TITLE
Remove blank lines before class docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 - Implicitly concatenated strings used as function args are no longer wrapped inside
   parentheses (#3640)
+- Remove blank lines between a class definition and its docstring (#3692)
 
 ### Configuration
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -634,6 +634,8 @@ class EmptyLineTracker:
             and self.previous_line.is_class
             and current_line.is_triple_quoted_string
         ):
+            if Preview.no_blank_line_before_class_docstring in current_line.mode:
+                return 0, 1
             return before, 1
 
         if self.previous_line and self.previous_line.opens_block:

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -158,6 +158,7 @@ class Preview(Enum):
     hex_codes_in_unicode_sequences = auto()
     improved_async_statements_handling = auto()
     multiline_string_handling = auto()
+    no_blank_line_before_class_docstring = auto()
     prefer_splitting_right_hand_side_of_assignments = auto()
     # NOTE: string_processing requires wrap_long_dict_values_in_parens
     # for https://github.com/psf/black/issues/3117 to be fixed.

--- a/tests/data/preview/no_blank_line_before_docstring.py
+++ b/tests/data/preview/no_blank_line_before_docstring.py
@@ -1,0 +1,58 @@
+def line_before_docstring():
+
+    """Please move me up"""
+
+
+class LineBeforeDocstring:
+
+    """Please move me up"""
+
+
+class EvenIfThereIsAMethodAfter:
+
+    """I'm the docstring"""
+    def method(self):
+        pass
+
+
+class TwoLinesBeforeDocstring:
+
+
+    """I want to be treated the same as if I were closer"""
+
+
+class MultilineDocstringsAsWell:
+
+    """I'm so far
+
+    and on so many lines...
+    """
+
+
+# output
+
+
+def line_before_docstring():
+    """Please move me up"""
+
+
+class LineBeforeDocstring:
+    """Please move me up"""
+
+
+class EvenIfThereIsAMethodAfter:
+    """I'm the docstring"""
+
+    def method(self):
+        pass
+
+
+class TwoLinesBeforeDocstring:
+    """I want to be treated the same as if I were closer"""
+
+
+class MultilineDocstringsAsWell:
+    """I'm so far
+
+    and on so many lines...
+    """


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Fixes psf/black#3659

Since psf/black#3035, the blank lines between a function and its docstring are removed. The class docstring is special cased in the code to leave one blank line **after**, so that change has no effect. This PR fixes that.

BTW, I couldn't find a test for the function case so I added one just to be sure it doesn't regress :)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
