### PR TITLE
Allow empty lines at beginnings of more blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 - Format module docstrings the same as class and function docstrings (#4095)
 - Fix bug where spaces were not added around parenthesized walruses in subscripts,
   unlike other binary operators (#4109)
+- Address a missing case in the change to allow empty lines at the beginning of all
+  blocks, except immediately before a docstring (#4130)
 
 ### Configuration
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -745,7 +745,10 @@ class EmptyLineTracker:
         if self.previous_line.depth < current_line.depth and (
             self.previous_line.is_class or self.previous_line.is_def
         ):
-            return 0, 0
+            if self.mode.is_pyi or not Preview.allow_empty_first_line_in_block:
+                return 0, 0
+            else:
+                return 1 if user_had_newline else 0, 0
 
         comment_to_add_newlines: Optional[LinesBlock] = None
         if (

--- a/tests/data/cases/class_blank_parentheses.py
+++ b/tests/data/cases/class_blank_parentheses.py
@@ -39,6 +39,7 @@ class ClassWithSpaceParentheses:
 
 
 class ClassWithEmptyFunc(object):
+
     def func_with_blank_parentheses():
         return 5
 

--- a/tests/data/cases/preview_allow_empty_first_line.py
+++ b/tests/data/cases/preview_allow_empty_first_line.py
@@ -22,7 +22,7 @@ def foo():
             Long comment here
             """
             a = 123
-
+    
     if z:
 
         for _ in range(100):

--- a/tests/data/cases/preview_allow_empty_first_line.py
+++ b/tests/data/cases/preview_allow_empty_first_line.py
@@ -22,7 +22,7 @@ def foo():
             Long comment here
             """
             a = 123
-    
+
     if z:
 
         for _ in range(100):
@@ -60,6 +60,15 @@ class Cls:
 
     def method(self):
 
+        pass
+
+
+def top_level(
+    a: int,
+    b: str,
+) -> Whatever[Generic, Something]:
+
+    def nested(x: int) -> int:
         pass
 
 # output
@@ -123,6 +132,16 @@ def quux():
 
 
 class Cls:
+
     def method(self):
 
+        pass
+
+
+def top_level(
+    a: int,
+    b: str,
+) -> Whatever[Generic, Something]:
+
+    def nested(x: int) -> int:
         pass

--- a/tests/data/cases/preview_form_feeds.py
+++ b/tests/data/cases/preview_form_feeds.py
@@ -37,7 +37,7 @@
 #
 
 #
-    
+        
 #
 
 \
@@ -72,7 +72,7 @@ pass
 pass
 
 pass
-    
+        
 pass
 
 
@@ -95,7 +95,7 @@ class Baz:
     def __init__(self):
         pass
     
-
+    
     def something(self):
         pass
     

--- a/tests/data/cases/preview_form_feeds.py
+++ b/tests/data/cases/preview_form_feeds.py
@@ -37,7 +37,7 @@
 #
 
 #
-        
+    
 #
 
 \
@@ -72,7 +72,7 @@ pass
 pass
 
 pass
-        
+    
 pass
 
 
@@ -95,7 +95,7 @@ class Baz:
     def __init__(self):
         pass
     
-    
+
     def something(self):
         pass
     
@@ -203,6 +203,7 @@ def bar(a=1, b: bool = False):
 
 
 class Baz:
+
     def __init__(self):
         pass
 


### PR DESCRIPTION
Fixes #4043, fixes #619

These include nested functions and methods.

I think the nested function case can quite clearly improve readability. I think the method case improves consistency, adherence to PEP 8 and resolves a point of contention.

#4060 intended to allow empty lines at the beginning of all blocks (except immediately before a docstring), but missed this case