### PR TITLE
Allow empty line after block open before a comment or compound statement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 ### Preview style
 
 - Fix merging implicit multiline strings that have inline comments (#3956)
-- Allow empty first line after block open before a comment or compound statement (#XXXX)
+- Allow empty first line after block open before a comment or compound statement (#3967)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 ### Preview style
 
 - Fix merging implicit multiline strings that have inline comments (#3956)
+- Allow empty first line after block open before a comment or compound statement (#XXXX)
 
 ### Configuration
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -190,6 +190,7 @@ class Preview(Enum):
     module_docstring_newlines = auto()
     accept_raw_docstrings = auto()
     fix_power_op_line_length = auto()
+    allow_empty_first_line_before_new_block_or_comment = auto()
 
 
 class Deprecated(UserWarning):

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -718,6 +718,10 @@ def is_multiline_string(leaf: Leaf) -> bool:
     return has_triple_quotes(leaf.value) and "\n" in leaf.value
 
 
+def is_funcdef(node: Node) -> bool:
+    return node.type == syms.funcdef
+
+
 def is_stub_suite(node: Node) -> bool:
     """Return True if `node` is a suite with a stub body."""
 

--- a/tests/data/cases/preview_allow_empty_first_line_in_special_cases.py
+++ b/tests/data/cases/preview_allow_empty_first_line_in_special_cases.py
@@ -1,0 +1,106 @@
+# flags: --preview
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+    
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123
+
+# output
+
+def foo():
+    """
+    Docstring
+    """
+
+    # Here we go
+    if x:
+
+        # This is also now fine
+        a = 123
+
+    else:
+        # But not necessary
+        a = 123
+
+    if y:
+
+        while True:
+
+            """
+            Long comment here
+            """
+            a = 123
+
+    if z:
+
+        for _ in range(100):
+            a = 123
+    else:
+
+        try:
+
+            # this should be ok
+            a = 123
+        except:
+
+            """also this"""
+            a = 123
+
+
+def bar():
+
+    if x:
+        a = 123
+
+
+def baz():
+
+    # OK
+    if x:
+        a = 123


### PR DESCRIPTION
### Description

I tried to follow the discussion around empty lines after a block open from [issue #3551](https://github.com/psf/black/issues/3551#issuecomment-1545878067). From what I gathered from the different issues linked to this, is that Black won't go back to allowing the empty line at block open, but loosening this rule a bit might be beneficial for some users. This PR enables empty lines after a block open for comments (# comments or """comments""") and compound statements, [as suggested by @JelleZijlstra](https://github.com/psf/black/issues/3551#issuecomment-1545878067). I understand that this is a complicated topic and this change might not be accepted in the end, but just wanted to put this out there, as it seemed like a low-hanging fruit.

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?