### PR TITLE
Adds paren to deps for hidden extra constraint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
-* Fixed a bug that included dependencies from the `d` extra by default (#4108, #4107).
+
+- Fixed a bug that included dependencies from the `d` extra by default (#4108, #4107).
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
-- Fixed a bug that included dependencies from the `d` extra by default (#4108, #4107).
+- Fixed a bug that included dependencies from the `d` extra by default (#4108)
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
+* Fixed a bug that included dependencies from the `d` extra by default (#4108, #4107).
 
 ### Parser
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ dynamic = ["readme", "version"]
 colorama = ["colorama>=0.4.3"]
 uvloop = ["uvloop>=0.15.2"]
 d = [
-  "aiohttp>=3.7.4; sys_platform != 'win32' or implementation_name != 'pypy'",
-  "aiohttp>=3.7.4, !=3.9.0; sys_platform == 'win32' and implementation_name == 'pypy'",
+  "aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and python_version >= '1'",
+  "aiohttp>=3.7.4, !=3.9.0 ; (sys_platform == 'win32' and implementation_name == 'pypy') and python_version >= '1'",
 ]
 jupyter = [
   "ipython>=7.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ preview = true
 # NOTE: You don't need this in your own Black configuration.
 
 [build-system]
-requires = ["hatchling>=1.8.0", "hatch-vcs", "hatch-fancy-pypi-readme"]
+requires = ["hatchling>=1.20.0", "hatch-vcs", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [project]
@@ -76,8 +76,8 @@ dynamic = ["readme", "version"]
 colorama = ["colorama>=0.4.3"]
 uvloop = ["uvloop>=0.15.2"]
 d = [
-  "aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and python_version >= '1'",
-  "aiohttp>=3.7.4, !=3.9.0 ; (sys_platform == 'win32' and implementation_name == 'pypy') and python_version >= '1'",
+  "aiohttp>=3.7.4; sys_platform != 'win32' or implementation_name != 'pypy'",
+  "aiohttp>=3.7.4, !=3.9.0; sys_platform == 'win32' and implementation_name == 'pypy'",
 ]
 jupyter = [
   "ipython>=7.8.0",
@@ -187,7 +187,7 @@ CC = "clang"
 build-frontend = { name = "build", args = ["--no-isolation"] }
 # Unfortunately, hatch doesn't respect MACOSX_DEPLOYMENT_TARGET
 before-build = [
-    "python -m pip install 'hatchling==1.18.0' hatch-vcs hatch-fancy-pypi-readme 'hatch-mypyc>=0.16.0' 'mypy==1.7.1' 'click==8.1.3'",
+    "python -m pip install 'hatchling==1.20.0' hatch-vcs hatch-fancy-pypi-readme 'hatch-mypyc>=0.16.0' 'mypy==1.7.1' 'click==8.1.3'",
     """sed -i '' -e "600,700s/'10_16'/os.environ['MACOSX_DEPLOYMENT_TARGET'].replace('.', '_')/" $(python -c 'import hatchling.builders.wheel as h; print(h.__file__)') """,
 ]
 


### PR DESCRIPTION
### Description

Fix #4107 by updating hatchling  ~~in a fairly hacky way though.~~

Hatch ~~will~~ used to strip out parenthesis in the extras if it thinks it doesn't need them and wouldn't add them back in. ~~:( We can, however, add a meaningless restriction like `and python_version >= '1'` to force hatch to use our parenthesis. Extremely hacky, and I would understand if we don't want this to be merged until a cleaner hatch fix is upstream. Also happy to come up with another way of essentially just having `true` in the spec, but I couldn't find one with a quick reading of https://peps.python.org/pep-0508/.~~

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?   I'm not sure it's a great idea to add a test to see that dependency was avoided, happy to add one if desired though!
      I did manually test this by installing my local checkout of the project, confirming that the dependencies for the `d` extra aren't installed:
      
```logs
$ pip install .
Processing /home/brycew/Developer/black
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: typing-extensions>=4.0.1 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (4.9.0)
Requirement already satisfied: tomli>=1.1.0 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (2.0.1)
Requirement already satisfied: mypy-extensions>=0.4.3 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (1.0.0)
Requirement already satisfied: pathspec>=0.9.0 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (0.12.1)
Requirement already satisfied: platformdirs>=2 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (4.1.0)
Requirement already satisfied: click>=8.0.0 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (8.1.7)
Requirement already satisfied: packaging>=22.0 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1763+gdad9f79.d20231212) (23.2)
Building wheels for collected packages: black
  Building wheel for black (pyproject.toml) ... done
  Created wheel for black: filename=black-0.1.dev1763+gdad9f79.d20231212-py3-none-any.whl size=194930 sha256=a511959e5af87f2bc5623744f13eba2bd3c406fd9b522e8a537c8f3d341b1a18
  Stored in directory: /tmp/pip-ephem-wheel-cache-o2gmqktu/wheels/92/d6/de/b610e33302c2b433609d1ae2283761d3ff26bd0fb805d38fe1
Successfully built black
Installing collected packages: black
  Attempting uninstall: black
    Found existing installation: black 0.1.dev1763+gdad9f79
    Uninstalling black-0.1.dev1763+gdad9f79:
      Successfully uninstalled black-0.1.dev1763+gdad9f79
Successfully installed black-0.1.dev1763+gdad9f79.d20231212
```

When run on main, this output includes `Requirement already satisfied: aiohttp>=3.7.4 in /home/brycew/Developer/.venv/lib/python3.10/site-packages (from black==0.1.dev1762+g35ce37d) (3.9.1)`, and all of it's dependencies.

- [x] Add new / update outdated documentation? (nothing changed here)

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
