### PR TITLE
Upgrade to Furo 2023.9.10 to fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,4 @@ Sphinx==7.2.3
 docutils==0.19
 sphinxcontrib-programoutput==0.17
 sphinx_copybutton==0.5.2
-furo==2023.8.19
+furo==2023.9.10


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

I spotted that https://black.readthedocs.io/en/stable/ is still pointing to 23.7.0 and https://black.readthedocs.io/en/latest/ to 23.7.1.dev33, instead of both at 2.3.9.0[.devXX].

The [last Read the Docs build](https://readthedocs.org/projects/black/builds/21871999/) failed with:

```pytb
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/black/envs/latest/lib/python3.11/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/black/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 272, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/black/envs/latest/lib/python3.11/site-packages/sphinx/application.py", line 343, in _init_builder
    self.events.emit('builder-inited')
  File "/home/docs/checkouts/readthedocs.org/user_builds/black/envs/latest/lib/python3.11/site-packages/sphinx/events.py", line 96, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/black/envs/latest/lib/python3.11/site-packages/furo/__init__.py", line 234, in _builder_inited
    raise ConfigError(
sphinx.errors.ConfigError: Furo is being used as an extension in a non-HTML build. This should not happen.

Configuration error:
Furo is being used as an extension in a non-HTML build. This should not happen.
```

This looks a Furo bug, and was fixed yesterday in https://github.com/pradyunsg/furo/commit/5abeb9fc962aee61eda02e0c75e872004635e9d5, but has not been released yet (cc @pradyunsg).

I checked latest Furo main (`furo @ git+https://github.com/pradyunsg/furo@main` in `requirements.txt`) and it [built](https://readthedocs.org/projects/hugovk-black/builds/21876618/) [fine](https://hugovk-black.readthedocs.io/en/fix-furo/).

Whilst awaiting a new release, let's use the last working version.

---

I also recommend enabling build previews for PRs at https://readthedocs.org/dashboard/black/advanced/ so future RTD build failures don't slip by.

<img width="615" alt="image" src="https://github.com/psf/black/assets/1324225/bdad59b0-21bc-4158-9d01-703768eeb1e6">

Docs: https://docs.readthedocs.io/en/stable/pull-requests.html



<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
