### PR TITLE
test preview cases with line-length 1 unless explicitly skipped

### DIFF
--- a/tests/data/cases/comment_type_hint.py
+++ b/tests/data/cases/comment_type_hint.py
@@ -1,0 +1,3 @@
+# flags: --no-preview-line-length-1
+# split out from comments2 as it does not work with line-length=1, losing the comment
+a = "type comment with trailing space"  # type: str

--- a/tests/data/cases/comments2.py
+++ b/tests/data/cases/comments2.py
@@ -155,8 +155,6 @@ class Test:
             pass
 
 
-a = "type comment with trailing space"  # type: str   
-
 #######################
 ### SECTION COMMENT ###
 #######################
@@ -334,8 +332,6 @@ class Test:
         if parsed.hostname is None or not parsed.hostname.strip():  # type: ignore
             pass
 
-
-a = "type comment with trailing space"  # type: str
 
 #######################
 ### SECTION COMMENT ###

--- a/tests/data/cases/fmtskip2.py
+++ b/tests/data/cases/fmtskip2.py
@@ -1,9 +1,12 @@
+# flags: --no-preview-line-length-1
+# l2 loses the comment with line-length=1 in preview mode
 l1 = ["This list should be broken up", "into multiple lines", "because it is way too long"]
 l2 = ["But this list shouldn't", "even though it also has", "way too many characters in it"]  # fmt: skip
 l3 = ["I have", "trailing comma", "so I should be braked",]
 
 # output
 
+# l2 loses the comment with line-length=1 in preview mode
 l1 = [
     "This list should be broken up",
     "into multiple lines",

--- a/tests/data/cases/pep_572_remove_parens.py
+++ b/tests/data/cases/pep_572_remove_parens.py
@@ -1,4 +1,4 @@
-# flags: --minimum-version=3.8
+# flags: --minimum-version=3.8 --no-preview-line-length-1
 if (foo := 0):
     pass
 

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -125,23 +125,6 @@ func([x for x in "short line"])
 func([x for x in "long line long line long line long line long line long line long line"])
 func([x for x in [x for x in "long line long line long line long line long line long line long line"]])
 
-func({"short line"})
-func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
-func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
-func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
-func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
-func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
-
-# Do not hug if the argument fits on a single line.
-func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
-func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
-func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
-func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
-func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
-array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
-array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
-array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -151,13 +134,10 @@ baaaaaaaaaaaaar(
 )
 
 nested_mapping = {"key": [{"a very long key 1": "with a very long value", "a very long key 2": "with a very long value"}]}
-nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]
 explicit_exploding = [[["short", "line",],],]
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
 
 foo(*[str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)])
 
@@ -310,69 +290,6 @@ func([
     ]
 ])
 
-func({"short line"})
-func({
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-})
-func({{
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-}})
-func((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-))
-func(((
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-)))
-func([[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]])
-
-# Do not hug if the argument fits on a single line.
-func(
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-)
-func(
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-)
-func(
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-)
-func(
-    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
-)
-func(
-    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
-)
-array = [
-    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
-]
-array = [
-    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
-]
-array = [
-    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
-]
-
 foooooooooooooooooooo(
     [{c: n + 1 for c in range(256)} for n in range(100)] + [{}], {size}
 )
@@ -387,13 +304,6 @@ nested_mapping = {
         "a very long key 2": "with a very long value",
     }]
 }
