### PR TITLE
Apply force exclude logic before symlink resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@
 ### Configuration
 
 - Add support for single-line format skip with other comments on the same line (#3959)
-
+- Consistently apply force exclusion logic before resolving symlinks (#4015)
 - Fix a bug in the matching of absolute path names in `--include` (#3976)
 
 ### Packaging

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -652,7 +652,9 @@ def get_sources(
                 )
                 continue
 
-            normalized_path = normalize_path_maybe_ignore(path, root, report)
+            normalized_path: Optional[str] = normalize_path_maybe_ignore(
+                path, root, report
+            )
             if normalized_path is None:
                 if verbose:
                     out(f'Skipping invalid source: "{normalized_path}"', fg="red")

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -639,23 +639,23 @@ def get_sources(
             path = Path(s)
             is_stdin = False
 
+        # Compare the logic here to the logic in `gen_python_files`.
         if is_stdin or path.is_file():
-            normalized_path: Optional[str] = normalize_path_maybe_ignore(
-                path, root, report
-            )
-            if normalized_path is None:
-                if verbose:
-                    out(f'Skipping invalid source: "{normalized_path}"', fg="red")
-                continue
-            if verbose:
-                out(f'Found input source: "{normalized_path}"', fg="blue")
+            root_relative_path = path.absolute().relative_to(root).as_posix()
 
-            normalized_path = "/" + normalized_path
+            root_relative_path = "/" + root_relative_path
+
             # Hard-exclude any files that matches the `--force-exclude` regex.
-            if path_is_excluded(normalized_path, force_exclude):
+            if path_is_excluded(root_relative_path, force_exclude):
                 report.path_ignored(
                     path, "matches the --force-exclude regular expression"
                 )
+                continue
+
+            normalized_path = normalize_path_maybe_ignore(path, root, report)
+            if normalized_path is None:
+                if verbose:
+                    out(f'Skipping invalid source: "{normalized_path}"', fg="red")
                 continue
 
             if is_stdin:
@@ -666,6 +666,8 @@ def get_sources(
             ):
                 continue
 
+            if verbose:
+                out(f'Found input source: "{normalized_path}"', fg="blue")
             sources.add(path)
         elif path.is_dir():
             path = root / (path.resolve().relative_to(root))

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2552,6 +2552,23 @@ class TestFileCollection:
             stdin_filename=stdin_filename,
         )
 
+    @patch("black.find_project_root", lambda *args: (THIS_DIR.resolve(), None))
+    def test_get_sources_with_stdin_filename_and_force_exclude_and_symlink(
+        self,
+    ) -> None:
+        # Force exclude should exclude a symlink based on the symlink, not its target
+        path = THIS_DIR / "data" / "include_exclude_tests"
+        stdin_filename = str(path / "symlink.py")
+        expected = [f"__BLACK_STDIN_FILENAME__{stdin_filename}"]
+        target = path / "b/exclude/a.py"
+        with patch("pathlib.Path.resolve", return_value=target):
+            assert_collected_sources(
+                src=["-"],
+                expected=expected,
+                force_exclude=r"exclude/a\.py",
+                stdin_filename=stdin_filename,
+            )
+
 
 class TestDeFactoAPI:
     """Test that certain symbols that are commonly used externally keep working.


### PR DESCRIPTION
Fixes #3826. Similar to #3846 that changed `gen_python_files`, but for `get_sources`