### PR TITLE
Max line length with bugbear

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -160,6 +160,8 @@ harder to work with line lengths exceeding 100 characters. It also adversely aff
 side-by-side diff review on typical screen resolutions. Long lines also make it harder
 to present code neatly in documentation or talk slides.
 
+#### Flake8
+
 If you use Flake8, you have a few options:
 
 1. Recommended is using [Bugbear](https://github.com/PyCQA/flake8-bugbear) and enabling its B950 check instead of using Flake8's E501, because it aligns with Black's 10% rule. Install Bugbear and use the following config:
@@ -172,6 +174,9 @@ If you use Flake8, you have a few options:
    extend-ignore = E203, E501
    ```
 
+   The rationale for E950 is explained in [Bugbear's documentation](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings).
+
+
 2. For a minimally compatible config:
 
    ```ini
@@ -179,6 +184,8 @@ If you use Flake8, you have a few options:
    max-line-length = 88
    extend-ignore = E203
    ```
+
+An explanation of why E203 is disabled can be found in the [Slices section](#slices) of this page.
 
 ### Empty lines
 

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -164,7 +164,9 @@ to present code neatly in documentation or talk slides.
 
 If you use Flake8, you have a few options:
 
-1. Recommended is using [Bugbear](https://github.com/PyCQA/flake8-bugbear) and enabling its B950 check instead of using Flake8's E501, because it aligns with Black's 10% rule. Install Bugbear and use the following config:
+1. Recommended is using [Bugbear](https://github.com/PyCQA/flake8-bugbear) and enabling
+   its B950 check instead of using Flake8's E501, because it aligns with Black's 10%
+   rule. Install Bugbear and use the following config:
 
    ```ini
    [flake8]
@@ -174,8 +176,8 @@ If you use Flake8, you have a few options:
    extend-ignore = E203, E501
    ```
 
-   The rationale for E950 is explained in [Bugbear's documentation](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings).
-
+   The rationale for E950 is explained in
+   [Bugbear's documentation](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings).
 
 2. For a minimally compatible config:
 
@@ -185,7 +187,8 @@ If you use Flake8, you have a few options:
    extend-ignore = E203
    ```
 
-An explanation of why E203 is disabled can be found in the [Slices section](#slices) of this page.
+An explanation of why E203 is disabled can be found in the [Slices section](#slices) of
+this page.
 
 ### Empty lines
 

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -160,33 +160,25 @@ harder to work with line lengths exceeding 100 characters. It also adversely aff
 side-by-side diff review on typical screen resolutions. Long lines also make it harder
 to present code neatly in documentation or talk slides.
 
-If you're using Flake8, you can bump `max-line-length` to 88 and mostly forget about it.
-However, it's better if you use [Bugbear](https://github.com/PyCQA/flake8-bugbear)'s
-B950 warning instead of E501, and bump the max line length to 88 (or the `--line-length`
-you used for black), which will align more with black's _"try to respect
-`--line-length`, but don't become crazy if you can't"_. You'd do it like this:
+If you use Flake8, you have a few options:
 
-```ini
-[flake8]
-max-line-length = 88
-...
-select = C,E,F,W,B,B950
-extend-ignore = E203, E501
-```
+1. Recommended is using [Bugbear](https://github.com/PyCQA/flake8-bugbear) and enabling its B950 check instead of using Flake8's E501, because it aligns with Black's 10% rule. Install Bugbear and use the following config:
 
-Explanation of why E203 is disabled can be found further in this documentation. And if
-you're curious about the reasoning behind B950,
-[Bugbear's documentation](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings)
-explains it. The tl;dr is "it's like highway speed limits, we won't bother you if you
-overdo it by a few km/h".
+   ```ini
+   [flake8]
+   max-line-length = 80
+   ...
+   select = C,E,F,W,B,B950
+   extend-ignore = E203, E501
+   ```
 
-**If you're looking for a minimal, black-compatible flake8 configuration:**
+2. For a minimally compatible config:
 
-```ini
-[flake8]
-max-line-length = 88
-extend-ignore = E203
-```
+   ```ini
+   [flake8]
+   max-line-length = 88
+   extend-ignore = E203
+   ```
 
 ### Empty lines
 


### PR DESCRIPTION
### Description

Fixes #3716

The current phrasing of the Flake8 section of the [line length documentation](https://black.readthedocs.io/en/latest/the_black_code_style/current_style.html#line-length) is very open.

This PR makes it more concise and explicit, as well as change the `max-line-length` example when using [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) to 80, as explained in #3716.

### Checklist - did you ...

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [X] Add new / update outdated documentation?