### PR TITLE
Disable coverage on pypy tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload coverage to Coveralls
         # Upload coverage if we are on the main repository and
         # we're running on Linux (this action only supports Linux)
-        if: github.repository == 'psf/black' && matrix.os == 'ubuntu-latest'
+        if: github.repository == 'psf/black' && matrix.os == 'ubuntu-latest' && !startsWith(matrix.python-version, 'pypy')
         uses: AndreMiras/coveralls-python-action@v20201129
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Upload coverage to Coveralls
         # Upload coverage if we are on the main repository and
         # we're running on Linux (this action only supports Linux)
-        if: github.repository == 'psf/black' && matrix.os == 'ubuntu-latest' && !startsWith(matrix.python-version, 'pypy')
+        if:
+          github.repository == 'psf/black' && matrix.os == 'ubuntu-latest' &&
+          !startsWith(matrix.python-version, 'pypy')
         uses: AndreMiras/coveralls-python-action@v20201129
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -43,15 +43,12 @@ commands =
     pytest tests \
         --run-optional no_jupyter \
         !ci: --numprocesses auto \
-        ci: --numprocesses 1 \
-        --cov {posargs}
+        ci: --numprocesses 1
     pip install -e .[jupyter]
     pytest tests --run-optional jupyter \
         -m jupyter \
         !ci: --numprocesses auto \
-        ci: --numprocesses 1 \
-        --cov --cov-append {posargs}
-    coverage report
+        ci: --numprocesses 1
 
 [testenv:{,ci-}311]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ deps =
 ; remove this when pypy releases the bugfix
 commands =
     pip install -e .[d]
-    coverage erase
     pytest tests \
         --run-optional no_jupyter \
         !ci: --numprocesses auto \


### PR DESCRIPTION
The pypy tests are reeeeaaally slow. This reduces time taken from like 20m to 3m. We no longer have pypy branches after dropping Python 3.7 support.