### PR TITLE
split long function parameter type hints without parentheses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 - Long type hints are now wrapped in parentheses and properly indented when split across
   multiple lines (#3899)
 - Magic trailing commas are now respected in return types. (#3916)
+- Long type hints in parameter lists now get split across multiple lines and properly
+  indented without being wrapped in parentheses (#3930)
 
 ### Configuration
 

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -67,6 +67,17 @@ class BracketTracker:
     _lambda_argument_depths: List[int] = field(default_factory=list)
     invisible: List[Leaf] = field(default_factory=list)
 
+    def copy(self) -> "BracketTracker":
+        return BracketTracker(
+            self.depth,
+            self.bracket_match.copy(),
+            self.delimiters.copy(),
+            self.previous,
+            self._for_loop_depths.copy(),
+            self._lambda_argument_depths.copy(),
+            self.invisible.copy(),
+        )
+
     def mark(self, leaf: Leaf) -> None:
         """Mark `leaf` with bracket-related metadata. Keep track of delimiters.
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -59,6 +59,16 @@ class Line:
     should_split_rhs: bool = False
     magic_trailing_comma: Optional[Leaf] = None
 
+    def reset(self, depth: Optional[int] = None) -> None:
+        if depth is not None:
+            self.depth = depth
+        self.leaves = []
+        self.comments = {}
+        self.bracket_tracker = BracketTracker()
+        self.inside_brackets = False
+        self.should_split_rhs = False
+        self.magic_trailing_comma = None
+
     def append(
         self, leaf: Leaf, preformatted: bool = False, track_bracket: bool = False
     ) -> None:
@@ -455,6 +465,18 @@ class Line:
                 length += len(comment.value)
 
             yield index, leaf, length
+
+    def deep_copy(self) -> "Line":
+        return Line(
+            mode=self.mode,
+            depth=self.depth,
+            leaves=self.leaves.copy(),
+            comments=self.comments.copy(),
+            bracket_tracker=self.bracket_tracker.copy(),
+            inside_brackets=self.inside_brackets,
+            should_split_rhs=self.should_split_rhs,
+            magic_trailing_comma=self.magic_trailing_comma,
+        )
 
     def clone(self) -> "Line":
         return Line(

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -181,6 +181,7 @@ class Preview(Enum):
     string_processing = auto()
     parenthesize_conditional_expressions = auto()
     parenthesize_long_type_hints = auto()
+    split_long_param_type_without_parens = auto()
     respect_magic_trailing_comma_in_return_type = auto()
     skip_magic_trailing_comma_in_subscript = auto()
     wrap_long_dict_values_in_parens = auto()

--- a/tests/data/preview_py_310/pep604_union_types_line_breaks.py
+++ b/tests/data/preview_py_310/pep604_union_types_line_breaks.py
@@ -83,6 +83,54 @@ def f(
     ...
 
 
+# don't lose comments
+def f(  # 1
+        looooooooooooooooooooooooooong  # 2
+        :  # 3
+        Loooooooooooooooooooooooooooooooooooooooooooooooong  # 4
+        |  # 5
+        Loooooooooooooooooooooooooooooooooooooooooooooooong  # 6
+        =  # 7
+        3  # 8
+        ):  # 9
+    ...  # 10
+
+
+loooooooooooooooooooooooooooooong: (
+    Loooooooooooooooooooooooooooong  # aoeuaoeuaoeuaoeuaoeuaoeu
+)
+
+
+def foo(
+    loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong:
+        Loooooooooooooooooooooooooooong,
+): ...
+
+
+def foo(
+    loooooooooooooooong: Tuple[
+        Looooooooooooooooooooooooooooong, Loooooooooooooong
+    ],  # aoeuaoeuaoeu
+): ...
+
+
+def foo(a: loooooooooooooong| loooooooooooooooooooooooooooong| looooooooooong| looooooooooong = 3): ...
+def foo(c: (loooooooooooooong| loooooooooooooooooooooooooooong| looooooooooong| looooooooooong) = 4): ...
+def foo(bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: bbbbbbbbbbbbbbbbbbbbloooooooooooooong| loooooooooooooooooooooooooooong| looooooooooong| looooooooooong = 5): ...
+def foo(not_too_long_param_name: not_too_long_typehint # but there's a reasonably long comment here
+        ): ...
+def foo(not_too_long_param_name: not_too_long_typehint # but there's a reasonably long comment here
+        | loooooooooooooooooooooooooooong| looooooooooong| looooooooooong = 5): ...
+def foo(a: tuple[int, int,] = (7, 3,)): ...
+def foo(a: (
+    # comment_inside_paren
+            loooooooooooooong
+            # comment2
+            |
+            # comment3
+            loooooooooooooong
+            )): ...
+
 # output
 # This has always worked
 z = (
@@ -158,12 +206,10 @@ def foo(i: (int,)) -> None: ...
 
 def foo(
     i: int,
-    x: (
-        Loooooooooooooooooooooooong
+    x: Loooooooooooooooooooooooong
         | Looooooooooooooooong
         | Looooooooooooooooooooong
-        | Looooooong
-    ),
+        | Looooooong,
     *,
     s: str,
 ) -> None:
@@ -172,16 +218,100 @@ def foo(
 
 @app.get("/path/")
 async def foo(
-    q: str | None = Query(
-        None, title="Some long title", description="Some long description"
-    )
+    q: str
+        | None
+        = Query(None, title="Some long title", description="Some long description")
 ):
     pass
 
 
 def f(
-    max_jobs: int | None = Option(
-        None, help="Maximum number of jobs to launch. And some additional text."
-    ),
+    max_jobs: int
+        | None
+        = Option(
+            None, help="Maximum number of jobs to launch. And some additional text."
+        ),
     another_option: bool = False,
+): ...
+
+
+# don't lose comments
+def f(  # 1
+    looooooooooooooooooooooooooong:  # 2  # 3
+        Loooooooooooooooooooooooooooooooooooooooooooooooong  # 4
+        | Loooooooooooooooooooooooooooooooooooooooooooooooong  # 5  # 6
+        = 3,  # 7  # 8
+):  # 9
+    ...  # 10
+
+
+loooooooooooooooooooooooooooooong: (
+    Loooooooooooooooooooooooooooong  # aoeuaoeuaoeuaoeuaoeuaoeu
+)
+
+
+def foo(
+    loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong:
+        Loooooooooooooooooooooooooooong,
+): ...
+
+
+def foo(
+    loooooooooooooooong: Tuple[
+        Looooooooooooooooooooooooooooong, Loooooooooooooong
+    ],  # aoeuaoeuaoeu
+): ...
+
+
+def foo(
+    a: loooooooooooooong
+        | loooooooooooooooooooooooooooong
+        | looooooooooong
+        | looooooooooong
+        = 3,
+): ...
+def foo(
+    c: loooooooooooooong
+        | loooooooooooooooooooooooooooong
+        | looooooooooong
+        | looooooooooong
+        = 4,
+): ...
+def foo(
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:
+        bbbbbbbbbbbbbbbbbbbbloooooooooooooong
+        | loooooooooooooooooooooooooooong
+        | looooooooooong
+        | looooooooooong
+        = 5,
+): ...
+def foo(
+    not_too_long_param_name:
+        not_too_long_typehint,  # but there's a reasonably long comment here
+): ...
+def foo(
+    not_too_long_param_name:
+        not_too_long_typehint  # but there's a reasonably long comment here
+        | loooooooooooooooooooooooooooong
+        | looooooooooong
+        | looooooooooong
+        = 5,
+): ...
+def foo(
+    a: tuple[
+        int,
+        int,
+    ] = (
+        7,
+        3,
+    )
+): ...
+def foo(
+    a:
+        # comment_inside_paren
+        loooooooooooooong
+        # comment2
+        |
+        # comment3
+        loooooooooooooong,
 ): ...


### PR DESCRIPTION
### Description

Resolves #2316 according to the `nextline` strategy. The poll is currently 10 to 6 of favor of this style, which certainly isn't a slam-dunk, but enough for me to implement it and we can progress the discussion after seeing impacts on existing code.

This is a pretty messy implementation, as can be seen by the sheer length and the complexity check having made me reformat my code several times to break out functions.
I don't love the existence of `_split_first_typehint` and feel like that should be handled on a second pass by `delimiter_split` or something. And likewise I ideally wouldn't need any changes in `visit_tname` after #3899 - I don't really remember why I gave up on resolving it while keeping invisible lpars.

I started out with `append_to_line` being a subfunction like in `delimiter_split` and `standalone_comment_split`, but when the complexity check for good reason wanted me to break up `_split_tname` I ended up having to add some helper functions to `Line` and `BracketTracker`, and while this is not *super* pretty it's probably better than having `append_to_line` repeated three times over in the code - and the other uses of it should probably be changed to use `_append_to_line` as well.

~~I stumbled upon #3834 just as I thought myself done, and realized that case should clearly also be handled without parentheses. I'm not entirely sure why it isn't, but will probably add that to this PR.~~ derp, it can't use the `nextline` strategy as per normal type hints since they're not inside parentheses and not `tname`s. This differentiation being one of the downsides of special-casing parameter lists.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation? (this is maybe noteworthy enough to be documented?)

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
