### PR TITLE
Block aiohttp==3.9.0 from being installed in CI on Windows/pypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dynamic = ["readme", "version"]
 colorama = ["colorama>=0.4.3"]
 uvloop = ["uvloop>=0.15.2"]
 d = [
-  "aiohttp>=3.7.4",
+  "aiohttp>=3.7.4, !=3.9.0",
 ]
 jupyter = [
   "ipython>=7.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,8 @@ dynamic = ["readme", "version"]
 colorama = ["colorama>=0.4.3"]
 uvloop = ["uvloop>=0.15.2"]
 d = [
-  "aiohttp>=3.7.4, !=3.9.0",
+  "aiohttp>=3.7.4; sys_platform != 'win32' or implementation_name != 'pypy'",
+  "aiohttp>=3.7.4, !=3.9.0; sys_platform == 'win32' and implementation_name == 'pypy'",
 ]
 jupyter = [
   "ipython>=7.8.0",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

`aiohttp==3.9.0` fails to import if you're using PyPy on Windows: see https://github.com/aio-libs/aiohttp/issues/7848. This is currently causing our Windows/PyPy CI job to fail on every PR. We're using PyPy3.8 in CI, but bumping to PyPy3.9 in CI doesn't fix the problem: see the failing CI on the latest commit of #4035.

This PR just blocks `aiohttp==3.9.0` from being installed in CI, to make things green again.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
