### PR TITLE
Avoid importing `IPython` if notebook cells do not contain magics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@
 
 <!-- Changes that improve Black's performance. -->
 
+- minimize cost of introspection to detect jupyter dependencies (#3782)
+
 ### Output
 
 <!-- Changes to Black's terminal output and error messages -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@
 
 <!-- Changes that improve Black's performance. -->
 
-- Avoid importing `IPython` if notebook cells do not contain magics (#3748)
+- Avoid importing `IPython` if notebook cells do not contain magics (#3782)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@
 
 <!-- Changes that improve Black's performance. -->
 
-- minimize cost of introspection to detect jupyter dependencies (#3782)
+- Avoid importing `IPython` if notebook cells do not contain magics (#3748)
 
 ### Output
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -668,7 +668,7 @@ def get_sources(
                 p = Path(f"{STDIN_PLACEHOLDER}{str(p)}")
 
             if p.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
-                verbose=verbose, quiet=quiet
+                warn=verbose or not quiet
             ):
                 continue
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -384,7 +384,7 @@ def gen_python_files(
 
         elif child.is_file():
             if child.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
-                verbose=verbose, quiet=quiet
+                warn=verbose or not quiet
             ):
                 continue
             include_match = include.search(normalized_path) if include else True

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -57,9 +57,9 @@ class Replacement:
 
 
 @lru_cache
-def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
+def jupyter_dependencies_are_installed(*, warn: bool) -> bool:
     installed = find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
-    if not installed and (verbose or not quiet):
+    if not installed and warn:
         msg = (
             "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
             'You can fix this by running ``pip install "black[jupyter]"``'

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -58,7 +58,9 @@ class Replacement:
 
 @lru_cache
 def jupyter_dependencies_are_installed(*, warn: bool) -> bool:
-    installed = find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
+    installed = (
+        find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
+    )
     if not installed and warn:
         msg = (
             "Skipping .ipynb files as Jupyter dependencies are not installed.\n"

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -6,6 +6,7 @@ import dataclasses
 import secrets
 import sys
 from functools import lru_cache
+from importlib.util import find_spec
 from typing import Dict, List, Optional, Tuple
 
 if sys.version_info >= (3, 10):
@@ -57,24 +58,14 @@ class Replacement:
 
 @lru_cache
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
-    try:
-        # isort: off
-        # tokenize_rt is less commonly installed than IPython
-        # and IPython is expensive to import
-        import tokenize_rt  # noqa:F401
-        import IPython  # noqa:F401
-
-        # isort: on
-    except ModuleNotFoundError:
-        if verbose or not quiet:
-            msg = (
-                "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
-                'You can fix this by running ``pip install "black[jupyter]"``'
-            )
-            out(msg)
-        return False
-    else:
-        return True
+    retv = find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
+    if not retv and (verbose or not quiet):
+        msg = (
+            "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
+            'You can fix this by running ``pip install "black[jupyter]"``'
+        )
+        out(msg)
+    return retv
 
 
 def remove_trailing_semicolon(src: str) -> Tuple[str, bool]:

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -58,14 +58,14 @@ class Replacement:
 
 @lru_cache
 def jupyter_dependencies_are_installed(*, verbose: bool, quiet: bool) -> bool:
-    retv = find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
-    if not retv and (verbose or not quiet):
+    installed = find_spec("tokenize_rt") is not None and find_spec("IPython") is not None
+    if not installed and (verbose or not quiet):
         msg = (
             "Skipping .ipynb files as Jupyter dependencies are not installed.\n"
             'You can fix this by running ``pip install "black[jupyter]"``'
         )
         out(msg)
-    return retv
+    return installed
 
 
 def remove_trailing_semicolon(src: str) -> Tuple[str, bool]:

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -440,17 +440,13 @@ def test_cache_isnt_written_if_no_jupyter_deps_single(
     nb = get_case_path("jupyter", "notebook_trailing_newline.ipynb")
     tmp_nb = tmp_path / "notebook.ipynb"
     tmp_nb.write_bytes(nb.read_bytes())
-    monkeypatch.setattr(
-        "black.jupyter_dependencies_are_installed", lambda warn: False
-    )
+    monkeypatch.setattr("black.jupyter_dependencies_are_installed", lambda warn: False)
     result = runner.invoke(
         main, [str(tmp_path / "notebook.ipynb"), f"--config={EMPTY_CONFIG}"]
     )
     assert "No Python files are present to be formatted. Nothing to do" in result.output
     jupyter_dependencies_are_installed.cache_clear()
-    monkeypatch.setattr(
-        "black.jupyter_dependencies_are_installed", lambda warn: True
-    )
+    monkeypatch.setattr("black.jupyter_dependencies_are_installed", lambda warn: True)
     result = runner.invoke(
         main, [str(tmp_path / "notebook.ipynb"), f"--config={EMPTY_CONFIG}"]
     )

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -441,7 +441,7 @@ def test_cache_isnt_written_if_no_jupyter_deps_single(
     tmp_nb = tmp_path / "notebook.ipynb"
     tmp_nb.write_bytes(nb.read_bytes())
     monkeypatch.setattr(
-        "black.jupyter_dependencies_are_installed", lambda verbose, quiet: False
+        "black.jupyter_dependencies_are_installed", lambda warn: False
     )
     result = runner.invoke(
         main, [str(tmp_path / "notebook.ipynb"), f"--config={EMPTY_CONFIG}"]
@@ -449,7 +449,7 @@ def test_cache_isnt_written_if_no_jupyter_deps_single(
     assert "No Python files are present to be formatted. Nothing to do" in result.output
     jupyter_dependencies_are_installed.cache_clear()
     monkeypatch.setattr(
-        "black.jupyter_dependencies_are_installed", lambda verbose, quiet: True
+        "black.jupyter_dependencies_are_installed", lambda warn: True
     )
     result = runner.invoke(
         main, [str(tmp_path / "notebook.ipynb"), f"--config={EMPTY_CONFIG}"]
@@ -466,13 +466,13 @@ def test_cache_isnt_written_if_no_jupyter_deps_dir(
     tmp_nb = tmp_path / "notebook.ipynb"
     tmp_nb.write_bytes(nb.read_bytes())
     monkeypatch.setattr(
-        "black.files.jupyter_dependencies_are_installed", lambda verbose, quiet: False
+        "black.files.jupyter_dependencies_are_installed", lambda warn: False
     )
     result = runner.invoke(main, [str(tmp_path), f"--config={EMPTY_CONFIG}"])
     assert "No Python files are present to be formatted. Nothing to do" in result.output
     jupyter_dependencies_are_installed.cache_clear()
     monkeypatch.setattr(
-        "black.files.jupyter_dependencies_are_installed", lambda verbose, quiet: True
+        "black.files.jupyter_dependencies_are_installed", lambda warn: True
     )
     result = runner.invoke(main, [str(tmp_path), f"--config={EMPTY_CONFIG}"])
     assert "reformatted" in result.output


### PR DESCRIPTION
### Description

follow up to #3748: completely avoid import overhead in `jupyter_dependencies_are_installed`. This function now takes <0.2ms regardless of the result, while the current implementation takes >200ms on first call when the result is `True`.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
