### PR TITLE
Fix comments getting removed from inside parenthesized strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Fix comments getting removed from inside parenthesized strings (#3909)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -942,6 +942,9 @@ class StringParenStripper(StringTransformer):
                 LL[lpar_or_rpar_idx].remove()  # Remove lpar.
                 replace_child(LL[idx], string_leaf)
                 new_line.append(string_leaf)
+                # replace comments
+                old_comments = new_line.comments.pop(id(LL[idx]), [])
+                new_line.comments.setdefault(id(string_leaf), []).extend(old_comments)
             else:
                 LL[lpar_or_rpar_idx].remove()  # This is a rpar.
 

--- a/tests/data/preview/comments7.py
+++ b/tests/data/preview/comments7.py
@@ -137,6 +137,11 @@ square = Square(4) # type: Optional[Square]
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     ),
 ]
+[
+    (  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ),
+]
 
 # output
 
@@ -296,4 +301,8 @@ square = Square(4)  # type: Optional[Square]
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     ),
 ]
-
+[
+    (  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ),
+]

--- a/tests/data/preview/comments7.py
+++ b/tests/data/preview/comments7.py
@@ -131,6 +131,13 @@ class C:
 
 square = Square(4) # type: Optional[Square]
 
+# Regression test for https://github.com/psf/black/issues/3756.
+[
+    (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ),
+]
+
 # output
 
 from .config import (
@@ -282,3 +289,11 @@ class C:
 
 
 square = Square(4)  # type: Optional[Square]
+
+# Regression test for https://github.com/psf/black/issues/3756.
+[
+    (  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ),
+]
+


### PR DESCRIPTION
### Description

Closes #3756

👋 First PR  c:

in this section:
https://github.com/psf/black/blob/e7c3368c1316c38338cef34fffc42ea3252b1802/src/black/trans.py#L940-L944
`StringParenStripper` was getting an input that looks like this:
```python
Line(leaves=[Leaf(LSQB, '['),
             Leaf(LPAR, '('),
             # ⬇️ this leaf's ID is the key of the comment
             Leaf(STRING, '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'), 
             Leaf(RPAR, ')'),
             Leaf(COMMA, ','),
             Leaf(RSQB, ']')],
     comments={4348688720: [Leaf(COMMENT, '# aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')]},
     ...
)
```
and outputting this:
```python
Line(leaves=[Leaf(LSQB, '['),
             # ⬇️ this is a new leaf with a different ID generated by
             # StringParenStripper, but it didn't update the comment key!
             Leaf(STRING, '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'),
             Leaf(COMMA, ','),
             Leaf(RSQB, ']')],
     comments={4348688720: [Leaf(COMMENT, '# aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')]},
     ...
)
```

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
