### PR TITLE
Make flake8 pass when run with Python 3.12

### DIFF
--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -175,7 +175,7 @@ def stringify_ast(node: ast.AST, depth: int = 0) -> Iterator[str]:
         except AttributeError:
             continue
 
-        yield f"{'  ' * (depth+1)}{field}="
+        yield f"{'  ' * (depth + 1)}{field}="
 
         if isinstance(value, list):
             for item in value:
@@ -211,6 +211,6 @@ def stringify_ast(node: ast.AST, depth: int = 0) -> Iterator[str]:
                 normalized = value.rstrip()
             else:
                 normalized = value
-            yield f"{'  ' * (depth+2)}{normalized!r},  # {value.__class__.__name__}"
+            yield f"{'  ' * (depth + 2)}{normalized!r},  # {value.__class__.__name__}"
 
     yield f"{'  ' * depth})  # /{node.__class__.__name__}"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

If you run `pre-commit run -a flake8` on Black with a Python 3.12 environment, it fails:

```
(.venv) C:\Users\alexw\coding\black>pre-commit run -a flake8
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-PyYAML,tomli >= 0.2.6, < 2.0.0,click >= 8.1.0, != 8.1.4, != 8.1.5,packaging >= 22.0,platformdirs >= 2.1.0,pytest,hypothesis,aiohttp >= 3.7.4,types-commonmark,urllib3,hypothesmith.
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

src/black/parsing.py:178:31: E226 missing whitespace around arithmetic operator
src/black/parsing.py:214:35: E226 missing whitespace around arithmetic operator
```

This is because flake8 is now able to detect errors inside f-strings on Python 3.12. It isn't able to do this on older versions of Python, but, due to changes in Python's tokenizer on Python 3.12, it can when run using Python 3.12.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
