### PR TITLE
Remove redundant condition from `has_magic_trailing_comma`

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -363,25 +363,6 @@ class Line:
             ):
                 return False
 
-            if not ensure_removable:
-                return True
-
-            comma = self.leaves[-1]
-            if comma.parent is None:
-                return False
-
-            if (
-                comma.parent.type == syms.subscriptlist
-                and closing.opening_bracket is not None
-                and is_one_sequence_between(
-                    closing.opening_bracket,
-                    closing,
-                    self.leaves,
-                    brackets=(token.LSQB, token.RSQB),
-                )
-            ):
-                return False
-
             return True
 
         if self.is_import:

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -351,9 +351,9 @@ class Line:
 
         if closing.type == token.RSQB:
             if (
-                closing.parent
+                closing.parent is not None
                 and closing.parent.type == syms.trailer
-                and closing.opening_bracket
+                and closing.opening_bracket is not None
                 and is_one_sequence_between(
                     closing.opening_bracket,
                     closing,
@@ -369,16 +369,20 @@ class Line:
             comma = self.leaves[-1]
             if comma.parent is None:
                 return False
-            return (
-                comma.parent.type != syms.subscriptlist
-                or closing.opening_bracket is None
-                or not is_one_sequence_between(
+
+            if (
+                comma.parent.type == syms.subscriptlist
+                and closing.opening_bracket is not None
+                and is_one_sequence_between(
                     closing.opening_bracket,
                     closing,
                     self.leaves,
                     brackets=(token.LSQB, token.RSQB),
                 )
-            )
+            ):
+                return False
+
+            return True
 
         if self.is_import:
             return True


### PR DESCRIPTION
Simplify the `has_magic_trailing_comma` logic (it will make #3918 a bit easier to implement).

The second `if` cannot be true at its execution point, because it is already covered by the first `if`. The condition
`comma.parent.type == syms.subscriptlist` always holds if `closing.parent.type == syms.trailer` holds, because `subscriptlist` only appears inside `trailer` in the grammar:

```
trailer: '(' [arglist] ')' | '[' subscriptlist ']' | '.' NAME
subscriptlist: (subscript|star_expr) (',' (subscript|star_expr))* [',']
```

NOTE: I split the PR to two commits, the first one is just a refactor with no logical changes, but makes the argument above easier to follow. The commits should be squashed when merging.