### PR TITLE
Add summary parameter to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Python Version specifier (PEP440) - e.g. "21.5b1"'
     required: false
     default: ""
+  summary:
+    description: "Whether to add the output to the workflow summary"
+    required: false
+    default: true
 branding:
   color: "black"
   icon: "check-circle"
@@ -47,10 +51,12 @@ runs:
         # Display the raw output in the step
         echo "${out}"
 
-        # Display the Markdown output in the job summary
-        echo "\`\`\`python" >> $GITHUB_STEP_SUMMARY
-        echo "${out}" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ inputs.summary }}" == "true" ]; then
+          # Display the Markdown output in the job summary
+          echo "\`\`\`python" >> $GITHUB_STEP_SUMMARY
+          echo "${out}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        fi
 
         # Exit with the exit-code returned by Black
         exit ${exit_code}


### PR DESCRIPTION
### Description

I would like to be able to suppress the github workflow summary output. To be able to do that I added a parameter

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->


I did not added anything because I didn't find neither documentation or tests regarding the action (I had a quick look, please help me find them if I am wrong)