### PR TITLE
[docker] Build with 3.12 image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@
 ### Integrations
 
 - Enable 3.12 CI (#4035)
-- Build docker images with 3.12 (##4055)
+- Build docker images with 3.12 (#4055)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 ### Integrations
 
 - Enable 3.12 CI (#4035)
+- Build docker images with 3.12 (##4055)
 
 ### Documentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS builder
+FROM python:3.12-slim AS builder
 
 RUN mkdir /src
 COPY . /src/
@@ -12,7 +12,7 @@ RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setupto
     && cd /src && hatch build -t wheel \
     && pip install --no-cache-dir dist/*-cp*[colorama,d,uvloop]
 
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # copy only Python packages to limit the image size
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
- We are a 3.12 package now, let's build docker with it

Test:
```
crl-m1:black cooper$ docker build --tag black_3_12 .
...
 => [stage-1 2/2] COPY --from=builder /opt/venv /opt/venv                                                                                                                                                  0.2s
 => exporting to image                                                                                                                                                                                     0.1s
 => => exporting layers                                                                                                                                                                                    0.1s
 => => writing image sha256:bd66acc9d76d2c40d287b0684ce6601401631e0468204c4e6a81f8f1eebaf1dd                                                                                                               0.0s
 => => naming to docker.io/library/black_3_12

crl-m1:black cooper$ docker image ls | grep black_3_12
black_3_12                     latest            bd66acc9d76d   59 seconds ago   193MB
```
Fixes #3919