### PR TITLE
added the py311 to target-version config

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -52,18 +52,19 @@ See also [the style documentation](labels/line-length).
 
 #### `-t`, `--target-version`
 
-Python versions that should be supported by Black's output. You should include all
-versions that your code supports. If you support Python 3.7 through 3.11, you should
+Python versions that should be supported by Black's output. You can run `black --help` and look for the `--target-version` option to see the full list of supported versions.
+You should include all
+versions that your code supports. If you support Python 3.8 through 3.11, you should
 write:
 
 ```console
-$ black -t py37 -t py38 -t py39 -t py310 -t py311
+$ black -t py38 -t py39 -t py310 -t py311
 ```
 
 In a [configuration file](#configuration-via-a-file), you can write:
 
 ```toml
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 ```
 
 _Black_ uses this option to decide what grammar to use to parse your code. In addition,

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -53,17 +53,17 @@ See also [the style documentation](labels/line-length).
 #### `-t`, `--target-version`
 
 Python versions that should be supported by Black's output. You should include all
-versions that your code supports. If you support Python 3.7 through 3.10, you should
+versions that your code supports. If you support Python 3.7 through 3.11, you should
 write:
 
 ```console
-$ black -t py37 -t py38 -t py39 -t py310
+$ black -t py37 -t py38 -t py39 -t py310 -t py311
 ```
 
 In a [configuration file](#configuration-via-a-file), you can write:
 
 ```toml
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py37", "py38", "py39", "py310", "py311"]
 ```
 
 _Black_ uses this option to decide what grammar to use to parse your code. In addition,

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -52,10 +52,10 @@ See also [the style documentation](labels/line-length).
 
 #### `-t`, `--target-version`
 
-Python versions that should be supported by Black's output. You can run `black --help` and look for the `--target-version` option to see the full list of supported versions.
-You should include all
-versions that your code supports. If you support Python 3.8 through 3.11, you should
-write:
+Python versions that should be supported by Black's output. You can run `black --help`
+and look for the `--target-version` option to see the full list of supported versions.
+You should include all versions that your code supports. If you support Python 3.8
+through 3.11, you should write:
 
 ```console
 $ black -t py38 -t py39 -t py310 -t py311


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

The documentation currently doesn't share that python 3.11 is supported as part of the `-t, --target-version` flag. This PR updates the documentation to support that.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
Issue: https://github.com/psf/black/issues/3897