### PR TITLE
[3608] Fix using multiple `fmt:skip` pragmas in a single block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 ### Stable style
 
-<!-- Changes that affect Black's stable style -->
+- Fix bug where multiple fmt:skip pragmas inside single block fails (#XXXX)
 
 ### Preview style
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -35,7 +35,7 @@ from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 
 from _black_version import version as __version__
 from black.cache import Cache
-from black.comments import normalize_fmt_off
+from black.comments import normalize_format_skipping
 from black.const import (
     DEFAULT_EXCLUDES,
     DEFAULT_INCLUDES,
@@ -1099,7 +1099,7 @@ def _format_str_once(src_contents: str, *, mode: Mode) -> str:
         for feature in {Feature.PARENTHESIZED_CONTEXT_MANAGERS}
         if supports_feature(versions, feature)
     }
-    normalize_fmt_off(src_node, mode)
+    normalize_format_skipping(src_node, mode)
     lines = LineGenerator(mode=mode, features=context_manager_features)
     elt = EmptyLineTracker(mode=mode)
     split_line_features = {

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -166,8 +166,6 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
                 if prev:
                     if found_fmt_off and prev.type not in WHITESPACE:
                         continue
-                    if found_fmt_skip and prev.type in WHITESPACE:
-                        continue
 
             if found_fmt_off:
                 ignored_nodes = list(_generate_ignored_nodes_from_fmt_off(leaf))

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -196,13 +196,12 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
 
             if found_fmt_off:
                 hidden_value = comment.value + "\n" + hidden_value
+                if hidden_value.endswith("\n"):
+                    # This happens when one of the `ignored_nodes` ended with a NEWLINE
+                    # leaf (possibly followed by a DEDENT).
+                    hidden_value = hidden_value[:-1]
             elif found_fmt_skip:
                 hidden_value += "  " + comment.value
-
-            if hidden_value.endswith("\n"):
-                # This happens when one of the `ignored_nodes` ended with a NEWLINE
-                # leaf (possibly followed by a DEDENT).
-                hidden_value = hidden_value[:-1]
 
             first_idx: Optional[int] = None
             for ignored in ignored_nodes:

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -179,15 +179,16 @@ def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
             first = ignored_nodes[0]  # Can be a container node with the `leaf`.
             parent = first.parent
             prefix = first.prefix
-            if comment.value in FMT_OFF:
+
+            if found_fmt_off:
                 first.prefix = prefix[comment.consumed :]
-            if _contains_fmt_skip_comment(comment.value, mode):
-                first.prefix = ""
-                standalone_comment_prefix = prefix
-            else:
                 standalone_comment_prefix = (
                     prefix[:previous_consumed] + "\n" * comment.newlines
                 )
+            elif found_fmt_skip:
+                first.prefix = ""
+                standalone_comment_prefix = prefix
+
             hidden_value = "".join(str(n) for n in ignored_nodes)
             if comment.value in FMT_OFF:
                 hidden_value = comment.value + "\n" + hidden_value

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -132,17 +132,21 @@ def make_comment(content: str) -> str:
     return "#" + content
 
 
-def normalize_fmt_off(node: Node, mode: Mode) -> None:
-    """Convert content between `# fmt: off`/`# fmt: on` into standalone comments."""
-    try_again = True
-    while try_again:
-        try_again = convert_one_fmt_off_pair(node, mode)
+def normalize_format_skipping(node: Node, mode: Mode) -> None:
+    """Convert content between `# fmt: off`/`# fmt: on` or on a line with `# fmt:skip`
+    into a STANDALONE_COMMENT leaf containing the content to skip formatting for.
+    """
+    more_to_process = True
+    while more_to_process:
+        more_to_process = _convert_one_fmt_off_or_skip(node, mode)
 
 
-def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
-    """Convert content of a single `# fmt: off`/`# fmt: on` into a standalone comment.
+def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
+    """Convert one `# fmt: off`/`# fmt: on` pair or single `# fmt:skip` into a
+    STANDALONE_COMMENT leaf. This removes the leaf range from the tree and inserts
+    the unformatted content as the STANDALONE_COMMENT leaf's value.
 
-    Returns True if a pair was converted.
+    Returns True if a format skip was processed.
     """
     for leaf in node.leaves():
         previous_consumed = 0

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -158,16 +158,15 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
                 previous_consumed = comment.consumed
                 continue
 
-            # We only want standalone comments. If there's no previous leaf or
-            # the previous leaf is indentation, it's a standalone comment in
-            # disguise.
-            if comment.type != STANDALONE_COMMENT:
-                prev = preceding_leaf(leaf)
-                if prev:
-                    if found_fmt_off and prev.type not in WHITESPACE:
+            if found_fmt_off:
+                # We only want standalone comments. If there's no previous leaf or
+                # the previous leaf is indentation, it's a standalone comment in
+                # disguise.
+                if comment.type != STANDALONE_COMMENT:
+                    prev = preceding_leaf(leaf)
+                    if prev and prev.type not in WHITESPACE:
                         continue
 
-            if found_fmt_off:
                 ignored_nodes = list(_generate_ignored_nodes_from_fmt_off(leaf))
             elif found_fmt_skip:
                 ignored_nodes = list(

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -136,9 +136,8 @@ def normalize_format_skipping(node: Node, mode: Mode) -> None:
     """Convert content between `# fmt: off`/`# fmt: on` or on a line with `# fmt:skip`
     into a STANDALONE_COMMENT leaf containing the content to skip formatting for.
     """
-    more_to_process = True
-    while more_to_process:
-        more_to_process = _convert_one_fmt_off_or_skip(node, mode)
+    while _convert_one_fmt_off_or_skip(node, mode):
+        pass
 
 
 def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -147,12 +147,14 @@ def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
     for leaf in node.leaves():
         previous_consumed = 0
         for comment in list_comments(leaf.prefix, is_endmarker=False):
-            should_pass_fmt = comment.value in FMT_OFF or _contains_fmt_skip_comment(
-                comment.value, mode
-            )
-            if not should_pass_fmt:
+            found_fmt_off = comment.value in FMT_OFF
+            found_fmt_skip = _contains_fmt_skip_comment(comment.value, mode)
+            should_skip_formatting = found_fmt_off or found_fmt_skip
+
+            if not should_skip_formatting:
                 previous_consumed = comment.consumed
                 continue
+
             # We only want standalone comments. If there's no previous leaf or
             # the previous leaf is indentation, it's a standalone comment in
             # disguise.

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -190,21 +190,26 @@ def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
                 standalone_comment_prefix = prefix
 
             hidden_value = "".join(str(n) for n in ignored_nodes)
-            if comment.value in FMT_OFF:
+
+            if found_fmt_off:
                 hidden_value = comment.value + "\n" + hidden_value
-            if _contains_fmt_skip_comment(comment.value, mode):
+            elif found_fmt_skip:
                 hidden_value += "  " + comment.value
+
             if hidden_value.endswith("\n"):
-                # That happens when one of the `ignored_nodes` ended with a NEWLINE
+                # This happens when one of the `ignored_nodes` ended with a NEWLINE
                 # leaf (possibly followed by a DEDENT).
                 hidden_value = hidden_value[:-1]
+
             first_idx: Optional[int] = None
             for ignored in ignored_nodes:
                 index = ignored.remove()
                 if first_idx is None:
                     first_idx = index
+
             assert parent is not None, "INTERNAL ERROR: fmt: on/off handling (1)"
             assert first_idx is not None, "INTERNAL ERROR: fmt: on/off handling (2)"
+
             parent.insert_child(
                 first_idx,
                 Leaf(

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -161,12 +161,9 @@ def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
             if comment.type != STANDALONE_COMMENT:
                 prev = preceding_leaf(leaf)
                 if prev:
-                    if comment.value in FMT_OFF and prev.type not in WHITESPACE:
+                    if found_fmt_off and prev.type not in WHITESPACE:
                         continue
-                    if (
-                        _contains_fmt_skip_comment(comment.value, mode)
-                        and prev.type in WHITESPACE
-                    ):
+                    if found_fmt_skip and prev.type in WHITESPACE:
                         continue
 
             ignored_nodes = list(generate_ignored_nodes(leaf, comment, mode))

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -156,7 +156,7 @@ def convert_one_fmt_off_pair(node: Node, mode: Mode) -> bool:
             # We only want standalone comments. If there's no previous leaf or
             # the previous leaf is indentation, it's a standalone comment in
             # disguise.
-            if should_pass_fmt and comment.type != STANDALONE_COMMENT:
+            if comment.type != STANDALONE_COMMENT:
                 prev = preceding_leaf(leaf)
                 if prev:
                     if comment.value in FMT_OFF and prev.type not in WHITESPACE:

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -160,9 +160,9 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
                 continue
 
             (ignored_nodes, hidden_value, standalone_comment_prefix) = (
-                _gather_fmt_off_data(leaf, comment, previous_consumed)
+                _gather_data_for_fmt_off(leaf, comment, previous_consumed)
                 if found_fmt_off
-                else _gather_fmt_skip_data(leaf, comment)
+                else _gather_data_for_fmt_skip(leaf, comment)
             )
 
             if not ignored_nodes:
@@ -194,7 +194,7 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
     return False
 
 
-def _gather_fmt_off_data(
+def _gather_data_for_fmt_off(
     leaf: Leaf, comment: ProtoComment, previous_consumed: int
 ) -> Tuple[List[LN], str, str]:
     # We only want standalone comments. If there's no previous leaf or
@@ -225,7 +225,7 @@ def _gather_fmt_off_data(
     return (ignored_nodes, hidden_value, standalone_comment_prefix)
 
 
-def _gather_fmt_skip_data(
+def _gather_data_for_fmt_skip(
     leaf: Leaf, comment: ProtoComment
 ) -> Tuple[List[LN], str, str]:
     ignored_nodes = list(_generate_ignored_nodes_from_fmt_skip(leaf, comment))

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -209,8 +209,8 @@ def _convert_one_fmt_off_or_skip(node: Node, mode: Mode) -> bool:
                 if first_idx is None:
                     first_idx = index
 
-            assert parent is not None, "INTERNAL ERROR: fmt: on/off handling (1)"
-            assert first_idx is not None, "INTERNAL ERROR: fmt: on/off handling (2)"
+            assert parent is not None, "INTERNAL ERROR: format skipping handling (1)"
+            assert first_idx is not None, "INTERNAL ERROR: format skipping handling (2)"
 
             parent.insert_child(
                 first_idx,

--- a/tests/data/cases/fmtskip5.py
+++ b/tests/data/cases/fmtskip5.py
@@ -17,6 +17,11 @@ if (
 else:
     print("I'm bad")
 
+x = [
+    1      ,  # fmt: skip
+    2   ,
+    3 , 4  # fmt: skip
+]
 
 # output
 
@@ -38,3 +43,9 @@ if (
     print("I'm good!")
 else:
     print("I'm bad")
+
+x = [
+    1      ,  # fmt: skip
+    2,
+    3 , 4  # fmt: skip
+]

--- a/tests/data/cases/fmtskip5.py
+++ b/tests/data/cases/fmtskip5.py
@@ -8,12 +8,30 @@ if (
 else:
     print("I'm bad")
 
+if (
+    a ==    3  # fmt: skip
+    and b    != 9  # fmt: skip
+    and c is not None
+):
+    print("I'm good!")
+else:
+    print("I'm bad")
+
 
 # output
 
 a, b, c = 3, 4, 5
 if (
     a == 3
+    and b    != 9  # fmt: skip
+    and c is not None
+):
+    print("I'm good!")
+else:
+    print("I'm bad")
+
+if (
+    a ==    3  # fmt: skip
     and b    != 9  # fmt: skip
     and c is not None
 ):

--- a/tests/data/cases/preview_single_line_format_skip_with_multiple_comments.py
+++ b/tests/data/cases/preview_single_line_format_skip_with_multiple_comments.py
@@ -12,7 +12,7 @@ skip_will_not_work2 =  "a" +  "b"  # some text; fmt:skip happens to be part of i
 
 foo =  123  # fmt: skip # noqa: E501 # pylint
 bar = (
-    123   ,
+    123,
     (        1      +           5      )  # pylint # fmt:skip
 )
 baz = "a"    +   "b"  # pylint; fmt: skip; noqa: E501


### PR DESCRIPTION
### Description

This PR contains some refactoring to `comments.py`, as the code was not the cleanest and comments/naming were not up to date. This also fixes bugs with using multiple `fmt: skip` pragmas inside a single block, originally reported [here](https://github.com/psf/black/issues/3608).
Due to the refactoring, this PR is in small commits, so it's easier to review the changes piece by piece.

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?