### PR TITLE
Remove is_function_or_class helper footgun

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -42,7 +42,7 @@ from black.nodes import (
     is_atom_with_invisible_parens,
     is_docstring,
     is_empty_tuple,
-    is_function_or_class,
+    is_parent_function_or_class,
     is_lpar_token,
     is_multiline_string,
     is_name_token,
@@ -302,7 +302,7 @@ class LineGenerator(Visitor[Line]):
 
         if node.parent and node.parent.type in STATEMENT:
             if Preview.dummy_implementations in self.mode:
-                condition = is_function_or_class(node.parent)
+                condition = is_parent_function_or_class(node)
             else:
                 condition = self.mode.is_pyi
             if condition and is_stub_body(node):

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -746,8 +746,11 @@ def is_funcdef(node: Node) -> bool:
     return node.type == syms.funcdef
 
 
-def is_function_or_class(node: Node) -> bool:
-    return node.type in {syms.funcdef, syms.classdef, syms.async_funcdef}
+def is_parent_function_or_class(node: Node) -> bool:
+    assert node.type in {syms.suite, syms.simple_stmt}
+    assert node.parent is not None
+    # Note this works for suites / simple_stmts in async def as well
+    return node.parent.type in {syms.funcdef, syms.classdef}
 
 
 def is_stub_suite(node: Node, mode: Mode) -> bool:
@@ -755,7 +758,7 @@ def is_stub_suite(node: Node, mode: Mode) -> bool:
     if (
         node.parent is not None
         and Preview.dummy_implementations in mode
-        and not is_function_or_class(node.parent)
+        and not is_parent_function_or_class(node)
     ):
         return False
 

--- a/tests/data/cases/preview_dummy_implementations.py
+++ b/tests/data/cases/preview_dummy_implementations.py
@@ -58,6 +58,17 @@ if some_condition:
 
 if already_dummy: ...
 
+class AsyncCls:
+    async def async_method(self):
+        ...
+
+async def async_function(self):
+    ...
+
+@decorated
+async def async_function(self):
+    ...
+
 # output
 
 from typing import NoReturn, Protocol, Union, overload
@@ -121,3 +132,14 @@ if some_condition:
 
 if already_dummy:
     ...
+
+
+class AsyncCls:
+    async def async_method(self): ...
+
+
+async def async_function(self): ...
+
+
+@decorated
+async def async_function(self): ...


### PR DESCRIPTION
This is a no-op change.

That function was not a good way to tell if something is a function or a class, since it basically only worked for async functions by accident (the parent of a suite / simple_stmt of async function body is a funcdef).