### PR TITLE
CI Test: Deprecating 'Healthcheck.all()' from Hypothesis in fuzz.py

### DIFF
--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -21,7 +21,7 @@ from blib2to3.pgen2.tokenize import TokenError
     max_examples=1000,  # roughly 1k tests/minute, or half that under coverage
     derandomize=True,  # deterministic mode to avoid CI flakiness
     deadline=None,  # ignore Hypothesis' health checks; we already know that
-    suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.
+    suppress_health_check=list(HealthCheck),  # this is slow and filter-heavy.
 )
 @given(
     # Note that while Hypothesmith might generate code unlike that written by


### PR DESCRIPTION
### Description

This PR replaced the deprecating `Healthcheck.all()` method used in the `Fuzz` GitHub Action with latest Hypothesis 
supporting approach.

See their [6.72.0 release](https://hypothesis.readthedocs.io/en/latest/changes.html#v6-72-0) about this deprecation.

Hypothesis has deprecated this method in April, considering they usually remove features after half year of deprecation, it seems appropriate to replace this usage for us as well.

After this fix, there will be no more `HypothesisDeprecationWarning` like this:

![image](https://github.com/psf/black/assets/13176405/9ed37d6b-11bd-438e-ad6a-db88a2931ee5)

### Checklist - did you ...

- [ ] Add an entry in `CHANGES.md` if necessary? not necessary
- [ ] Add / update tests if necessary? not necessary
- [ ] Add new / update outdated documentation? not necessary