### PR TITLE
Remove outdated mentions of runtime support of Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Try it out now using the [Black Playground](https://black.vercel.app). Watch the
 
 ### Installation
 
-_Black_ can be installed by running `pip install black`. It requires Python 3.7+ to run.
+_Black_ can be installed by running `pip install black`. It requires Python 3.8+ to run.
 If you want to format Jupyter Notebooks, install with `pip install "black[jupyter]"`.
 
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -75,8 +75,8 @@ def _initialize_black_env(upgrade=False):
       return True
 
   pyver = sys.version_info[:3]
-  if pyver < (3, 7):
-    print("Sorry, Black requires Python 3.7+ to run.")
+  if pyver < (3, 8):
+    print("Sorry, Black requires Python 3.8+ to run.")
     return False
 
   from pathlib import Path

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -86,7 +86,7 @@ disabled-by-default counterpart W504. E203 should be disabled while changes are 
 
 ## Which Python versions does Black support?
 
-Currently the runtime requires Python 3.7-3.11. Formatting is supported for files
+Currently the runtime requires Python 3.8-3.11. Formatting is supported for files
 containing syntax from Python 3.3 to 3.11. We promise to support at least all Python
 versions that have not reached their end of life. This is the case for both running
 _Black_ and formatting code.
@@ -95,7 +95,7 @@ Support for formatting Python 2 code was removed in version 22.0. While we've ma
 plans to stop supporting older Python 3 minor versions immediately, their support might
 also be removed some time in the future without a deprecation period.
 
-Runtime support for 3.6 was removed in version 22.10.0.
+Runtime support for 3.7 was removed in version 23.7.0.
 
 ## Why does my linter or typechecker complain after I format my code?
 
@@ -107,7 +107,7 @@ codebase with _Black_.
 
 ## Can I run Black with PyPy?
 
-Yes, there is support for PyPy 3.7 and higher.
+Yes, there is support for PyPy 3.8 and higher.
 
 ## Why does Black not detect syntax errors in my code?
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,7 +16,7 @@ Also, you can try out _Black_ online for minimal fuss on the
 
 ## Installation
 
-_Black_ can be installed by running `pip install black`. It requires Python 3.7+ to run.
+_Black_ can be installed by running `pip install black`. It requires Python 3.8+ to run.
 If you want to format Jupyter Notebooks, install with `pip install "black[jupyter]"`.
 
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -236,7 +236,7 @@ Configuration:
 
 #### Installation
 
-This plugin **requires Vim 7.0+ built with Python 3.7+ support**. It needs Python 3.7 to
+This plugin **requires Vim 7.0+ built with Python 3.8+ support**. It needs Python 3.8 to
 be able to run _Black_ inside the Vim process which is much faster than calling an
 external command.
 


### PR DESCRIPTION
### Description

I noticed that the README mentioned _Black_ requiring Python 3.7+ to run even though runtime support for Python 3.7 was dropped in #3765. Running `git grep '3\.7'` revealed a few more outdated mentions.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?