### PR TITLE
Minor refactoring in get_sources and gen_python_files

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -632,15 +632,15 @@ def get_sources(
 
     for s in src:
         if s == "-" and stdin_filename:
-            p = Path(stdin_filename)
+            path = Path(stdin_filename)
             is_stdin = True
         else:
-            p = Path(s)
+            path = Path(s)
             is_stdin = False
 
-        if is_stdin or p.is_file():
+        if is_stdin or path.is_file():
             normalized_path: Optional[str] = normalize_path_maybe_ignore(
-                p, root, report
+                path, root, report
             )
             if normalized_path is None:
                 if verbose:
@@ -656,33 +656,35 @@ def get_sources(
             else:
                 force_exclude_match = None
             if force_exclude_match and force_exclude_match.group(0):
-                report.path_ignored(p, "matches the --force-exclude regular expression")
+                report.path_ignored(
+                    path, "matches the --force-exclude regular expression"
+                )
                 continue
 
             if is_stdin:
-                p = Path(f"{STDIN_PLACEHOLDER}{str(p)}")
+                path = Path(f"{STDIN_PLACEHOLDER}{str(path)}")
 
-            if p.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
+            if path.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
                 warn=verbose or not quiet
             ):
                 continue
 
-            sources.add(p)
-        elif p.is_dir():
-            p_relative = normalize_path_maybe_ignore(p, root, report)
+            sources.add(path)
+        elif path.is_dir():
+            p_relative = normalize_path_maybe_ignore(path, root, report)
             assert p_relative is not None
-            p = root / p_relative
+            path = root / p_relative
             if verbose:
-                out(f'Found input source directory: "{p}"', fg="blue")
+                out(f'Found input source directory: "{path}"', fg="blue")
 
             if using_default_exclude:
                 gitignore = {
                     root: root_gitignore,
-                    p: get_gitignore(p),
+                    path: get_gitignore(path),
                 }
             sources.update(
                 gen_python_files(
-                    p.iterdir(),
+                    path.iterdir(),
                     root,
                     include,
                     exclude,
@@ -697,7 +699,7 @@ def get_sources(
         elif s == "-":
             if verbose:
                 out("Found input source stdin", fg="blue")
-            sources.add(p)
+            sources.add(path)
         else:
             err(f"invalid path: {s}")
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -668,9 +668,7 @@ def get_sources(
 
             sources.add(path)
         elif path.is_dir():
-            p_relative = normalize_path_maybe_ignore(path, root, report)
-            assert p_relative is not None
-            path = root / p_relative
+            path = root / (path.resolve().relative_to(root))
             if verbose:
                 out(f'Found input source directory: "{path}"', fg="blue")
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -50,6 +50,7 @@ from black.files import (
     get_gitignore,
     normalize_path_maybe_ignore,
     parse_pyproject_toml,
+    path_is_excluded,
     wrap_stream_for_windows,
 )
 from black.handle_ipynb_magics import (
@@ -651,11 +652,7 @@ def get_sources(
 
             normalized_path = "/" + normalized_path
             # Hard-exclude any files that matches the `--force-exclude` regex.
-            if force_exclude:
-                force_exclude_match = force_exclude.search(normalized_path)
-            else:
-                force_exclude_match = None
-            if force_exclude_match and force_exclude_match.group(0):
+            if path_is_excluded(normalized_path, force_exclude):
                 report.path_ignored(
                     path, "matches the --force-exclude regular expression"
                 )

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -280,7 +280,6 @@ def _path_is_ignored(
     root_relative_path: str,
     root: Path,
     gitignore_dict: Dict[Path, PathSpec],
-    report: Report,
 ) -> bool:
     path = root / root_relative_path
     # Note that this logic is sensitive to the ordering of gitignore_dict. Callers must
@@ -291,9 +290,6 @@ def _path_is_ignored(
         except ValueError:
             break
         if pattern.match_file(relative_path):
-            report.path_ignored(
-                path.relative_to(root), "matches a .gitignore file content"
-            )
             return True
     return False
 
@@ -334,8 +330,9 @@ def gen_python_files(
 
         # First ignore files matching .gitignore, if passed
         if gitignore_dict and _path_is_ignored(
-            root_relative_path, root, gitignore_dict, report
+            root_relative_path, root, gitignore_dict
         ):
+            report.path_ignored(child, "matches a .gitignore file content")
             continue
 
         # Then ignore with `--exclude` `--extend-exclude` and `--force-exclude` options.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -504,7 +504,7 @@ class BlackTestCase(BlackBaseTestCase):
             return _mocked_calls
 
         with patch("pathlib.Path.iterdir", return_value=target_contents), patch(
-            "pathlib.Path.cwd", return_value=working_directory
+            "pathlib.Path.resolve", return_value=target_abspath
         ), patch("pathlib.Path.is_dir", side_effect=mock_n_calls([True])):
             # Note that the root folder (project_root) isn't the folder
             # named "root" (aka working_directory)
@@ -526,7 +526,8 @@ class BlackTestCase(BlackBaseTestCase):
             for _, mock_args, _ in report.path_ignored.mock_calls
         ), "A symbolic link was reported."
         report.path_ignored.assert_called_once_with(
-            Path("root", "child", "b.py"), "matches a .gitignore file content"
+            Path(working_directory, "child", "b.py"),
+            "matches a .gitignore file content",
         )
 
     def test_report_verbose(self) -> None:


### PR DESCRIPTION
These changes are basically a no-op. The logic in these two functions is quite similar. In the next PR I make, I'll fix https://github.com/psf/black/issues/3826 by making the logic in `get_sources` match the newer logic in `gen_python_files`. This PR separates out non-functional changes from that functional change.

Can be reviewed commit by commit. The last commit is probably the most notable; it would change an AssertionError into whatever the underlying error is.