### PR TITLE
perf: increasing the performance to remove unnecessary for loops

### DIFF
--- a/action/main.py
+++ b/action/main.py
@@ -26,12 +26,12 @@ else:
 if version_specifier:
     req = f"black{extra_deps}{version_specifier}"
 else:
-    describe_name = ""
     with open(ACTION_PATH / ".git_archival.txt", encoding="utf-8") as fp:
-        for line in fp:
-            if line.startswith("describe-name: "):
-                describe_name = line[len("describe-name: ") :].rstrip()
-                break
+        prefix = "describe-name: "
+        describe_name = "".join(
+            filter(lambda x: x.startswith(prefix), fp)
+        ).split(maxsplit=1)
+
     if not describe_name:
         print("::error::Failed to detect action version.", file=sys.stderr, flush=True)
         sys.exit(1)

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -63,17 +63,18 @@ def find_project_root(
     if not srcs:
         srcs = [str(Path.cwd().resolve())]
 
-    path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
+    src_parents = list()
+    for src in srcs:
+        path = Path(Path.cwd(), src).resolve()
 
-    # A list of lists of parents for each 'src'. 'src' is included as a
-    # "parent" of itself if it is a directory
-    src_parents = [
-        list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
-    ]
+        # `src` is included as a `parent` of itself if it is a directory.
+        parents = list(path.parents) + ([path] if path.is_dir() else [])
+        parents_in_set = set(parents)
+        src_parents.append(parents_in_set)
 
     common_base = max(
-        set.intersection(*(set(parents) for parents in src_parents)),
-        key=lambda path: path.parts,
+        set.intersection(*(src_parents)),
+        key=lambda path: path.parts
     )
 
     for directory in (common_base, *common_base.parents):


### PR DESCRIPTION
1) Removing the for loop and using the filter, which increase little performance when opening the ```.git_archival.txt``` file in ```black/action/main```. 
2) Removing unnecessary for loops in ```black/src/black/files```.

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
