### PR TITLE
[Docs] Add note on `--exclude` about possibly verbose regex

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -268,6 +268,10 @@ recursive searches. An empty value means no paths are excluded. Use forward slas
 directories on all platforms (Windows, too). By default, Black also ignores all paths
 listed in `.gitignore`. Changing this value will override all default exclusions.
 
+If the regular expression contains newlines, it is treated as a verbose regular
+expression. This is typically useful if setting these options in a `pyproject.toml`
+config file, see [Configuration format](#configuration-format) for more information.
+
 #### `--extend-exclude`
 
 Like `--exclude`, but adds additional files and directories on top of the default values

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -269,10 +269,9 @@ directories on all platforms (Windows, too). By default, Black also ignores all 
 listed in `.gitignore`. Changing this value will override all default exclusions.
 
 If the regular expression contains newlines, it is treated as a
-[verbose regular expression](https://docs.python.org/3/library/re.html#re.VERBOSE).
-This is typically useful when setting these options in a `pyproject.toml`
-configuration file; see [Configuration format](#configuration-format) for more
-information.
+[verbose regular expression](https://docs.python.org/3/library/re.html#re.VERBOSE). This
+is typically useful when setting these options in a `pyproject.toml` configuration file;
+see [Configuration format](#configuration-format) for more information.
 
 #### `--extend-exclude`
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -270,7 +270,8 @@ listed in `.gitignore`. Changing this value will override all default exclusions
 
 If the regular expression contains newlines, it is treated as a verbose regular
 expression. This is typically useful when setting these options in a `pyproject.toml`
-configuration file; see [Configuration format](#configuration-format) for more information.
+configuration file; see [Configuration format](#configuration-format) for more
+information.
 
 #### `--extend-exclude`
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -269,8 +269,8 @@ directories on all platforms (Windows, too). By default, Black also ignores all 
 listed in `.gitignore`. Changing this value will override all default exclusions.
 
 If the regular expression contains newlines, it is treated as a verbose regular
-expression. This is typically useful if setting these options in a `pyproject.toml`
-config file, see [Configuration format](#configuration-format) for more information.
+expression. This is typically useful when setting these options in a `pyproject.toml`
+configuration file; see [Configuration format](#configuration-format) for more information.
 
 #### `--extend-exclude`
 

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -268,8 +268,9 @@ recursive searches. An empty value means no paths are excluded. Use forward slas
 directories on all platforms (Windows, too). By default, Black also ignores all paths
 listed in `.gitignore`. Changing this value will override all default exclusions.
 
-If the regular expression contains newlines, it is treated as a verbose regular
-expression. This is typically useful when setting these options in a `pyproject.toml`
+If the regular expression contains newlines, it is treated as a
+[verbose regular expression](https://docs.python.org/3/library/re.html#re.VERBOSE).
+This is typically useful when setting these options in a `pyproject.toml`
 configuration file; see [Configuration format](#configuration-format) for more
 information.
 


### PR DESCRIPTION
### Description

Black has regex options to exclude/include files from processing: `exclude`, `extend-exclude`, `force-exclude`, `include`.

As other options `pyproject.toml` can be used to set values.

For example:

```toml
extend-exclude = '^file_one\.py|file_two\.py$'
```

However that's not too readable especially if the list was longer...

Thankfully black accepts regexs with newlines:

```toml
extend-exclude = '''
^
file_one\.py
|file_two\.py
$
'''
```

This works by parsing a regex as a [verbose regex](https://docs.python.org/3/library/re.html#re.X) when it contains newlines:

https://github.com/psf/black/blob/e11eaf2f44d3db5713fb99bdec966ba974b60c8c/src/black/__init__.py#L194-L202

I discovered all this while making changes to document this behavior, this has all been magic to me for a long time.

It turns out this behavior is documented here: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format

However I never found about it when Ctrl+F / search ing the documentation.

So this PR simply adds a link to that part after a short comment near the `--exclude` option which I think is the primary thing you would look at for information. (at least I did)

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary? *Not necessary*
- [x] Add / update tests if necessary? *Not necessary*
- [x] Add new / update outdated documentation? *That's the point*
