### PR TITLE
CI Test: Deprecating 'set-output' command 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,8 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Update GitHub Action to display black output in the job summary (#3688)
+- Deprecated `set-output` command in CI test to keep up to date with GitHub's
+  deprecation announcement (#3757)
 
 ### Documentation
 

--- a/scripts/diff_shades_gha_helper.py
+++ b/scripts/diff_shades_gha_helper.py
@@ -52,7 +52,13 @@ def set_output(name: str, value: str) -> None:
         print(f"[INFO]: setting '{name}' to '{value}'")
     else:
         print(f"[INFO]: setting '{name}' to [{len(value)} chars]")
-    print(f"::set-output name={name}::{value}")
+
+    # Originally the `set-output` workflow command was used here, now replaced
+    # by the new `GITHUB_OUTPUT` environment variable to stay up to date
+    # with GitHub's update.
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            print(f"{name}={value}", file=f)
 
 
 def http_get(url: str, *, is_json: bool = True, **kwargs: Any) -> Any:

--- a/scripts/diff_shades_gha_helper.py
+++ b/scripts/diff_shades_gha_helper.py
@@ -54,8 +54,8 @@ def set_output(name: str, value: str) -> None:
         print(f"[INFO]: setting '{name}' to [{len(value)} chars]")
 
     # Originally the `set-output` workflow command was used here, now replaced
-    # by the new `GITHUB_OUTPUT` environment variable to stay up to date
-    # with GitHub's update.
+    # by setting variables through the `GITHUB_OUTPUT` environment variable
+    # to stay up to date with GitHub's update.
     if "GITHUB_OUTPUT" in os.environ:
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             print(f"{name}={value}", file=f)

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -88,7 +88,7 @@ from blib2to3.pytree import Leaf, Node
 
 COMPILED = Path(__file__).suffix in (".pyd", ".so")
 
-# types1
+# types
 FileContent = str
 Encoding = str
 NewLine = str

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -88,7 +88,7 @@ from blib2to3.pytree import Leaf, Node
 
 COMPILED = Path(__file__).suffix in (".pyd", ".so")
 
-# types
+# types1
 FileContent = str
 Encoding = str
 NewLine = str


### PR DESCRIPTION
### Description

This PR replaced the deprecating `set-output` command used in the `diff_shades_comment` GitHub Action with latest GitHub supported method.

See this [GitHub blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) about this deprecation.

The original method of setting variables directly using the `set-output` command has now been replaced with setting variables through the `GITHUB_OUTPUT` environment variable. 

After this fix, there will be no more warnings like this popping up when executing this CI test:

![image](https://github.com/psf/black/assets/13176405/6627425d-6b26-4986-9552-10fe078f144d)


### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary? not necessary
- [ ] Add new / update outdated documentation? not necessary

