### PR TITLE
Remove tox pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,12 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'tox<4.7'
+          python -m pip install --upgrade tox
 
       - name: Unit tests
         if: "!startsWith(matrix.python-version, 'pypy')"
-        run: tox -e ci-py -- -v --color=yes
+        run:
+          tox -e ci-py$(echo ${{ matrix.python-version }} | tr -d '.') -- -v --color=yes
 
       - name: Unit tests (pypy)
         if: "startsWith(matrix.python-version, 'pypy')"


### PR DESCRIPTION
### Description
A more permanent fix for tox issue. This reverts #3843

Starting with `4.9`, tox will throw an error for unspecified environment names. The run command was missing the python version. _Doing the fix inline might not be as nice as a separate variable but works for all three OS without issues._

https://tox.wiki/en/latest/changelog.html#v4-9-0-2023-08-16
https://github.com/tox-dev/tox/issues/2858