### PR TITLE
Simplify chained expressions and remove unused param

### DIFF
--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -115,7 +115,7 @@ class BracketTracker:
             if delim and self.previous is not None:
                 self.delimiters[id(self.previous)] = delim
             else:
-                delim = is_split_after_delimiter(leaf, self.previous)
+                delim = is_split_after_delimiter(leaf)
                 if delim:
                     self.delimiters[id(leaf)] = delim
         if leaf.type in OPENING_BRACKETS:
@@ -215,7 +215,7 @@ class BracketTracker:
         return self.bracket_match.get((self.depth - 1, token.RSQB))
 
 
-def is_split_after_delimiter(leaf: Leaf, previous: Optional[Leaf] = None) -> Priority:
+def is_split_after_delimiter(leaf: Leaf) -> Priority:
     """Return the priority of the `leaf` delimiter, given a line break after it.
 
     The delimiter priorities returned here are from those delimiters that would

--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -58,9 +58,9 @@ class Cache:
 
     @classmethod
     def read(cls, mode: Mode) -> Self:
-        """Read the cache if it exists and is well formed.
+        """Read the cache if it exists and is well-formed.
 
-        If it is not well formed, the call to write later should
+        If it is not well-formed, the call to write later should
         resolve the issue.
         """
         cache_file = get_cache_file(mode)

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -221,8 +221,8 @@ def convert_one_fmt_off_pair(
             if comment.value in FMT_OFF:
                 fmt_off_prefix = ""
                 if len(lines) > 0 and not any(
-                    comment_lineno >= line[0] and comment_lineno <= line[1]
-                    for line in lines
+                        line[0] <= comment_lineno <= line[1]
+                        for line in lines
                 ):
                     # keeping indentation of comment by preserving original whitespaces.
                     fmt_off_prefix = prefix.split(comment.value)[0]

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -221,8 +221,7 @@ def convert_one_fmt_off_pair(
             if comment.value in FMT_OFF:
                 fmt_off_prefix = ""
                 if len(lines) > 0 and not any(
-                        line[0] <= comment_lineno <= line[1]
-                        for line in lines
+                    line[0] <= comment_lineno <= line[1] for line in lines
                 ):
                     # keeping indentation of comment by preserving original whitespaces.
                     fmt_off_prefix = prefix.split(comment.value)[0]

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1635,7 +1635,7 @@ def generate_trailers_to_omit(line: Line, line_length: int) -> Iterator[Set[Leaf
     opening_bracket: Optional[Leaf] = None
     closing_bracket: Optional[Leaf] = None
     inner_brackets: Set[LeafID] = set()
-    for index, leaf, leaf_length in line.enumerate_with_length(reversed=True):
+    for index, leaf, leaf_length in line.enumerate_with_length(is_reversed=True):
         length += leaf_length
         if length > line_length:
             break

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -451,7 +451,7 @@ class Line:
         )
 
     def enumerate_with_length(
-        self, reversed: bool = False
+            self, is_reversed: bool = False
     ) -> Iterator[Tuple[Index, Leaf, int]]:
         """Return an enumeration of leaves with their length.
 
@@ -459,7 +459,7 @@ class Line:
         """
         op = cast(
             Callable[[Sequence[Leaf]], Iterator[Tuple[Index, Leaf]]],
-            enumerate_reversed if reversed else enumerate,
+            enumerate_reversed if is_reversed else enumerate,
         )
         for index, leaf in op(self.leaves):
             length = len(leaf.prefix) + len(leaf.value)

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -451,7 +451,7 @@ class Line:
         )
 
     def enumerate_with_length(
-            self, is_reversed: bool = False
+        self, is_reversed: bool = False
     ) -> Iterator[Tuple[Index, Leaf, int]]:
         """Return an enumeration of leaves with their length.
 

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -487,10 +487,7 @@ def _find_lines_mapping_index(
     index = start_index
     while index < len(lines_mappings):
         mapping = lines_mappings[index]
-        if (
-            mapping.original_start <= original_line
-            and original_line <= mapping.original_end
-        ):
+        if mapping.original_start <= original_line <= mapping.original_end:
             return index
         index += 1
     return index

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1273,7 +1273,7 @@ def iter_fexpr_spans(s: str) -> Iterator[Tuple[int, int]]:
             i += 1
             continue
 
-        # if we're in an expression part of the f-string, fast forward through strings
+        # if we're in an expression part of the f-string, fast-forward through strings
         # note that backslashes are not legal in the expression portion of f-strings
         if stack:
             delim = None
@@ -1740,7 +1740,7 @@ class StringSplitter(BaseStringSplitter, CustomSplitMapMixin):
             """
             Returns:
                 True iff ALL of the conditions listed in the 'Transformations'
-                section of this classes' docstring would be be met by returning @i.
+                section of this classes' docstring would be met by returning @i.
             """
             is_space = string[i] == " "
             is_split_safe = is_valid_index(i - 1) and string[i - 1] in SPLIT_SAFE_CHARS
@@ -1932,7 +1932,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                 OR
             None, otherwise.
         """
-        # If this line is apart of a return/yield statement and the first leaf
+        # If this line is a part of a return/yield statement and the first leaf
         # contains either the "return" or "yield" keywords...
         if parent_type(LL[0]) in [syms.return_stmt, syms.yield_expr] and LL[
             0
@@ -1957,7 +1957,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                 OR
             None, otherwise.
         """
-        # If this line is apart of a ternary expression and the first leaf
+        # If this line is a part of a ternary expression and the first leaf
         # contains the "else" keyword...
         if (
             parent_type(LL[0]) == syms.test
@@ -1984,7 +1984,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                 OR
             None, otherwise.
         """
-        # If this line is apart of an assert statement and the first leaf
+        # If this line is a part of an assert statement and the first leaf
         # contains the "assert" keyword...
         if parent_type(LL[0]) == syms.assert_stmt and LL[0].value == "assert":
             is_valid_index = is_valid_index_factory(LL)
@@ -2019,7 +2019,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                 OR
             None, otherwise.
         """
-        # If this line is apart of an expression statement or is a function
+        # If this line is a part of an expression statement or is a function
         # argument AND the first leaf contains a variable name...
         if (
             parent_type(LL[0]) in [syms.expr_stmt, syms.argument, syms.power]
@@ -2040,7 +2040,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                         string_parser = StringParser()
                         idx = string_parser.parse(LL, string_idx)
 
-                        # The next leaf MAY be a comma iff this line is apart
+                        # The next leaf MAY be a comma iff this line is a part
                         # of a function argument...
                         if (
                             parent_type(LL[0]) == syms.argument
@@ -2187,8 +2187,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
                 if opening_bracket is not None and opening_bracket in left_leaves:
                     index = left_leaves.index(opening_bracket)
                     if (
-                        index > 0
-                        and index < len(left_leaves) - 1
+                        0 < index < len(left_leaves) - 1
                         and left_leaves[index - 1].type == token.COLON
                         and left_leaves[index + 1].value == "lambda"
                     ):
@@ -2297,7 +2296,7 @@ class StringParser:
             * @leaves[@string_idx].type == token.STRING
 
         Returns:
-            The index directly after the last leaf which is apart of the string
+            The index directly after the last leaf which is a part of the string
             trailer, if a "trailer" exists.
             OR
             @string_idx + 1, if no string "trailer" exists.
@@ -2320,7 +2319,7 @@ class StringParser:
               MUST be the leaf directly following @leaf.
 
         Returns:
-            True iff @leaf is apart of the string's trailer.
+            True iff @leaf is a part of the string's trailer.
         """
         # We ignore empty LPAR or RPAR leaves.
         if is_empty_par(leaf):


### PR DESCRIPTION
### Description

- `previous` was unused in `is_split_after_delimiter` so removed it
- rename `reversed` in `enumerate_with_length` to `is_reversed` because `reversed` is a [Python built-in function](https://docs.python.org/3/library/functions.html#reversed)

<img width="679" alt="Screenshot 2023-12-15 at 10 11 54 PM" src="https://github.com/psf/black/assets/24191989/cd375091-5c8b-4068-bcd9-c636f673485c">

- Simpify if statements to make them easier to read
- Fix docstrings (`well-formed` and `fast-forward` is one word, `Therefore` and `Otherwise` needs a comma after, remove `be be`, should be `a part` instead of `apart`)

### Checklist - did you ...

None of the below are necessary!

- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?