### PR TITLE
[ci] Move 'lint' to 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint + format ourselves
 
 on: [push, pull_request]
 
@@ -11,7 +11,11 @@ jobs:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
       github.repository
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,12 +30,12 @@ jobs:
       - name: Set up latest Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "*"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[d]'
+          python -m pip install -e '.'
           python -m pip install tox
 
       - name: Run pre-commit hooks

--- a/tox.ini
+++ b/tox.ini
@@ -94,5 +94,5 @@ commands =
 setenv = PYTHONPATH = {toxinidir}/src
 skip_install = True
 commands =
-    pip install -e .[d]
+    pip install -e .
     black --check {toxinidir}/src {toxinidir}/tests


### PR DESCRIPTION
- Add to run on MacOS + Windows too
- Do not install [d] depdendecies as blackd is not actually ran / checked
- Move to default GitHub action version - which is 3.12 today

Fixes #3983