-nested_array = [[[
-    "long line",
-    "long long line",
-    "long long long line",
-    "long long long long line",
-    "long long long long long line",
-]]]
 explicit_exploding = [
     [
         [
@@ -405,12 +315,6 @@ explicit_exploding = [
 single_item_do_not_explode = Context({
     "version": get_docs_version(),
 })
-
-foo(*[
-    "long long long long long line",
-    "long long long long long line",
-    "long long long long long line",
-])
 
 foo(*[
     str(i) for i in range(100000000000000000000000000000000000000000000000000000000000)

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
@@ -1,0 +1,106 @@
+# flags: --preview --no-preview-line-length-1
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*["long long long long long line", "long long long long long line", "long long long long long line"])
+func({"short line"})
+func({"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"})
+func({{"long line", "long long line", "long long long line", "long long long long line", "long long long long long line"}})
+func(("long line", "long long line", "long long long line", "long long long long line", "long long long long long line"))
+func((("long line", "long long line", "long long long line", "long long long long line", "long long long long long line")))
+func([["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]])
+
+
+# Do not hug if the argument fits on a single line.
+func({"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"})
+func(("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"))
+func(["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"])
+func(**{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"})
+func(*("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----"))
+array = [{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}]
+array = [("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")]
+array = [["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]]
+
+nested_array = [[["long line", "long long line", "long long long line", "long long long long line", "long long long long long line"]]]
+
+# output
+
+# split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
+# different code on the second pass with line-length 1 in many cases.
+# Seems to be about whether the last string in a sequence gets wrapped in parens or not.
+foo(*[
+    "long long long long long line",
+    "long long long long long line",
+    "long long long long long line",
+])
+func({"short line"})
+func({
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+})
+func({{
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+}})
+func((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+))
+func(((
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+)))
+func([[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]])
+
+
+# Do not hug if the argument fits on a single line.
+func(
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+)
+func(
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+)
+func(
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+)
+func(
+    **{"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit---"}
+)
+func(
+    *("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit----")
+)
+array = [
+    {"fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"}
+]
+array = [
+    ("fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line")
+]
+array = [
+    ["fit line", "fit line", "fit line", "fit line", "fit line", "fit line", "fit line"]
+]
+
+nested_array = [[[
+    "long line",
+    "long long line",
+    "long long long line",
+    "long long long long line",
+    "long long long long long line",
+]]]

--- a/tests/data/cases/return_annotation_brackets_crash_line_length_1.py
+++ b/tests/data/cases/return_annotation_brackets_crash_line_length_1.py
@@ -1,9 +1,0 @@
-# flags: --preview --minimum-version=3.10 --line-length=1
-
-def foo() -> tuple[int, int,]:
-    ...
-# output
-def foo() -> tuple[
-    int,
-    int,
-]: ...

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -30,6 +30,7 @@ def check_file(subdir: str, filename: str, *, data: bool = True) -> None:
         fast=args.fast,
         minimum_version=args.minimum_version,
         lines=args.lines,
+        no_preview_line_length_1=args.no_preview_line_length_1,
     )
     if args.minimum_version is not None:
         major, minor = args.minimum_version
@@ -42,6 +43,7 @@ def check_file(subdir: str, filename: str, *, data: bool = True) -> None:
             fast=args.fast,
             minimum_version=args.minimum_version,
             lines=args.lines,
+            no_preview_line_length_1=args.no_preview_line_length_1,
         )
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -144,7 +144,7 @@ def assert_format(
                 lines=lines,
             )
         except Exception as e:
-            text = "preview" if mode.preview else "non-preview"
+            text = "preview" if preview_mode else "non-preview"
             raise FormatFailure(
                 f"Black crashed formatting this case in {text} mode with line-length=1."
             ) from e

--- a/tests/util.py
+++ b/tests/util.py
@@ -46,6 +46,7 @@ class TestCaseArgs:
     fast: bool = False
     minimum_version: Optional[Tuple[int, int]] = None
     lines: Collection[Tuple[int, int]] = ()
+    no_preview_line_length_1: bool = False
 
 
 def _assert_format_equal(expected: str, actual: str) -> None:
@@ -96,6 +97,7 @@ def assert_format(
     fast: bool = False,
     minimum_version: Optional[Tuple[int, int]] = None,
     lines: Collection[Tuple[int, int]] = (),
+    no_preview_line_length_1: bool = False,
 ) -> None:
     """Convenience function to check that Black formats as expected.
 
@@ -124,21 +126,28 @@ def assert_format(
             f"Black crashed formatting this case in {text} mode."
         ) from e
     # Similarly, setting line length to 1 is a good way to catch
-    # stability bugs. But only in non-preview mode because preview mode
-    # currently has a lot of line length 1 bugs.
-    try:
-        _assert_format_inner(
-            source,
-            None,
-            replace(mode, preview=False, line_length=1),
-            fast=fast,
-            minimum_version=minimum_version,
-            lines=lines,
-        )
-    except Exception as e:
-        raise FormatFailure(
-            "Black crashed formatting this case with line-length set to 1."
-        ) from e
+    # stability bugs. Some tests are known to be broken in preview mode with line length
+    # of 1 though, and have marked that with a flag --no-preview-line-length-1
+    preview_modes = [False]
+    if not no_preview_line_length_1:
+        preview_modes.append(True)
+
+    for preview_mode in preview_modes:
+
+        try:
+            _assert_format_inner(
+                source,
+                None,
+                replace(mode, preview=preview_mode, line_length=1),
+                fast=fast,
+                minimum_version=minimum_version,
+                lines=lines,
+            )
+        except Exception as e:
+            text = "preview" if mode.preview else "non-preview"
+            raise FormatFailure(
+                f"Black crashed formatting this case in {text} mode with line-length=1."
+            ) from e
 
 
 def _assert_format_inner(
@@ -246,6 +255,15 @@ def get_flags_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--line-ranges", action="append")
+    parser.add_argument(
+        "--no-preview-line-length-1",
+        default=False,
+        action="store_true",
+        help=(
+            "Don't run in preview mode with --line-length=1, as that's known to cause a"
+            " crash"
+        ),
+    )
     return parser
 
 
@@ -266,7 +284,11 @@ def parse_mode(flags_line: str) -> TestCaseArgs:
     else:
         lines = []
     return TestCaseArgs(
-        mode=mode, fast=args.fast, minimum_version=args.minimum_version, lines=lines
+        mode=mode,
+        fast=args.fast,
+        minimum_version=args.minimum_version,
+        lines=lines,
+        no_preview_line_length_1=args.no_preview_line_length_1,
     )
 
 


### PR DESCRIPTION
### Description

As discussed in #4062 with @JelleZijlstra 

* Add new flag for tests, --no-preview-line-length-1, to be used for test cases known to not work in preview mode with line-length=1.
* Split out the problematic cases in three cases to separate files.
* Removed now redundant test case which explicitly tested preview annotations with line-length=1

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

