### PR TITLE
add support for printing the diff of AST trees when running tests

### DIFF
--- a/docs/contributing/the_basics.md
+++ b/docs/contributing/the_basics.md
@@ -37,6 +37,44 @@ the root of the black repo:
 (.venv)$ tox -e run_self
 ```
 
+### Development
+
+Further examples of invoking the tests
+
+```console
+# Run all of the above mentioned, in parallel
+(.venv)$ tox --parallel=auto
+
+# Run tests on a specific python version
+(.venv)$ tox -e py39
+
+# pass arguments to pytest
+(.venv)$ tox -e py -- --no-cov
+
+# print full tree diff, see documentation below
+(.venv)$ tox -e py -- --print-full-tree
+
+# disable diff printing, see documentation below
+(.venv)$ tox -e py -- --print-tree-diff=False
+```
+
+`Black` has two pytest command-line options for QoL while developing features that uses
+test files in `tests/data/` and are split into an input part, and an output part,
+separated by a line with`# output`. These can be passed to `pytest` through `tox`, or
+directly into pytest if not using `tox`.
+
+#### `--print-full-tree`
+
+Upon a failing test, print the full CST tree as it is after processing the input
+("actual"), and the tree that's yielded after parsing the output ("expected"). Note that
+a test can fail with different output with the same CST tree. This used to be the
+default, but now defaults to `False`.
+
+#### `--print-tree-diff`
+
+Upon a failing test, print the diff of the trees as described above. This is the
+default, to turn it off pass `--print-tree-diff=False`.
+
 ### News / Changelog Requirement
 
 `Black` has CI that will check for an entry corresponding to your PR in `CHANGES.md`. If

--- a/docs/contributing/the_basics.md
+++ b/docs/contributing/the_basics.md
@@ -58,16 +58,16 @@ Further examples of invoking the tests
 (.venv)$ tox -e py -- --print-tree-diff=False
 ```
 
-`Black` has two pytest command-line options affecting
-test files in `tests/data/` that are split into an input part, and an output part,
-separated by a line with`# output`. These can be passed to `pytest` through `tox`, or
-directly into pytest if not using `tox`.
+`Black` has two pytest command-line options affecting test files in `tests/data/` that
+are split into an input part, and an output part, separated by a line with`# output`.
+These can be passed to `pytest` through `tox`, or directly into pytest if not using
+`tox`.
 
 #### `--print-full-tree`
 
-Upon a failing test, print the full concrete syntax tree (CST) as it is after processing the input
-("actual"), and the tree that's yielded after parsing the output ("expected"). Note that
-a test can fail with different output with the same CST. This used to be the
+Upon a failing test, print the full concrete syntax tree (CST) as it is after processing
+the input ("actual"), and the tree that's yielded after parsing the output ("expected").
+Note that a test can fail with different output with the same CST. This used to be the
 default, but now defaults to `False`.
 
 #### `--print-tree-diff`

--- a/docs/contributing/the_basics.md
+++ b/docs/contributing/the_basics.md
@@ -58,22 +58,22 @@ Further examples of invoking the tests
 (.venv)$ tox -e py -- --print-tree-diff=False
 ```
 
-`Black` has two pytest command-line options for QoL while developing features that uses
-test files in `tests/data/` and are split into an input part, and an output part,
+`Black` has two pytest command-line options affecting
+test files in `tests/data/` that are split into an input part, and an output part,
 separated by a line with`# output`. These can be passed to `pytest` through `tox`, or
 directly into pytest if not using `tox`.
 
 #### `--print-full-tree`
 
-Upon a failing test, print the full CST tree as it is after processing the input
+Upon a failing test, print the full concrete syntax tree (CST) as it is after processing the input
 ("actual"), and the tree that's yielded after parsing the output ("expected"). Note that
-a test can fail with different output with the same CST tree. This used to be the
+a test can fail with different output with the same CST. This used to be the
 default, but now defaults to `False`.
 
 #### `--print-tree-diff`
 
 Upon a failing test, print the diff of the trees as described above. This is the
-default, to turn it off pass `--print-tree-diff=False`.
+default. To turn it off pass `--print-tree-diff=False`.
 
 ### News / Changelog Requirement
 

