### PR TITLE
Fix support for pre-commit versions < 3.2.0

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   name: black
   description: "Black: The uncompromising Python code formatter"
   entry: black
-  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  stages: [commit, merge-commit, push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true
@@ -14,7 +14,7 @@
   description:
     "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
   entry: black
-  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  stages: [commit, merge-commit, push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 
 ### Integrations
 
-- Fix support for pre-commit versions < 3.2.0 (#4040)
+- Fix support for pre-commit versions < 3.2.0 (#4041)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 
 ### Integrations
 
-<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Fix support for pre-commit versions < 3.2.0 (#4040)
 
 ### Documentation
 


### PR DESCRIPTION
### Description

This [previous change](https://github.com/psf/black/pull/3940/files) broke support for versions of pre-commit earlier than 3.2.0.

As far as I can tell, there's no reason _not_ to leave these as `commit`, `merge-commit` and `push` for now. Eventually they will need to be updated, but the current version of pre-commit supports both sets of values.

### Checklist - did you ...
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?