### PR TITLE
fix crash in preview mode with --line-length=1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Standalone form feed characters at the module level are no longer removed (#4021)
 - Additional cases of immediately nested tuples, lists, and dictionaries are now
   indented less (#4012)
+- fix crash in preview mode when using a short --line-length (#4086)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 - Standalone form feed characters at the module level are no longer removed (#4021)
 - Additional cases of immediately nested tuples, lists, and dictionaries are now
   indented less (#4012)
-- fix crash in preview mode when using a short --line-length (#4086)
+- Fix crash in preview mode when using a short `--line-length` (#4086)
 
 ### Configuration
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -744,7 +744,7 @@ def left_hand_split(
             if leaf.type in OPENING_BRACKETS:
                 matching_bracket = leaf
                 current_leaves = body_leaves
-    if not matching_bracket:
+    if not matching_bracket or not tail_leaves:
         raise CannotSplit("No brackets found")
 
     head = bracket_split_build_line(

--- a/tests/data/cases/return_annotation_brackets_crash_line_length_1.py
+++ b/tests/data/cases/return_annotation_brackets_crash_line_length_1.py
@@ -1,0 +1,9 @@
+# flags: --preview --minimum-version=3.10 --line-length=1
+
+def foo() -> tuple[int, int,]:
+    ...
+# output
+def foo() -> tuple[
+    int,
+    int,
+]: ...


### PR DESCRIPTION
fixes #4062

crash happened when right_hand_split first split
```python
def foo() -> tuple[int, int,]:  ...
```
to
```python
def foo() -> tuple[
  int,
  int,
]: ...
```
and then left_hand_split followed up with splitting on the invisible LPAR around the return type in the first line to make it
```python
def foo() ->
tuple[
```

This was due to insufficient logic in left_hand_split to abort in some weird cases, that it previously never got into because the code wasn't modified by `right_hand_split` beforehand - but that became a thing in #3916.


<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
