### PR TITLE
Hug parens also with multiline unpacking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 - Multiline dictionaries and lists that are the sole argument to a function are now
   indented less (#3964)
 - Multiline list unpacking as the sole argument to a function is now also indented less
-  (#XXXX)
+  (#3992)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,8 @@
 
 - Multiline dictionaries and lists that are the sole argument to a function are now
   indented less (#3964)
-- Multiline list unpacking as the sole argument to a function is now also indented less
-  (#3992)
+- Multiline list and dict unpacking as the sole argument to a function is now also
+  indented less (#3992)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 - Multiline dictionaries and lists that are the sole argument to a function are now
   indented less (#3964)
+- Multiline list unpacking as the sole argument to a function is now also indented less
+  (#XXXX)
 
 ### Configuration
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -139,7 +139,7 @@ foo([
 ])
 ```
 
-This also applies to list unpacking:
+This also applies to list and dictionary unpacking:
 
 ```python
 foo(

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -144,9 +144,8 @@ This also applies to list unpacking:
 ```python
 foo(
     *[
-        1,
-        2,
-        3,
+        a_long_function_name(a_long_variable_name)
+        for a_long_variable_name in some_generator
     ]
 )
 ```
@@ -155,9 +154,8 @@ will become:
 
 ```python
 foo(*[
-    1,
-    2,
-    3,
+    a_long_function_name(a_long_variable_name)
+    for a_long_variable_name in some_generator
 ])
 ```
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -139,6 +139,28 @@ foo([
 ])
 ```
 
+This also applies to list unpacking:
+
+```python
+foo(
+    *[
+        1,
+        2,
+        3,
+    ]
+)
+```
+
+will become:
+
+```python
+foo(*[
+    1,
+    2,
+    3,
+])
+```
+
 You can use a magic trailing comma to avoid this compacting behavior; by default,
 _Black_ will not reformat the following code:
 

--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -124,9 +124,9 @@ class Cache:
 
     def write(self, sources: Iterable[Path]) -> None:
         """Update the cache file data and write a new cache file."""
-        self.file_data.update(
-            **{str(src.resolve()): Cache.get_file_data(src) for src in sources}
-        )
+        self.file_data.update(**{
+            str(src.resolve()): Cache.get_file_data(src) for src in sources
+        })
         try:
             CACHE_DIR.mkdir(parents=True, exist_ok=True)
             with tempfile.NamedTemporaryFile(

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -817,16 +817,17 @@ def _first_right_hand_split(
     head_leaves.reverse()
 
     if Preview.hug_parens_with_braces_and_square_brackets in line.mode:
+        is_unpacking = 1 if body_leaves[0].type == token.STAR else 0
         if (
             tail_leaves[0].type == token.RPAR
             and tail_leaves[0].value
             and tail_leaves[0].opening_bracket is head_leaves[-1]
             and body_leaves[-1].type in [token.RBRACE, token.RSQB]
-            and body_leaves[-1].opening_bracket is body_leaves[0]
+            and body_leaves[-1].opening_bracket is body_leaves[is_unpacking]
         ):
-            head_leaves = head_leaves + body_leaves[:1]
+            head_leaves = head_leaves + body_leaves[: 1 + is_unpacking]
             tail_leaves = body_leaves[-1:] + tail_leaves
-            body_leaves = body_leaves[1:-1]
+            body_leaves = body_leaves[1 + is_unpacking : -1]
 
     head = bracket_split_build_line(
         head_leaves, line, opening_bracket, component=_BracketSplitComponent.head

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -817,7 +817,7 @@ def _first_right_hand_split(
     head_leaves.reverse()
 
     if Preview.hug_parens_with_braces_and_square_brackets in line.mode:
-        is_unpacking = 1 if body_leaves[0].type == token.STAR else 0
+        is_unpacking = 1 if body_leaves[0].type in [token.STAR, token.DOUBLESTAR] else 0
         if (
             tail_leaves[0].type == token.RPAR
             and tail_leaves[0].value

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -150,6 +150,8 @@ foo(
     }
 )
 
+foo(**{x: y for x, y in enumerate(["long long long long line","long long long long line"])})
+
 # output
 def foo_brackets(request):
     return JsonResponse({
@@ -316,4 +318,8 @@ foo(**{
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
     "ccccccccccccccccccccccccccccccccc": 3,
     **other,
+})
+
+foo(**{
+    x: y for x, y in enumerate(["long long long long line", "long long long long line"])
 })

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -137,6 +137,8 @@ baaaaaaaaaaaaar(
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], {x}, "a string", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 )
 
+foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
+
 # output
 def foo_brackets(request):
     return JsonResponse({
@@ -287,3 +289,9 @@ foooooooooooooooooooo(
 baaaaaaaaaaaaar(
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], {x}, "a string", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 )
+
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -139,6 +139,8 @@ baaaaaaaaaaaaar(
 
 foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
 
+foo(*[str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)])
+
 # output
 def foo_brackets(request):
     return JsonResponse({
@@ -294,4 +296,8 @@ foo(*[
     "long long long long long line",
     "long long long long long line",
     "long long long long long line",
+])
+
+foo(*[
+    str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)
 ])

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -141,6 +141,15 @@ foo(*["long long long long long line", "long long long long long line", "long lo
 
 foo(*[str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)])
 
+foo(
+    **{
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
+        "ccccccccccccccccccccccccccccccccc": 3,
+        **other,
+    }
+)
+
 # output
 def foo_brackets(request):
     return JsonResponse({
@@ -301,3 +310,10 @@ foo(*[
 foo(*[
     str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)
 ])
+
+foo(**{
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": 1,
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": 2,
+    "ccccccccccccccccccccccccccccccccc": 3,
+    **other,
+})


### PR DESCRIPTION
### Description

As noted by @Avasam [here](https://github.com/psf/black/pull/3964#issuecomment-1783318353), hugging parens with brackets on multiline dictionaries and lists as sole function parameters didn't take into account list/dict unpacking. This PR fixes that shortcoming.

### Checklist - did you ...

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?