### PR TITLE
Preview: Keep requiring two empty lines between module-level docstring and first function or class definition.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   indented less (#3964)
 - Multiline list and dict unpacking as the sole argument to a function is now also
   indented less (#3992)
+- Keep requiring two empty lines between module-level docstring and first function or
+  class definition. (#4028)
 
 ### Configuration
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -578,6 +578,7 @@ class EmptyLineTracker:
             and self.previous_block.previous_block is None
             and len(self.previous_block.original_line.leaves) == 1
             and self.previous_block.original_line.is_triple_quoted_string
+            and not (current_line.is_class or current_line.is_def)
         ):
             before = 1
 

--- a/tests/data/cases/module_docstring_followed_by_class.py
+++ b/tests/data/cases/module_docstring_followed_by_class.py
@@ -1,0 +1,11 @@
+# flags: --preview
+"""Two blank lines between module docstring and a class."""
+class MyClass:
+    pass
+
+# output
+"""Two blank lines between module docstring and a class."""
+
+
+class MyClass:
+    pass

--- a/tests/data/cases/module_docstring_followed_by_function.py
+++ b/tests/data/cases/module_docstring_followed_by_function.py
@@ -1,0 +1,11 @@
+# flags: --preview
+"""Two blank lines between module docstring and a function def."""
+def function():
+    pass
+
+# output
+"""Two blank lines between module docstring and a function def."""
+
+
+def function():
+    pass


### PR DESCRIPTION
Fixes #4027.

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
