### PR TITLE
docs: Unify option descriptions between `--help` and `the_basics.md`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 
 - `--line-ranges` now skips _Black_'s internal stability check in `--safe` mode. This
   avoids a crash on rare inputs that have many unformatted same-content lines. (#4034)
+- Clarify some changelog entries (#4075)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,6 @@
 
 - `--line-ranges` now skips _Black_'s internal stability check in `--safe` mode. This
   avoids a crash on rare inputs that have many unformatted same-content lines. (#4034)
-- Clarify some changelog entries (#4076)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
 
 - `--line-ranges` now skips _Black_'s internal stability check in `--safe` mode. This
   avoids a crash on rare inputs that have many unformatted same-content lines. (#4034)
-- Clarify some changelog entries (#4075)
+- Clarify some changelog entries (#4076)
 
 ### Packaging
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -115,7 +115,7 @@ magics. Useful for formatting cells with custom python magics.
 
 #### `-x, --skip-source-first-line`
 
-Skip formatting the first line of the source code.
+Skip the first line of the source code.
 
 #### `-S, --skip-string-normalization`
 
@@ -297,8 +297,8 @@ error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
 #### `-v`, `--verbose`
 
 Emit messages about files that were not changed or were ignored due to exclusion
-patterns. If _Black_ is using a configuration file, a blue message detailing which one
-it is using will be emitted.
+patterns. If _Black_ is using a configuration file, a message detailing which one it is
+using will be emitted.
 
 ```console
 $ black src/ -v
@@ -438,8 +438,7 @@ refers to the path to your home directory. On Windows, this will be something li
 You can also explicitly specify the path to a particular file that you want with
 `--config`. In this situation _Black_ will not look for any other file.
 
-If you're running with `--verbose`, you will see a blue message if a file was found and
-used.
+If you're running with `--verbose`, you will see a message if a file was found and used.
 
 Please note `blackd` will not use `pyproject.toml` configuration.
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -266,7 +266,7 @@ instead of overriding them.
 Like `--exclude`, but files and directories matching this regex will be excluded even
 when they are passed explicitly as arguments. This is useful when invoking Black
 programmatically on changed files, such as in a pre-commit hook or editor plugin.
-        
+
 #### `--stdin-filename`
 
 The name of the file when passing it through stdin. Useful to make sure Black will

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -35,6 +35,10 @@ are deliberately limited and rarely added.
 Note that all command-line options listed above can also be configured using a
 `pyproject.toml` file (more on that below).
 
+#### `-h`, `--help`
+
+Show available command-line options and exit.
+
 #### `-c`, `--code`
 
 Format the code passed in as a string.
@@ -109,6 +113,10 @@ useful when piping source on standard input.
 When processing Jupyter Notebooks, add the given magic to the list of known python-
 magics. Useful for formatting cells with custom python magics.
 
+#### `-x, --skip-source-first-line`
+
+Skip formatting the first line of the source code.
+
 #### `-S, --skip-string-normalization`
 
 By default, _Black_ uses double quotes for all strings and normalizes string prefixes,
@@ -132,7 +140,7 @@ functionality in the next major release. Read more about
 
 #### `--check`
 
-Passing `--check` will make _Black_ exit with:
+Don't write the files back, just return the status. _Black_ will exit with:
 
 - code 0 if nothing would change;
 - code 1 if some files would be reformatted; or
@@ -162,8 +170,8 @@ $ echo $?
 
 #### `--diff`
 
-Passing `--diff` will make _Black_ print out diffs that indicate what changes _Black_
-would've made. They are printed to stdout so capturing them is simple.
+Don't write the files back, just output a diff to indicate what changes _Black_ would've
+made. They are printed to stdout so capturing them is simple.
 
 If you'd like colored diffs, you can enable them with `--color`.
 
@@ -178,6 +186,10 @@ would reformat test.py
 All done! ✨ 🍰 ✨
 1 file would be reformatted.
 ```
+
+#### `--color` / `--no-color`
+
+Show (or do not show) colored diff. Only applies when `--diff` is given.
 
 ### `--line-ranges`
 
@@ -201,10 +213,6 @@ Due to [#4052](https://github.com/psf/black/issues/4052), `--line-ranges` might 
 extra lines outside of the ranges when ther are unformatted lines with the exact
 content. It also disables _Black_'s formatting stability check in `--safe` mode.
 ```
-
-#### `--color` / `--no-color`
-
-Show (or do not show) colored diff. Only applies when `--diff` is given.
 
 #### `--fast` / `--safe`
 
@@ -263,8 +271,7 @@ Useful if you simply want to add to the default.
 #### `--force-exclude`
 
 Like `--exclude`, but files and directories matching this regex will be excluded even
-when they are passed explicitly as arguments. This is useful when invoking _Black_
-programmatically on changed files, such as in a pre-commit hook or editor plugin.
+when they are passed explicitly as arguments.
 
 #### `--stdin-filename`
 
@@ -275,12 +282,12 @@ respect the `--force-exclude` option on some editors that rely on using stdin.
 
 When _Black_ formats multiple files, it may use a process pool to speed up formatting.
 This option controls the number of parallel workers. This can also be specified via the
-`BLACK_NUM_WORKERS` environment variable.
+`BLACK_NUM_WORKERS` environment variable. Defaults to the number of CPUs in the system.
 
 #### `-q`, `--quiet`
 
-Passing `-q` / `--quiet` will cause _Black_ to stop emitting all non-critical output.
-Error messages will still be emitted (which can silenced by `2>/dev/null`).
+Stop emitting all non-critical output. Error messages will still be emitted (which can
+silenced by `2>/dev/null`).
 
 ```console
 $ black src/ -q
@@ -289,9 +296,9 @@ error: cannot format src/black_primer/cli.py: Cannot parse: 5:6: mport asyncio
 
 #### `-v`, `--verbose`
 
-Passing `-v` / `--verbose` will cause _Black_ to also emit messages about files that
-were not changed or were ignored due to exclusion patterns. If _Black_ is using a
-configuration file, a blue message detailing which one it is using will be emitted.
+Emit messages about files that were not changed or were ignored due to exclusion
+patterns. If _Black_ is using a configuration file, a blue message detailing which one
+it is using will be emitted.
 
 ```console
 $ black src/ -v
@@ -320,10 +327,6 @@ black, 23.11.0
 
 Read configuration options from a configuration file. See
 [below](#configuration-via-a-file) for more details on the configuration file.
-
-#### `-h`, `--help`
-
-Show available command-line options and exit.
 
 ### Environment variable options
 
@@ -355,7 +358,7 @@ All done! ✨ 🍰 ✨
 use `--stdin-filename`. Useful to make sure _Black_ will respect the `--force-exclude`
 option on some editors that rely on using stdin.
 
-You can also pass code as a string using the `-c` / `--code` option.
+You can also pass code as a string using the `--code` option.
 
 ### Writeback and reporting
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -264,8 +264,9 @@ instead of overriding them.
 #### `--force-exclude`
 
 Like `--exclude`, but files and directories matching this regex will be excluded even
-when they are passed explicitly as arguments.
-
+when they are passed explicitly as arguments. This is useful when invoking Black
+programmatically on changed files, such as in a pre-commit hook or editor plugin.
+        
 #### `--stdin-filename`
 
 The name of the file when passing it through stdin. Useful to make sure Black will

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -235,25 +235,26 @@ def validate_regex(
     callback=target_version_option_callback,
     multiple=True,
     help=(
-        "Python versions that should be supported by Black's output. By default, Black"
-        " will try to infer this from the project metadata in pyproject.toml. If this"
-        " does not yield conclusive results, Black will use per-file auto-detection."
+        "Python versions that should be supported by Black's output. You should"
+        " include all versions that your code supports. By default, Black will infer"
+        " target versions from the project metadata in pyproject.toml. If this does"
+        " not yield conclusive results, Black will use per-file auto-detection."
     ),
 )
 @click.option(
     "--pyi",
     is_flag=True,
     help=(
-        "Format all input files like typing stubs regardless of file extension (useful"
-        " when piping source on standard input)."
+        "Format all input files like typing stubs regardless of file extension. This"
+        " is useful when piping source on standard input."
     ),
 )
 @click.option(
     "--ipynb",
     is_flag=True,
     help=(
-        "Format all input files like Jupyter Notebooks regardless of file extension "
-        "(useful when piping source on standard input)."
+        "Format all input files like Jupyter Notebooks regardless of file extension."
+        "This is useful when piping source on standard input."
     ),
 )
 @click.option(
@@ -270,7 +271,7 @@ def validate_regex(
     "-x",
     "--skip-source-first-line",
     is_flag=True,
-    help="Skip the first line of the source code.",
+    help="Skip formatting the first line of the source code.",
 )
 @click.option(
     "-S",
@@ -310,14 +311,22 @@ def validate_regex(
 @click.option(
     "--diff",
     is_flag=True,
-    help="Don't write the files back, just output a diff for each file on stdout.",
+    help=(
+        "Don't write the files back, just output a diff to indicate what changes"
+        " Black would've made. They are printed to stdout so capturing them is simple."
+    ),
+)
+@click.option(
+    "--color/--no-color",
+    is_flag=True,
+    help="Show (or do not show) colored diff. Only applies when --diff is given.",
 )
 @click.option(
     "--line-ranges",
     multiple=True,
     metavar="START-END",
     help=(
-        "When specified, _Black_ will try its best to only format these lines. This"
+        "When specified, Black will try its best to only format these lines. This"
         " option can be specified multiple times, and a union of the lines will be"
         " formatted. Each range must be specified as two integers connected by a `-`:"
         " `<START>-<END>`. The `<START>` and `<END>` integer indices are 1-based and"
@@ -326,22 +335,23 @@ def validate_regex(
     default=(),
 )
 @click.option(
-    "--color/--no-color",
-    is_flag=True,
-    help="Show colored diff. Only applies when `--diff` is given.",
-)
-@click.option(
     "--fast/--safe",
     is_flag=True,
-    help="If --fast given, skip temporary sanity checks. [default: --safe]",
+    help=(
+        "By default, Black performs an AST safety check after formatting your code."
+        " The --fast flag turns off this check and the --safe flag explicitly enables"
+        " it. [default: --safe]"
+    ),
 )
 @click.option(
     "--required-version",
     type=str,
     help=(
-        "Require a specific version of Black to be running (useful for unifying results"
-        " across many environments e.g. with a pyproject.toml file). It can be"
-        " either a major version number or an exact version."
+        "Require a specific version of Black to be running. This is useful for"
+        " ensuring that all contributors to your project are using the same"
+        " version, because different versions of Black may format code a little"
+        " differently. This option can be set in a configuration file for consistent"
+        " results across environments."
     ),
 )
 @click.option(
@@ -376,7 +386,7 @@ def validate_regex(
     callback=validate_regex,
     help=(
         "Like --exclude, but adds additional files and directories on top of the"
-        " excluded ones. (Useful if you simply want to add to the default)"
+        " excluded ones. Useful if you simply want to add to the default."
     ),
 )
 @click.option(
@@ -384,8 +394,10 @@ def validate_regex(
     type=str,
     callback=validate_regex,
     help=(
-        "Like --exclude, but files and directories matching this regex will be "
-        "excluded even when they are passed explicitly as arguments."
+        "Like --exclude, but files and directories matching this regex will be excluded"
+        " even when they are passed explicitly as arguments. This is useful when"
+        " invoking Black programmatically on changed files, such as in a pre-commit"
+        " hook or editor plugin."
     ),
 )
 @click.option(
@@ -393,9 +405,9 @@ def validate_regex(
     type=str,
     is_eager=True,
     help=(
-        "The name of the file when passing it through stdin. Useful to make "
-        "sure Black will respect --force-exclude option on some "
-        "editors that rely on using stdin."
+        "The name of the file when passing it through stdin. Useful to make sure Black"
+        " will respect the --force-exclude option on some editors that rely on using"
+        " stdin."
     ),
 )
 @click.option(
@@ -404,8 +416,10 @@ def validate_regex(
     type=click.IntRange(min=1),
     default=None,
     help=(
-        "Number of parallel workers [default: BLACK_NUM_WORKERS environment variable "
-        "or number of CPUs in the system]"
+        "When Black formats multiple files, it may use a process pool to speed up"
+        " formatting. This option controls the number of parallel workers. This can"
+        " also be specified via the BLACK_NUM_WORKERS environment variable. Defaults"
+        " to the number of CPUs in the system."
     ),
 )
 @click.option(
@@ -413,8 +427,9 @@ def validate_regex(
     "--quiet",
     is_flag=True,
     help=(
-        "Don't emit non-error messages to stderr. Errors are still emitted; silence"
-        " those with 2>/dev/null."
+        "Stop emitting all non-critical output. Error messages will still be emitted"
+        " (which can Error messages will still be emitted (which can silenced by"
+        " 2>/dev/null)."
     ),
 )
 @click.option(
@@ -422,8 +437,9 @@ def validate_regex(
     "--verbose",
     is_flag=True,
     help=(
-        "Also emit messages to stderr about files that were not changed or were ignored"
-        " due to exclusion patterns."
+        "Emit messages about files that were not changed or were ignored due to"
+        " exclusion patterns. If Black is using a configuration file, a blue message"
+        " detailing which one it is using will be emitted."
     ),
 )
 @click.version_option(
@@ -454,7 +470,7 @@ def validate_regex(
     ),
     is_eager=True,
     callback=read_pyproject_toml,
-    help="Read configuration from FILE path.",
+    help="Read configuration options from a configuration file.",
 )
 @click.pass_context
 def main(  # noqa: C901

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -271,7 +271,7 @@ def validate_regex(
     "-x",
     "--skip-source-first-line",
     is_flag=True,
-    help="Skip formatting the first line of the source code.",
+    help="Skip the first line of the source code.",
 )
 @click.option(
     "-S",
@@ -428,8 +428,7 @@ def validate_regex(
     is_flag=True,
     help=(
         "Stop emitting all non-critical output. Error messages will still be emitted"
-        " (which can Error messages will still be emitted (which can silenced by"
-        " 2>/dev/null)."
+        " (which can silenced by 2>/dev/null)."
     ),
 )
 @click.option(
@@ -438,7 +437,7 @@ def validate_regex(
     is_flag=True,
     help=(
         "Emit messages about files that were not changed or were ignored due to"
-        " exclusion patterns. If Black is using a configuration file, a blue message"
+        " exclusion patterns. If Black is using a configuration file, a message"
         " detailing which one it is using will be emitted."
     ),
 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

The descriptions for some options were inconsistent between the `--help` command and the `the_basics` documentation page. This PR unifies the two, as well as making the order consistant. Finally, the `-x` option was previously not mentioned at all in the documentation, so I added it.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary? (N/A)
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
