### PR TITLE
Disable the stability check with --line-ranges for now.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
 
 <!-- Changes to how Black can be configured -->
 
+- `--line-ranges` now skips _Black_'s internal stability check in `--safe` mode. This
+  avoids a crash on rare inputs that have many unformatted same-content lines. (#4034)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -196,7 +196,11 @@ Example: `black --line-ranges=1-10 --line-ranges=21-30 test.py` will format line
 
 This option is mainly for editor integrations, such as "Format Selection".
 
-Currently it also disables _Black_'s formatting stability check in `--safe` mode.
+```{note}
+Due to #4052, `--line-ranges` might format extra lines outside of the ranges when there
+are unformatted lines with the exact content. It also disables _Black_'s formatting
+stability check in `--safe` mode.
+```
 
 #### `--color` / `--no-color`
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -192,6 +192,8 @@ Example: `black --line-ranges=1-10 --line-ranges=21-30 test.py` will format line
 
 This option is mainly for editor integrations, such as "Format Selection".
 
+Currently it also disables _Black_'s formatting stability check in `--safe` mode.
+
 #### `--color` / `--no-color`
 
 Show (or do not show) colored diff. Only applies when `--diff` is given.

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -197,7 +197,7 @@ Example: `black --line-ranges=1-10 --line-ranges=21-30 test.py` will format line
 This option is mainly for editor integrations, such as "Format Selection".
 
 ```{note}
-Due to #4052, `--line-ranges` might format extra lines outside of the ranges when there
+Due to [#4052](https://github.com/psf/black/issues/4052), `--line-ranges` might format extra lines outside of the ranges when there
 are unformatted lines with the exact content. It also disables _Black_'s formatting
 stability check in `--safe` mode.
 ```

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -197,9 +197,9 @@ Example: `black --line-ranges=1-10 --line-ranges=21-30 test.py` will format line
 This option is mainly for editor integrations, such as "Format Selection".
 
 ```{note}
-Due to [#4052](https://github.com/psf/black/issues/4052), `--line-ranges` might format extra lines outside of the ranges when there
-are unformatted lines with the exact content. It also disables _Black_'s formatting
-stability check in `--safe` mode.
+Due to [#4052](https://github.com/psf/black/issues/4052), `--line-ranges` might format
+extra lines outside of the ranges when ther are unformatted lines with the exact
+content. It also disables _Black_'s formatting stability check in `--safe` mode.
 ```
 
 #### `--color` / `--no-color`

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1465,11 +1465,16 @@ def assert_stable(
     src: str, dst: str, mode: Mode, *, lines: Collection[Tuple[int, int]] = ()
 ) -> None:
     """Raise AssertionError if `dst` reformats differently the second time."""
+    if lines:
+        # Formatting specified lines requires `adjusted_lines` to map original lines
+        # to the formatted lines before re-formatting the previously formatted result.
+        # Due to less-ideal diff algorithm, some edge cases produce incorrect new line
+        # ranges. Hence for now, we skip the stable check.
+        # See https://github.com/psf/black/issues/4033 for context.
+        return
     # We shouldn't call format_str() here, because that formats the string
     # twice and may hide a bug where we bounce back and forth between two
     # versions.
-    if lines:
-        lines = adjusted_lines(lines, src, dst)
     newdst = _format_str_once(dst, mode=mode, lines=lines)
     if dst != newdst:
         log = dump_to_file(

--- a/tests/data/cases/line_ranges_diff_edge_case.py
+++ b/tests/data/cases/line_ranges_diff_edge_case.py
@@ -1,0 +1,28 @@
+# flags: --line-ranges=8-9
+# NOTE: If you need to modify this file, pay special attention to the --line-ranges=
+# flag above as it's formatting specifically these lines.
+
+# Reproducible example for https://github.com/psf/black/issues/4033.
+# This can be fixed in the future if we use a better diffing algorithm, or make Black
+# perform formatting in a single pass.
+
+print ( "format me" )
+print ( "format me" )
+print ( "format me" )
+print ( "format me" )
+print ( "format me" )
+
+# output
+# flags: --line-ranges=8-9
+# NOTE: If you need to modify this file, pay special attention to the --line-ranges=
+# flag above as it's formatting specifically these lines.
+
+# Reproducible example for https://github.com/psf/black/issues/4033
+# This can be fixed in the future if we use a better diffing algorithm, or make Black
+# perform formatting in a single pass.
+
+print ( "format me" )
+print("format me")
+print("format me")
+print("format me")
+print("format me")

--- a/tests/data/cases/line_ranges_diff_edge_case.py
+++ b/tests/data/cases/line_ranges_diff_edge_case.py
@@ -1,4 +1,4 @@
-# flags: --line-ranges=8-9
+# flags: --line-ranges=10-11
 # NOTE: If you need to modify this file, pay special attention to the --line-ranges=
 # flag above as it's formatting specifically these lines.
 
@@ -13,11 +13,11 @@ print ( "format me" )
 print ( "format me" )
 
 # output
-# flags: --line-ranges=8-9
+# flags: --line-ranges=10-11
 # NOTE: If you need to modify this file, pay special attention to the --line-ranges=
 # flag above as it's formatting specifically these lines.
 
-# Reproducible example for https://github.com/psf/black/issues/4033
+# Reproducible example for https://github.com/psf/black/issues/4033.
 # This can be fixed in the future if we use a better diffing algorithm, or make Black
 # perform formatting in a single pass.
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

When performing a second formatting pass with `--line-ranges`, we can't simply use the original lines specified by the user.

For example, unformatted:

```python
def restrict_to_this_line(arg1,
  arg2,
  arg3):
    print  ( "This should not be formatted." )
    print  ( "This should not be formatted." )
```

If we let it format lines `1-3`, after the first pass it becomes:

```python
def restrict_to_this_line(arg1, arg2, arg3):
    print  ( "This should not be formatted." )
    print  ( "This should not be formatted." )
```

If we use the original `1-3` lines in a second pass, it would format all the lines now.

To solve this, we have an [`adjusted_lines`](https://github.com/psf/black/blob/58f31a70efe6509ce8213afac998bc5d5bb7e34d/src/black/ranges.py#L48) function to calculate the new line ranges for the second pass. It uses the diffing algorithm from `difflib.SequenceMatcher`. Unfortunately it could produce undesired results for certain edge cases like a list of unformatted lines with the same content.

I _think_ we could use a custom algorithm that takes advantage of the diff is produced by a formatter (it rarely adds/removes lines of code, except blank lines, optional parenthesis). But it's complicated so I'm proposing to simply disable the stability check for now to avoid the crash mentioned in #4033.

This could still lead to formatting more lines than requested, but it should be very rare in practice. Even when that happens, it usually doesn't hurt too much if a few extra lines are reformatted. Also, if we could get rid of the two-pass formatting, this will no longer be an issue. (We still need a better `adjusted_lines` to re-enable the stability check, but it should be a smaller issue.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
