### PR TITLE
Decrease cost of ipynb code path when unneeded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@
 
 <!-- Changes that improve Black's performance. -->
 
+- Avoid importing `IPython` in a case where we wouldn't need it (#3748)
+
 ### Output
 
 <!-- Changes to Black's terminal output and error messages -->

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -61,6 +61,7 @@ def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
         # isort: off
         import tokenize_rt  # noqa:F401
         import IPython  # noqa:F401
+
         # isort: on
     except ModuleNotFoundError:
         if verbose or not quiet:

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -59,6 +59,7 @@ class Replacement:
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
     try:
         # isort: off
+        # tokenize_rt is less commonly installed than IPython and IPython is expensive to import
         import tokenize_rt  # noqa:F401
         import IPython  # noqa:F401
 

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -58,8 +58,8 @@ class Replacement:
 @lru_cache()
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
     try:
-        import IPython  # noqa:F401
         import tokenize_rt  # noqa:F401
+        import IPython  # noqa:F401
     except ModuleNotFoundError:
         if verbose or not quiet:
             msg = (

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -58,8 +58,10 @@ class Replacement:
 @lru_cache()
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
     try:
+        # isort: off
         import tokenize_rt  # noqa:F401
         import IPython  # noqa:F401
+        # isort: on
     except ModuleNotFoundError:
         if verbose or not quiet:
             msg = (

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -59,7 +59,8 @@ class Replacement:
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
     try:
         # isort: off
-        # tokenize_rt is less commonly installed than IPython and IPython is expensive to import
+        # tokenize_rt is less commonly installed than IPython
+        # and IPython is expensive to import
         import tokenize_rt  # noqa:F401
         import IPython  # noqa:F401
 


### PR DESCRIPTION
IPython is a very expensive import, like, at least 300ms. I'd also venture that it's much more common than tokenize-rt, which is like 30ms. I work in a repo where I use black, have IPython installed and there happen to be a couple notebooks (that we don't want formatted). I know I can force exclude ipynb, but this change doesn't really have a cost.