### PR TITLE
Better error message for invalid exclude types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@
 - Fix black not honouring `pyproject.toml` settings when running `--stdin-filename` and
   the `pyproject.toml` found isn't in the current working directory (#3719)
 - Black will now error if `exclude` and `extend-exclude` have invalid data types in
-  `pyproject.toml`, instead of silently doing the wrong thing.
+  `pyproject.toml`, instead of silently doing the wrong thing (#3764)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
 - `.pytest_cache`, `.ruff_cache` and `.vscode` are now excluded by default (#3691)
 - Fix black not honouring `pyproject.toml` settings when running `--stdin-filename` and
   the `pyproject.toml` found isn't in the current working directory (#3719)
+- Black will now error if `exclude` and `extend-exclude` have invalid data types in
+  `pyproject.toml`, instead of silently doing the wrong thing.
 
 ### Packaging
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -159,9 +159,7 @@ def read_pyproject_toml(
 
     exclude = config.get("exclude")
     if exclude is not None and not isinstance(exclude, str):
-        raise click.BadOptionUsage(
-            "exclude", "Config key exclude must be a string"
-        )
+        raise click.BadOptionUsage("exclude", "Config key exclude must be a string")
 
     extend_exclude = config.get("extend_exclude")
     if extend_exclude is not None and not isinstance(extend_exclude, str):

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -157,6 +157,18 @@ def read_pyproject_toml(
             "target-version", "Config key target-version must be a list"
         )
 
+    exclude = config.get("exclude")
+    if exclude is not None and not isinstance(exclude, str):
+        raise click.BadOptionUsage(
+            "exclude", "Config key exclude must be a string"
+        )
+
+    extend_exclude = config.get("extend_exclude")
+    if extend_exclude is not None and not isinstance(extend_exclude, str):
+        raise click.BadOptionUsage(
+            "extend-exclude", "Config key extend-exclude must be a string"
+        )
+
     default_map: Dict[str, Any] = {}
     if ctx.default_map:
         default_map.update(ctx.default_map)


### PR DESCRIPTION
Currently if this is a list, this ends up using the repr of the list as a regex.

Fixes #3574, fixes #3754