### PR TITLE
Update output display to job summary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- The action output displayed in the job summary is now wrapped in Markdown (#3914)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,14 @@ runs:
     - name: black
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          python $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY
+          out=$(python $GITHUB_ACTION_PATH/action/main.py)
         else
-          python3 $GITHUB_ACTION_PATH/action/main.py | tee -a $GITHUB_STEP_SUMMARY
+          out=$(python3 $GITHUB_ACTION_PATH/action/main.py)
         fi
+
+        echo "\`\`\`python" >> $GITHUB_STEP_SUMMARY
+        echo "${out}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
       env:
         # TODO: Remove once https://github.com/actions/runner/issues/665 is fixed.
         INPUT_OPTIONS: ${{ inputs.options }}

--- a/action.yml
+++ b/action.yml
@@ -36,14 +36,24 @@ runs:
     - name: black
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          out=$(python $GITHUB_ACTION_PATH/action/main.py)
+          runner="python"
         else
-          out=$(python3 $GITHUB_ACTION_PATH/action/main.py)
+          runner="python3"
         fi
 
+        out=$(${runner} $GITHUB_ACTION_PATH/action/main.py)
+        exit_code=$?
+
+        # Display the raw output in the step
+        echo "${out}"
+
+        # Display the Markdown output in the job summary
         echo "\`\`\`python" >> $GITHUB_STEP_SUMMARY
         echo "${out}" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+        # Exit with the exit-code returned by Black
+        exit ${exit_code}
       env:
         # TODO: Remove once https://github.com/actions/runner/issues/665 is fixed.
         INPUT_OPTIONS: ${{ inputs.options }}


### PR DESCRIPTION
### Description

Black default job summary isn't really readable, since Python code will be converted 1:1 in Markdown, leading to something like this: https://github.com/csalerno-asml/test-black-repo/actions/runs/6380983558#summary-17316480770 

With this proposal, the diff will be wrapped in a triple-quoted python box: https://github.com/csalerno-asml/test-black-repo/actions/runs/6380983558#summary-17316481072

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
