### PR TITLE
Parenthesize singleton yield tuples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Fix comments getting removed from inside parenthesized strings (#3909)
+- Parenthesize singleton tuples in `yield` expressions as they already are in `return` statements,
+  e.g. `yield 5,` ➡️ `yield (5,)` (#3912)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Fix comments getting removed from inside parenthesized strings (#3909)
-- Parenthesize singleton tuples in `yield` expressions as they already are in `return` statements,
-  e.g. `yield 5,` ➡️ `yield (5,)` (#3912)
+- Parenthesize singleton tuples in `yield` expressions as they already are in `return`
+  statements, e.g. `yield 5,` ➡️ `yield (5,)` (#3912)
 
 ### Preview style
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -216,6 +216,21 @@ class LineGenerator(Visitor[Line]):
 
             yield from self.visit(child)
 
+    def visit_yield_expr(self, node: Node) -> Iterator[Line]:
+        """
+        If a "yield expr", treat similarly to "return expr",
+        but if it is a "yield from expr", treat expr as a group
+        """
+        content = node.children[1]
+        if content.type != syms.yield_arg:
+            # this is a "yield expr"
+            yield from self.visit_stmt(node, keywords=set(), parens={"yield"})
+            return
+        # this is a "yield from expr"
+        assert isinstance(content, Node)
+        wrap_in_parentheses(content, content.children[1], visible=False)
+        yield from self.visit_default(node)
+
     def visit_typeparams(self, node: Node) -> Iterator[Line]:
         yield from self.visit_default(node)
         node.children[0].prefix = ""
@@ -1414,6 +1429,7 @@ def maybe_make_parens_invisible_in_atom(
             syms.expr_stmt,
             syms.assert_stmt,
             syms.return_stmt,
+            syms.yield_expr,
             syms.except_clause,
             syms.funcdef,
             syms.with_stmt,

--- a/tests/data/simple_cases/parenthesized_yield_tuple.py
+++ b/tests/data/simple_cases/parenthesized_yield_tuple.py
@@ -1,0 +1,101 @@
+async def main():
+    yield x
+    (yield x)
+    await (yield x)
+
+
+# Regression test for https://github.com/psf/black/issues/3851.
+def f():
+    yield x,
+    return x,
+
+    yield (y,)
+    yield from (y,)
+    return (y,)
+
+    yield this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    return this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+
+    yield (this_variable_is_over_the_line_length_limit_of_88_______________________________________,)
+    yield from (this_variable_is_over_the_line_length_limit_of_88_______________________________________,)
+    return (this_variable_is_over_the_line_length_limit_of_88_______________________________________,)
+
+    yield """
+        multiline string
+    """,
+    return """
+        multiline string
+    """,
+
+    yield ("""
+        multiline string
+    """,)
+    yield from ("""
+        multiline string
+    """,)
+    return ("""
+        multiline string
+    """,)
+
+
+# output
+
+
+async def main():
+    yield x
+    (yield x)
+    await (yield x)
+
+
+# Regression test for https://github.com/psf/black/issues/3851.
+def f():
+    yield (x,)
+    return (x,)
+
+    yield (y,)
+    yield from (y,)
+    return (y,)
+
+    yield (
+        this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    )
+    return (
+        this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    )
+
+    yield (
+        this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    )
+    yield from (
+        this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    )
+    return (
+        this_variable_is_over_the_line_length_limit_of_88_______________________________________,
+    )
+
+    yield (
+        """
+        multiline string
+    """,
+    )
+    return (
+        """
+        multiline string
+    """,
+    )
+
+    yield (
+        """
+        multiline string
+    """,
+    )
+    yield from (
+        """
+        multiline string
+    """,
+    )
+    return (
+        """
+        multiline string
+    """,
+    )


### PR DESCRIPTION
### Description

Closes #3851

Please let me know if I should be going along a different path c^: 

I had originally intended to make a `visit_yield_expr = partial(v, keywords={"yield"}, parens={"yield"})` to be more similar to `return` alongside this, but that doesn't work since `yield` can be an expression but `return` can't.  https://github.com/psf/black/blob/1b08cbc63400a8b8e0fbb620b6b2a4dab35e1e7b/src/black/linegen.py#L527 

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
