### PR TITLE
Set Docker to use 3.11 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim AS builder
+FROM python:3.11-slim AS builder
 
 RUN mkdir /src
 COPY . /src/
@@ -10,7 +10,7 @@ RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setupto
     && cd /src \
     && pip install --no-cache-dir .[colorama,d]
 
-FROM python:3-slim
+FROM python:3.11-slim
 
 # copy only Python packages to limit the image size
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
Until we get new aiohttp wheels we need to build with 3.11. You can see an example of a fail here:

Workaround for #3919 - Will leave it open until we can move to 3.12

EDIT: Forgot to add I ran this locally on my box from the root of the black repo:
- `docker build -t black_test --network host .`