### PR TITLE
Add mypyc test marks to new tests that patch

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1985,6 +1985,7 @@ class TestCaching:
             assert not cache.is_changed(one)
             assert not cache.is_changed(two)
 
+    @pytest.mark.incompatible_with_mypyc
     @pytest.mark.parametrize("color", [False, True], ids=["no-color", "with-color"])
     def test_no_cache_when_writeback_diff(self, color: bool) -> None:
         mode = DEFAULT_MODE
@@ -2046,6 +2047,7 @@ class TestCaching:
             read_cache = black.Cache.read(mode)
             assert not read_cache.is_changed(src)
 
+    @pytest.mark.incompatible_with_mypyc
     def test_filter_cached(self) -> None:
         with TemporaryDirectory() as workspace:
             path = Path(workspace)


### PR DESCRIPTION
This is enough for me to get a clean test run on current main with Python 3.9 with mypyc.
This is needed for the usual reason that mypyc doesn't like monkeypatching.

I'd say we should merge this even if we merge https://github.com/psf/black/pull/3870 , because it would be nice to completely undo that PR.

I have not been able to repro the pickle failures on either Linux or macOS, note those also happen on tests other than these ones.