### PR TITLE
Fix minor typos in docstrings

### DIFF
--- a/src/black/numerics.py
+++ b/src/black/numerics.py
@@ -14,7 +14,7 @@ def format_hex(text: str) -> str:
 
 
 def format_scientific_notation(text: str) -> str:
-    """Formats a numeric string utilizing scentific notation"""
+    """Formats a numeric string utilizing scientific notation"""
     before, after = text.split("e")
     sign = ""
     if after.startswith("-"):

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -172,7 +172,7 @@ class _TopLevelStatementsVisitor(Visitor[None]):
     A node visitor that converts unchanged top-level statements to
     STANDALONE_COMMENT.
 
-    This is used in addition to _convert_unchanged_lines_by_flatterning, to
+    This is used in addition to _convert_unchanged_line_by_line, to
     speed up formatting when there are unchanged top-level
     classes/functions/statements.
     """
@@ -302,7 +302,7 @@ def _convert_node_to_standalone_comment(node: LN) -> None:
     index = node.remove()
     if index is not None:
         # Remove the '\n', as STANDALONE_COMMENT will have '\n' appended when
-        # genearting the formatted code.
+        # generating the formatted code.
         value = str(node)[:-1]
         parent.insert_child(
             index,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

I noticed typos in the docstrings.

- numerics.py
  - `scentific` -> `scientific`
- ranges.py
  - `genearting` -> `generating`
  - `_convert_unchanged_lines_by_flatterning` -> `_convert_unchanged_line_by_line` (this corrects the function name)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
