### PR TITLE
exclude tests/data/.* from mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,10 @@ no_implicit_reexport = False
 # to avoid 'em in the first place.
 warn_unreachable=True
 
+# CI only checks src/, but in case users are running LSP or similar we explicitly exclude
+# test data files
+exclude = (?x)(tests/data/.*)
+
 [mypy-blib2to3.driver.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,10 +19,6 @@ no_implicit_reexport = False
 # to avoid 'em in the first place.
 warn_unreachable=True
 
-# CI only checks src/, but in case users are running LSP or similar we explicitly exclude
-# test data files
-exclude = (?x)(tests/data/.*)
-
 [mypy-blib2to3.driver.*]
 ignore_missing_imports = True
 
@@ -43,3 +39,8 @@ ignore_missing_imports = True
 
 [mypy-_black_version.*]
 ignore_missing_imports = True
+
+# CI only checks src/, but in case users are running LSP or similar we explicitly ignore
+# errors in test data files.
+[mypy-tests.data.*]
+ignore_errors = True


### PR DESCRIPTION
### Description
I run pylsp-mypy in my dev environment, which screams loudly about all the illegal stuff being done in `tests/data/.*`. So excluding those files in the mypy config would be a nice QoL for me, and probably other users as well, while making no difference to the CI.

### Checklist - did you ...
None of the below
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?