### PR TITLE
Bump RTD Python version from 3.8 to 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
Recent ReadTheDocs builds have been failing as our documentation dependencies (notably Sphinx) require Python 3.9+.

https://readthedocs.org/projects/black/builds/21869742/