### PR TITLE
Move Docker image to hatch + compile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
+- Change Dockerfile to hatch + compile black (#3965)
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
+
 - Change Dockerfile to hatch + compile black (#3965)
 
 ### Parser

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@ FROM python:3.11-slim AS builder
 RUN mkdir /src
 COPY . /src/
 ENV VIRTUAL_ENV=/opt/venv
+ENV HATCH_BUILD_HOOKS_ENABLE=1
 # Install build tools to compile dependencies that don't have prebuilt wheels
 RUN apt update && apt install -y build-essential git python3-dev
 RUN python -m venv $VIRTUAL_ENV
-RUN python -m pip install --no-cache-dir hatch
+RUN python -m pip install --no-cache-dir hatch hatch-fancy-pypi-readme hatch-vcs
 RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setuptools \
     && cd /src && hatch build -t wheel \
-    && pip install --no-cache-dir dist/*[colorama,d]
+    && pip install --no-cache-dir dist/*-cp*[colorama,d,uvloop]
 
 FROM python:3.11-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM python:3.11-slim AS builder
 RUN mkdir /src
 COPY . /src/
 ENV VIRTUAL_ENV=/opt/venv
+# Install build tools to compile dependencies that don't have prebuilt wheels
+RUN apt update && apt install -y build-essential git python3-dev
 RUN python -m venv $VIRTUAL_ENV
-RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setuptools wheel \
-    # Install build tools to compile dependencies that don't have prebuilt wheels
-    && apt update && apt install -y git build-essential \
-    && cd /src \
-    && pip install --no-cache-dir .[colorama,d]
+RUN python -m pip install --no-cache-dir hatch
+RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setuptools \
+    && cd /src && hatch build -t wheel \
+    && pip install --no-cache-dir dist/*[colorama,d]
 
 FROM python:3.11-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /src
 COPY . /src/
 ENV VIRTUAL_ENV=/opt/venv
 ENV HATCH_BUILD_HOOKS_ENABLE=1
-# Install build tools to compile dependencies that don't have prebuilt wheels
+# Install build tools to compile black + dependencies
 RUN apt update && apt install -y build-essential git python3-dev
 RUN python -m venv $VIRTUAL_ENV
 RUN python -m pip install --no-cache-dir hatch hatch-fancy-pypi-readme hatch-vcs

--- a/docs/usage_and_configuration/black_docker_image.md
+++ b/docs/usage_and_configuration/black_docker_image.md
@@ -24,6 +24,8 @@ created for all unreleased
 [commits on the `main` branch](https://github.com/psf/black/commits/main). This tag is
 not meant to be used by external users.
 
+From version 23.11.0 the Docker image installs a compiled black into the image.
+
 ## Usage
 
 A permanent container doesn't have to be created to use _Black_ as a Docker image. It's


### PR DESCRIPTION
- Move to hatch to build wheel
- Install wheel into venv we copy with colorama, d + uvloop

Fixes #3928

Test:
- Build image
  - `docker build -t black_compiled .`
- See we can get black to execute:
```
crl-m1:black cooper$ docker run --rm black_compiled black --version
black, 23.10.1.dev3+g5add198.d20231022 (compiled: yes)
Python (CPython) 3.11.6
```
- Check size: TODO: Update when compiled
```
crl-m1:black cooper$ docker image ls
REPOSITORY                     TAG               IMAGE ID       CREATED          SIZE
black_compiled                 latest            56d4237e8dde   2 minutes ago    186MB
```
