### PR TITLE
Fix matching of absolute paths in `--include`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 
 <!-- Changes to how Black can be configured -->
 
-- Fix a bug in the matching of absolute path names in `--include` (#3975)
+- Fix a bug in the matching of absolute path names in `--include` (#3976)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
 <!-- Changes to how Black can be configured -->
 
+- Fix a bug in the matching of absolute path names in `--include` (#3975)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -361,10 +361,6 @@ def gen_python_files(
         if normalized_path is None:
             continue
 
-        normalized_path = "/" + normalized_path
-        if child.is_dir():
-            normalized_path += "/"
-
         if child.is_dir():
             # If gitignore is None, gitignore usage is disabled, while a Falsey
             # gitignore is when the directory doesn't have a .gitignore file.
@@ -393,7 +389,7 @@ def gen_python_files(
                 warn=verbose or not quiet
             ):
                 continue
-            include_match = include.search(normalized_path) if include else True
+            include_match = include.search(root_relative_path) if include else True
             if include_match:
                 yield child
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -361,6 +361,10 @@ def gen_python_files(
         if normalized_path is None:
             continue
 
+        normalized_path = "/" + normalized_path
+        if child.is_dir():
+            normalized_path += "/"
+
         if child.is_dir():
             # If gitignore is None, gitignore usage is disabled, while a Falsey
             # gitignore is when the directory doesn't have a .gitignore file.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2422,7 +2422,6 @@ class TestFileCollection:
 
     @pytest.mark.incompatible_with_mypyc
     def test_symlinks(self) -> None:
-        path = MagicMock()
         root = THIS_DIR.resolve()
         include = re.compile(black.DEFAULT_INCLUDES)
         exclude = re.compile(black.DEFAULT_EXCLUDES)
@@ -2430,19 +2429,44 @@ class TestFileCollection:
         gitignore = PathSpec.from_lines("gitwildmatch", [])
 
         regular = MagicMock()
-        outside_root_symlink = MagicMock()
-        ignored_symlink = MagicMock()
-
-        path.iterdir.return_value = [regular, outside_root_symlink, ignored_symlink]
-
         regular.absolute.return_value = root / "regular.py"
         regular.resolve.return_value = root / "regular.py"
         regular.is_dir.return_value = False
+        regular.is_file.return_value = True
 
+        outside_root_symlink = MagicMock()
         outside_root_symlink.absolute.return_value = root / "symlink.py"
         outside_root_symlink.resolve.return_value = Path("/nowhere")
+        outside_root_symlink.is_dir.return_value = False
+        outside_root_symlink.is_file.return_value = True
 
+        ignored_symlink = MagicMock()
         ignored_symlink.absolute.return_value = root / ".mypy_cache" / "symlink.py"
+        ignored_symlink.is_dir.return_value = False
+        ignored_symlink.is_file.return_value = True
+
+        # A symlink that has an excluded name, but points to an included name
+        symlink_excluded_name = MagicMock()
+        symlink_excluded_name.absolute.return_value = root / "excluded_name"
+        symlink_excluded_name.resolve.return_value = root / "included_name.py"
+        symlink_excluded_name.is_dir.return_value = False
+        symlink_excluded_name.is_file.return_value = True
+
+        # A symlink that has an included name, but points to an excluded name
+        symlink_included_name = MagicMock()
+        symlink_included_name.absolute.return_value = root / "included_name.py"
+        symlink_included_name.resolve.return_value = root / "excluded_name"
+        symlink_included_name.is_dir.return_value = False
+        symlink_included_name.is_file.return_value = True
+
+        path = MagicMock()
+        path.iterdir.return_value = [
+            regular,
+            outside_root_symlink,
+            ignored_symlink,
+            symlink_excluded_name,
+            symlink_included_name,
+        ]
 
         files = list(
             black.gen_python_files(
@@ -2458,7 +2482,7 @@ class TestFileCollection:
                 quiet=False,
             )
         )
-        assert files == [regular]
+        assert files == [regular, symlink_included_name]
 
         path.iterdir.assert_called_once()
         outside_root_symlink.resolve.assert_called_once()

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2395,7 +2395,7 @@ class TestFileCollection:
             Path(path / "b/dont_exclude/a.pie"),
         ]
         assert_collected_sources(
-                src, expected, root=path, include=r"^/b/dont_exclude/a\.pie$", exclude=""
+            src, expected, root=path, include=r"^/b/dont_exclude/a\.pie$", exclude=""
         )
 
     def test_exclude_absolute_path(self) -> None:
@@ -2406,7 +2406,7 @@ class TestFileCollection:
             Path(path / "b/.definitely_exclude/a.py"),
         ]
         assert_collected_sources(
-                src, expected, root=path, include=r"\.py$", exclude=r"^/b/exclude/a\.py$"
+            src, expected, root=path, include=r"\.py$", exclude=r"^/b/exclude/a\.py$"
         )
 
     def test_extend_exclude(self) -> None:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2398,6 +2398,17 @@ class TestFileCollection:
                 src, expected, root=path, include=r"^/b/dont_exclude/a\.pie$", exclude=""
         )
 
+    def test_exclude_absolute_path(self) -> None:
+        path = DATA_DIR / "include_exclude_tests"
+        src = [path]
+        expected = [
+            Path(path / "b/dont_exclude/a.py"),
+            Path(path / "b/.definitely_exclude/a.py"),
+        ]
+        assert_collected_sources(
+                src, expected, root=path, include=r"\.py$", exclude=r"^/b/exclude/a\.py$"
+        )
+
     def test_extend_exclude(self) -> None:
         path = DATA_DIR / "include_exclude_tests"
         src = [path]

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2388,6 +2388,16 @@ class TestFileCollection:
         # Setting exclude explicitly to an empty string to block .gitignore usage.
         assert_collected_sources(src, expected, include="", exclude="")
 
+    def test_include_absolute_path(self) -> None:
+        path = DATA_DIR / "include_exclude_tests"
+        src = [path]
+        expected = [
+            Path(path / "b/dont_exclude/a.pie"),
+        ]
+        assert_collected_sources(
+                src, expected, root=path, include=r"^/b/dont_exclude/a\.pie$", exclude=""
+        )
+
     def test_extend_exclude(self) -> None:
         path = DATA_DIR / "include_exclude_tests"
         src = [path]


### PR DESCRIPTION
### Description

This is a fix for #3975.

It modifies `normalized_path` in the way it was done before #3846, so that the check for included files still matches the same files.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
