### PR TITLE
Remove unneeded mypy dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,10 +43,8 @@ repos:
       - id: mypy
         exclude: ^docs/conf.py
         additional_dependencies:
-          - types-dataclasses >= 0.1.3
           - types-PyYAML
           - tomli >= 0.2.6, < 2.0.0
-          - types-typed-ast >= 1.4.1
           - click >= 8.1.0, != 8.1.4
           - packaging >= 22.0
           - platformdirs >= 2.1.0


### PR DESCRIPTION
Black no longer uses typed-ast or the dataclasses backport, so these should both be unnecessary now!