### PR TITLE
Check excludes before symlink resolution for command line parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
 
 - Add support for single line format skip with other comments on the same line (#3959)
 - File exclusion and inclusion logic is now consistently applied before symlink
-  resolution. (#3987, #3976)
+  resolution. (#3987) (#3976)
 - Fix a bug in the matching of absolute path names in `--include` (#3976)
 
 ### Packaging

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@
 ### Configuration
 
 - Add support for single line format skip with other comments on the same line (#3959)
-
+- File exclusion and inclusion logic is now consistently applied before symlink
+  resolution. (#3987, #3976)
 - Fix a bug in the matching of absolute path names in `--include` (#3976)
 
 ### Packaging

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -50,6 +50,7 @@ from black.files import (
     get_gitignore,
     normalize_path_maybe_ignore,
     parse_pyproject_toml,
+    path_is_excluded,
     wrap_stream_for_windows,
 )
 from black.handle_ipynb_magics import (
@@ -639,25 +640,26 @@ def get_sources(
             is_stdin = False
 
         if is_stdin or p.is_file():
+            root_relative_path = p.absolute().relative_to(root).as_posix()
+
+            root_relative_path = "/" + root_relative_path
+            if p.is_dir():
+                root_relative_path += "/"
+
+            # Hard-exclude any files that matches the `--force-exclude` regex.
+            if path_is_excluded(root_relative_path, force_exclude):
+                report.path_ignored(p, "matches the --force-exclude regular expression")
+                continue
+
             normalized_path: Optional[str] = normalize_path_maybe_ignore(
                 p, root, report
             )
             if normalized_path is None:
                 if verbose:
-                    out(f'Skipping invalid source: "{normalized_path}"', fg="red")
+                    out(f'Skipping invalid source: "{p}"', fg="red")
                 continue
             if verbose:
-                out(f'Found input source: "{normalized_path}"', fg="blue")
-
-            normalized_path = "/" + normalized_path
-            # Hard-exclude any files that matches the `--force-exclude` regex.
-            if force_exclude:
-                force_exclude_match = force_exclude.search(normalized_path)
-            else:
-                force_exclude_match = None
-            if force_exclude_match and force_exclude_match.group(0):
-                report.path_ignored(p, "matches the --force-exclude regular expression")
-                continue
+                out(f'Found input source: "{p}"', fg="blue")
 
             if is_stdin:
                 p = Path(f"{STDIN_PLACEHOLDER}{str(p)}")


### PR DESCRIPTION
### Description

This adjusts exclusion checking for command line parameters the same way as #3846 did for other files. Specifically, `--force-exclude` is now checked before symlink resolution. This way symlink handling is consistent between command line parameters and other collected files.
    
Fixes #3826.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
