### PR TITLE
Improve annotations for `black.concurrency.cancel`

### DIFF
--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -38,7 +38,7 @@ def maybe_install_uvloop() -> None:
         pass
 
 
-def cancel(tasks: Iterable["asyncio.Task[Any]"]) -> None:
+def cancel(tasks: Iterable["asyncio.Future[Any]"]) -> None:
     """asyncio signal handler that cancels all `tasks` and reports to stderr."""
     err("Aborted!")
     for task in tasks:


### PR DESCRIPTION
### Description

This PR improves the type hints for `black.concurrency.cancel`, which are currently imperfect.

The function is annotated to say that it expects an iterable of `asyncio.Task`s. However, at the only place where `cancel` is (indirectly) "called" (via `loop.add_signal_handler`), it is "passed" an object (`pending`) that can only be inferred by a type checker to be an iterable of `asyncio.Future`s (`asyncio.Task` is a subclass of `asyncio.Future`):

https://github.com/psf/black/blob/58f31a70efe6509ce8213afac998bc5d5bb7e34d/src/black/concurrency.py#L153-L164

Type checkers must infer `pending` to be an iterable of `Future`s rather than an iterable of `Tasks`, because typeshed annotates `asyncio.ensure_future` as returning an `asyncio.Future` rather than an `asyncio.Task` (and I think it's correct to do so). I think the call to `add_signal_handler` itself is valid here: the annotations for `cancel()` just need to be changed to say that it accepts an iterable of any `Future`: the items in the iterable don't necessarily have to be `Task`s.

Type checkers haven't been complaining about this up to now, because `cancel` is only ever indirectly "called" via `loop.add_signal_handler()`. Up till now, typeshed hasn't been able to annotate `add_signal_handler` properly, so mypy hasn't been able to infer that the third argument to `add_signal_handler` needs to be `*args` that would be valid to be passed to the second argument to `add_signal_handler`. If https://github.com/python/typeshed/pull/11015 is merged, however, they'll start complaining about this (see https://github.com/python/typeshed/pull/11015#issuecomment-1810345635)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