--- a/src/black/debug.py
+++ b/src/black/debug.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Iterator, TypeVar, Union
+from dataclasses import dataclass, field
+from typing import Any, Iterator, List, TypeVar, Union
 
 from black.nodes import Visitor
 from black.output import out
@@ -14,26 +14,33 @@ T = TypeVar("T")
 @dataclass
 class DebugVisitor(Visitor[T]):
     tree_depth: int = 0
+    list_output: List[str] = field(default_factory=list)
+    print_output: bool = True
+
+    def out(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.list_output.append(message)
+        if self.print_output:
+            out(message, *args, **kwargs)
 
     def visit_default(self, node: LN) -> Iterator[T]:
         indent = " " * (2 * self.tree_depth)
         if isinstance(node, Node):
             _type = type_repr(node.type)
-            out(f"{indent}{_type}", fg="yellow")
+            self.out(f"{indent}{_type}", fg="yellow")
             self.tree_depth += 1
             for child in node.children:
                 yield from self.visit(child)
 
             self.tree_depth -= 1
-            out(f"{indent}/{_type}", fg="yellow", bold=False)
+            self.out(f"{indent}/{_type}", fg="yellow", bold=False)
         else:
             _type = token.tok_name.get(node.type, str(node.type))
-            out(f"{indent}{_type}", fg="blue", nl=False)
+            self.out(f"{indent}{_type}", fg="blue", nl=False)
             if node.prefix:
                 # We don't have to handle prefixes for `Node` objects since
                 # that delegates to the first child anyway.
-                out(f" {node.prefix!r}", fg="green", bold=False, nl=False)
-            out(f" {node.value!r}", fg="blue", bold=False)
+                self.out(f" {node.prefix!r}", fg="green", bold=False, nl=False)
+            self.out(f" {node.value!r}", fg="blue", bold=False)
 
     @classmethod
     def show(cls, code: Union[str, Leaf, Node]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--print-full-tree",
         action="store_true",
         default=False,
-        help="print full CST trees on failed tests",
+        help="print full syntax trees on failed tests",
     )
     parser.addoption(
         "--print-tree-diff",
         action="store_true",
         default=True,
-        help="print diff of CST trees on failed tests",
+        help="print diff of syntax trees on failed tests",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,28 @@
+import pytest
+
 pytest_plugins = ["tests.optional"]
+
+PRINT_FULL_TREE: bool = False
+PRINT_TREE_DIFF: bool = True
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--print-full-tree",
+        action="store_true",
+        default=False,
+        help="print full CST trees on failed tests",
+    )
+    parser.addoption(
+        "--print-tree-diff",
+        action="store_true",
+        default=True,
+        help="print diff of CST trees on failed tests",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global PRINT_FULL_TREE
+    global PRINT_TREE_DIFF
+    PRINT_FULL_TREE = config.getoption("--print-full-tree")
+    PRINT_TREE_DIFF = config.getoption("--print-tree-diff")

--- a/tests/util.py
+++ b/tests/util.py
@@ -35,7 +35,7 @@ fs = partial(black.format_str, mode=DEFAULT_MODE)
 
 def _assert_format_equal(expected: str, actual: str) -> None:
     ast_print = not os.environ.get("SKIP_AST_PRINT")
-    ast_print_diff = os.environ.get("SKIP_AST_PRINT_DIFF")
+    ast_print_diff = not os.environ.get("SKIP_AST_PRINT_DIFF")
     if actual != expected and (ast_print or ast_print_diff):
         bdv: DebugVisitor[Any]
         actual_out: str = ""

--- a/tests/util.py
+++ b/tests/util.py
@@ -34,31 +34,32 @@ fs = partial(black.format_str, mode=DEFAULT_MODE)
 
 
 def _assert_format_equal(expected: str, actual: str) -> None:
-    ast_print = not os.environ.get("SKIP_AST_PRINT")
-    ast_print_diff = not os.environ.get("SKIP_AST_PRINT_DIFF")
-    if actual != expected and (ast_print or ast_print_diff):
+    # need to import inside the function for the monkeypatching tests to work
+    from .conftest import PRINT_FULL_TREE, PRINT_TREE_DIFF
+
+    if actual != expected and (PRINT_FULL_TREE or PRINT_TREE_DIFF):
         bdv: DebugVisitor[Any]
         actual_out: str = ""
         expected_out: str = ""
-        if ast_print:
+        if PRINT_FULL_TREE:
             out("Expected tree:", fg="green")
         try:
             exp_node = black.lib2to3_parse(expected)
-            bdv = DebugVisitor(print_output=bool(ast_print))
+            bdv = DebugVisitor(print_output=bool(PRINT_FULL_TREE))
             list(bdv.visit(exp_node))
             expected_out = "\n".join(bdv.list_output)
         except Exception as ve:
             err(str(ve))
-        if ast_print:
+        if PRINT_FULL_TREE:
             out("Actual tree:", fg="red")
         try:
             exp_node = black.lib2to3_parse(actual)
-            bdv = DebugVisitor(print_output=bool(ast_print))
+            bdv = DebugVisitor(print_output=bool(PRINT_FULL_TREE))
             list(bdv.visit(exp_node))
             actual_out = "\n".join(bdv.list_output)
         except Exception as ve:
             err(str(ve))
-        if ast_print_diff:
+        if PRINT_TREE_DIFF:
             out("Tree Diff:")
             out(
                 diff(expected_out, actual_out, "expected tree", "actual tree")

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,6 +12,8 @@ from black.debug import DebugVisitor
 from black.mode import TargetVersion
 from black.output import diff, err, out
 
+from . import conftest
+
 PYTHON_SUFFIX = ".py"
 ALLOWED_SUFFIXES = (PYTHON_SUFFIX, ".pyi", ".out", ".diff", ".ipynb")
 
@@ -34,32 +36,29 @@ fs = partial(black.format_str, mode=DEFAULT_MODE)
 
 
 def _assert_format_equal(expected: str, actual: str) -> None:
-    # need to import inside the function for the monkeypatching tests to work
-    from .conftest import PRINT_FULL_TREE, PRINT_TREE_DIFF
-
-    if actual != expected and (PRINT_FULL_TREE or PRINT_TREE_DIFF):
+    if actual != expected and (conftest.PRINT_FULL_TREE or conftest.PRINT_TREE_DIFF):
         bdv: DebugVisitor[Any]
         actual_out: str = ""
         expected_out: str = ""
-        if PRINT_FULL_TREE:
+        if conftest.PRINT_FULL_TREE:
             out("Expected tree:", fg="green")
         try:
             exp_node = black.lib2to3_parse(expected)
-            bdv = DebugVisitor(print_output=bool(PRINT_FULL_TREE))
+            bdv = DebugVisitor(print_output=conftest.PRINT_FULL_TREE)
             list(bdv.visit(exp_node))
             expected_out = "\n".join(bdv.list_output)
         except Exception as ve:
             err(str(ve))
-        if PRINT_FULL_TREE:
+        if conftest.PRINT_FULL_TREE:
             out("Actual tree:", fg="red")
         try:
             exp_node = black.lib2to3_parse(actual)
-            bdv = DebugVisitor(print_output=bool(PRINT_FULL_TREE))
+            bdv = DebugVisitor(print_output=conftest.PRINT_FULL_TREE)
             list(bdv.visit(exp_node))
             actual_out = "\n".join(bdv.list_output)
         except Exception as ve:
             err(str(ve))
-        if PRINT_TREE_DIFF:
+        if conftest.PRINT_TREE_DIFF:
             out("Tree Diff:")
             out(
                 diff(expected_out, actual_out, "expected tree", "actual tree")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = {,ci-}py{37,38,39,310,311,py3},fuzz,run_self
+envlist = {,ci-}py{38,39,310,311,py3},fuzz,run_self
 
 [testenv]
 setenv =


### PR DESCRIPTION
### Description
As I've been working more on Black, I found the full printing of AST trees to be cumbersome and *insanely long*, but it regardless often containing necessary info, so I ended up modifying the value of that variable a lot and/or temporarily splitting tests into shorter files. But realized that diff-printing would solve that issue, and while not as simple as I'd initially hoped it wasn't too tricky to work out and is turning out very useful. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
      I don't think changes to test QoL warrants entries in `CHANGES.md`
- [x] Add / update tests if necessary?
      Given the precedence of `test_assertFormatEqual` I should probably write one.
- [x] Add new / update outdated documentation?
      `"SKIP_AST_PRINT"` isn't documented anywhere, but it and this should probably be in `CONTRIBUTING.md` and/or the contributing documentation on RTD - it took me a while to find myself.