### PR TITLE
blackd: show default values for options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,9 @@
 ### _Blackd_
 
 <!-- Changes to blackd -->
-- The `blackd` argument parser now shows the default values for options in their help text (#3712)
+
+- The `blackd` argument parser now shows the default values for options in their help
+  text (#3712)
 
 ### Integrations
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 ### _Blackd_
 
 <!-- Changes to blackd -->
+- The `blackd` argument parser now shows the default values for options in their help text (#3712)
 
 ### Integrations
 

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -59,9 +59,15 @@ class InvalidVariantHeader(Exception):
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
-    "--bind-host", type=str, help="Address to bind the server to.", default="localhost"
+    "--bind-host",
+    type=str,
+    help="Address to bind the server to.",
+    default="localhost",
+    show_default=True,
 )
-@click.option("--bind-port", type=int, help="Port to listen on", default=45484)
+@click.option(
+    "--bind-port", type=int, help="Port to listen on", default=45484, show_default=True
+)
 @click.version_option(version=black.__version__)
 def main(bind_host: str, bind_port: int) -> None:
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
I personally find this very useful.

Reference: https://click.palletsprojects.com/en/8.1.x/api/#click.Option

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
