### PR TITLE
Remove ENV_PATH on Black action completion.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- The `.black.env` folder specified by `ENV_PATH` will now be removed on the completion
+  of the GitHub Action. (#3759)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/action/main.py
+++ b/action/main.py
@@ -1,7 +1,7 @@
 import os
 import shlex
-import sys
 import shutil
+import sys
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run
 

--- a/action/main.py
+++ b/action/main.py
@@ -74,6 +74,6 @@ else:
         stderr=STDOUT,
         encoding="utf-8",
     )
-shutil.rmtree(ENV_PATH)
+shutil.rmtree(ENV_PATH, ignore_errors=True)
 print(proc.stdout)
 sys.exit(proc.returncode)

--- a/action/main.py
+++ b/action/main.py
@@ -1,6 +1,7 @@
 import os
 import shlex
 import sys
+import shutil
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run
 
@@ -73,5 +74,6 @@ else:
         stderr=STDOUT,
         encoding="utf-8",
     )
+shutil.rmtree(ENV_PATH)
 print(proc.stdout)
 sys.exit(proc.returncode)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Relates to #3708 by deleting the `.black.env` folder specified by `ENV_PATH` on action completion.

I had a difficult time replicating the issue above @JelleZijlstra and I can't see that any changes were made to stable that would effect this behaviour. Probably worth deleting that `.black.env` dir anyway?

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
