### PR TITLE
Revert "confine pre-commit to stages (#3940)"

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,6 @@
   name: black
   description: "Black: The uncompromising Python code formatter"
   entry: black
-  stages: [pre-commit, pre-merge-commit, pre-push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true
@@ -14,7 +13,6 @@
   description:
     "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
   entry: black
-  stages: [pre-commit, pre-merge-commit, pre-push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Revert the change to run Black's pre-commit integration only on specific git hooks
+  (#3940) for better compatibility with older versions of pre-commit (#4137)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes


### PR DESCRIPTION
Fixes #4065, closes #4067, closes #4041

See comment in https://github.com/psf/black/pull/4041#issuecomment-1871863867

The two possible fixes are both not ideal. Changing the names of the stages guarantees that things will break with new pre-commit later this year. Raising the minimum pre-commit version doesn't make things work for users who currently have issues, it just results in a better error message. Meanwhile, users who want Black to run in specific stages in pre-commit can just specify that themselves, so I think the simplest thing to do is just revert.

I'm open to trying the change later, after pre-commit has released its new breaking change and forced more folks to upgrade (and after we've released the 2024 style)