### PR TITLE
Format one-tuples and one-subscripts as multi-line if already multi-line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Magic trailing commas are now respected in one-tuples and single-element
-  subscripts when they are already split to multiple lines. So a multiline
-  one-tuple is no longer collapsed to a single line when magic trailing
-  commas are enabled. (#4038)
+- Magic trailing commas are now respected in one-tuples and single-element subscripts
+  when they are already split to multiple lines. So a multiline one-tuple is no longer
+  collapsed to a single line when magic trailing commas are enabled. (#4038)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Magic trailing commas are now respected in one-tuples and single-element
+  subscripts when they are already split to multiple lines. So a multiline
+  one-tuple is no longer collapsed to a single line when magic trailing
+  commas are enabled. (#4038)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -337,9 +337,6 @@ class Line:
         - there's a trailing comma here
         - it's not a one-tuple
         - it's not a single-element subscript
-        Additionally, if ensure_removable:
-        - it's not from square bracket indexing
-        (specifically, single-element square bracket indexing)
         """
         if not (
             closing.type in CLOSING_BRACKETS

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -367,15 +367,21 @@ class Line:
 
             return True
 
-        if self.is_import:
-            return True
+        if closing.type == token.RPAR:
+            if self.is_import:
+                return True
 
-        if closing.opening_bracket is not None and not is_one_sequence_between(
-            closing.opening_bracket, closing, self.leaves
-        ):
-            return True
+            if closing.opening_bracket is not None and not is_one_sequence_between(
+                closing.opening_bracket,
+                closing,
+                self.leaves,
+                brackets=(token.LPAR, token.RPAR),
+            ):
+                return True
 
-        return False
+            return False
+
+        return False  # pragma: no cover
 
     def append_comment(self, comment: Leaf) -> bool:
         """Add an inline or standalone comment to the line."""

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -371,15 +371,15 @@ class Line:
             if self.is_import:
                 return True
 
-            if closing.opening_bracket is not None and not is_one_sequence_between(
+            if closing.opening_bracket is not None and is_one_sequence_between(
                 closing.opening_bracket,
                 closing,
                 self.leaves,
                 brackets=(token.LPAR, token.RPAR),
             ):
-                return True
+                return False
 
-            return False
+            return True
 
         return False  # pragma: no cover
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -333,10 +333,18 @@ class Line:
     def has_magic_trailing_comma(
         self, closing: Leaf, ensure_removable: bool = False
     ) -> bool:
-        """Return True if we have a magic trailing comma, that is when:
-        - there's a trailing comma here
-        - it's not a one-tuple
-        - it's not a single-element subscript
+        """Return whether we have a magic trailing comma.
+
+        This is when:
+
+        * there's a trailing comma here
+        * it's not a one-tuple
+        * it's not a single-element subscript
+
+        Additionally, if ``ensure_removable`` is false:
+
+        * it's a one-tuple or single-element subscript that is already split to
+          multiple lines
         """
         if not (
             closing.type in CLOSING_BRACKETS
@@ -360,7 +368,10 @@ class Line:
                     brackets=(token.LSQB, token.RSQB),
                 )
             ):
-                return False
+                return (
+                    closing.opening_bracket.lineno != closing.lineno
+                    and not ensure_removable
+                )
 
             return True
 
@@ -374,7 +385,10 @@ class Line:
                 self.leaves,
                 brackets=(token.LPAR, token.RPAR),
             ):
-                return False
+                return (
+                    closing.opening_bracket.lineno != closing.lineno
+                    and not ensure_removable
+                )
 
             return True
 

--- a/tests/data/cases/collections.py
+++ b/tests/data/cases/collections.py
@@ -37,6 +37,9 @@ nested_long_lines = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbb
 ['ls', 'lsoneple/%s' % (foo,)]
 x = {"oneple": (1,)}
 y = {"oneple": (1,),}
+z = {"oneple": (
+    1,
+)}
 assert False, ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s" % bar)
 
 # looping over a 1-tuple should also not get wrapped
@@ -45,6 +48,18 @@ for x in (1,):
 for (x,) in (1,), (2,), (3,):
     pass
 
+(1,)
+(
+    1,
+)
+[1,]
+[
+    1,
+]
+{1,}
+{
+    1,
+}
 [1, 2, 3,]
 
 division_result_tuple = (6/2,)
@@ -127,6 +142,11 @@ x = {"oneple": (1,)}
 y = {
     "oneple": (1,),
 }
+z = {
+    "oneple": (
+        1,
+    )
+}
 assert False, (
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa wraps %s"
     % bar
@@ -138,6 +158,22 @@ for x in (1,):
 for (x,) in (1,), (2,), (3,):
     pass
 
+(1,)
+(
+    1,
+)
+[
+    1,
+]
+[
+    1,
+]
+{
+    1,
+}
+{
+    1,
+}
 [
     1,
     2,

--- a/tests/data/cases/one_element_subscript.py
+++ b/tests/data/cases/one_element_subscript.py
@@ -1,7 +1,16 @@
 # We should not treat the trailing comma
-# in a single-element subscript.
+# in a single-line single-element subscript.
 a: tuple[int,]
 b = tuple[int,]
+
+# Trailing comma should be preserved on multi-line
+# single-element subscript.
+a: tuple[
+    int,
+]
+b = tuple[
+    int,
+]
 
 # The magic comma still applies to multi-element subscripts.
 c: tuple[int, int,]
@@ -13,9 +22,18 @@ list_of_types = [tuple[int,],]
 
 # output
 # We should not treat the trailing comma
-# in a single-element subscript.
+# in a single-line single-element subscript.
 a: tuple[int,]
 b = tuple[int,]
+
+# Trailing comma should be preserved on multi-line
+# single-element subscript.
+a: tuple[
+    int,
+]
+b = tuple[
+    int,
+]
 
 # The magic comma still applies to multi-element subscripts.
 c: tuple[

--- a/tests/data/cases/skip_magic_trailing_comma.py
+++ b/tests/data/cases/skip_magic_trailing_comma.py
@@ -1,7 +1,13 @@
 # flags: --skip-magic-trailing-comma
 # We should not remove the trailing comma in a single-element subscript.
 a: tuple[int,]
+aa: tuple[
+    int,
+]
 b = tuple[int,]
+bb = tuple[
+    int,
+]
 
 # But commas in multiple element subscripts should be removed.
 c: tuple[int, int,]
@@ -15,6 +21,9 @@ set_of_types = {tuple[int,],}
 
 # Except single element tuples
 small_tuple = (1,)
+small_multiline_tuple = (
+    1,
+)
 
 # Trailing commas in multiple chained non-nested parens.
 zero(
@@ -50,7 +59,9 @@ func(
 # output
 # We should not remove the trailing comma in a single-element subscript.
 a: tuple[int,]
+aa: tuple[int,]
 b = tuple[int,]
+bb = tuple[int,]
 
 # But commas in multiple element subscripts should be removed.
 c: tuple[int, int]
@@ -64,6 +75,7 @@ set_of_types = {tuple[int,]}
 
 # Except single element tuples
 small_tuple = (1,)
+small_multiline_tuple = (1,)
 
 # Trailing commas in multiple chained non-nested parens.
 zero(one).two(three).four(five)


### PR DESCRIPTION
This implement the proposal in #3918.

I wasn't sure if this needs to go as a preview option; it shouldn't affect already formatted code (so adheres to the Stability Policy), but it does change how unformatted input is formatted.

Split to multiple commits to make reviewing a bit easier. Can be squashed to a single commit. The actual meaningful change is the last commit.

I've used `opening.lineno != closing.lineno` as an easy way to detect "multiline". I think it's correct and simple but maybe it's not appropriate.

Tested on some of our projects and it has the intended effect. For `skip-magic-trailing-comma = true` configurations it should have no effect at all.