### PR TITLE
Report all stacktraces in verbose mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@
 
 - Black no longer attempts to provide special errors for attempting to format Python 2
   code (#3933)
+- Black will more consistently print stacktraces on internal errors in verbose mode
+  (#3938)
 
 ### _Blackd_
 

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -173,7 +173,9 @@ async def schedule_formatting(
                 cancelled.append(task)
             elif task.exception():
                 if report.verbose:
-                    traceback.print_exception(task.exception())
+                    exc = task.exception()
+                    assert exc is not None
+                    traceback.print_exception(type(exc), exc, exc.__traceback__)
                 report.failed(src, str(task.exception()))
             else:
                 changed = Changed.YES if task.result() else Changed.NO

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -12,6 +12,7 @@ import sys
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from multiprocessing import Manager
 from pathlib import Path
+import traceback
 from typing import Any, Iterable, Optional, Set
 
 from mypy_extensions import mypyc_attr
@@ -171,6 +172,8 @@ async def schedule_formatting(
             if task.cancelled():
                 cancelled.append(task)
             elif task.exception():
+                if report.verbose:
+                    traceback.print_exception(task.exception())
                 report.failed(src, str(task.exception()))
             else:
                 changed = Changed.YES if task.result() else Changed.NO

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -9,10 +9,10 @@ import logging
 import os
 import signal
 import sys
+import traceback
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from multiprocessing import Manager
 from pathlib import Path
-import traceback
 from typing import Any, Iterable, Optional, Set
 
 from mypy_extensions import mypyc_attr

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -171,7 +171,7 @@ async def schedule_formatting(
             src = tasks.pop(task)
             if task.cancelled():
                 cancelled.append(task)
-            elif (exc := task.exception()):
+            elif exc := task.exception():
                 if report.verbose:
                     traceback.print_exception(type(exc), exc, exc.__traceback__)
                 report.failed(src, str(exc))

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -171,9 +171,7 @@ async def schedule_formatting(
             src = tasks.pop(task)
             if task.cancelled():
                 cancelled.append(task)
-            elif task.exception():
-                exc = task.exception()
-                assert exc is not None
+            elif (exc := task.exception()):
                 if report.verbose:
                     traceback.print_exception(type(exc), exc, exc.__traceback__)
                 report.failed(src, str(exc))

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -172,11 +172,11 @@ async def schedule_formatting(
             if task.cancelled():
                 cancelled.append(task)
             elif task.exception():
+                exc = task.exception()
+                assert exc is not None
                 if report.verbose:
-                    exc = task.exception()
-                    assert exc is not None
                     traceback.print_exception(type(exc), exc, exc.__traceback__)
-                report.failed(src, str(task.exception()))
+                report.failed(src, str(exc))
             else:
                 changed = Changed.YES if task.result() else Changed.NO
                 # If the file was written back or was successfully checked as


### PR DESCRIPTION
Previously these were swallowed; make the reporting more as like `black/__init__.py`