### PR TITLE
Fixed the empty spaces of '# type:'

### DIFF
--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -875,7 +875,7 @@ def is_type_comment(leaf: Leaf) -> bool:
     used in modern version of Python, this function may be deprecated in the future."""
     t = leaf.type
     v = leaf.value
-    return t in {token.COMMENT, STANDALONE_COMMENT} and v.startswith("# type:")
+    return t in {token.COMMENT, STANDALONE_COMMENT} and v.startswith(" ".join("# type:".split()))
 
 
 def is_type_ignore_comment(leaf: Leaf) -> bool:


### PR DESCRIPTION
Fixes #2097

### Description

I have added the `join` and `split` methods so that the `split` method breaks up the string into a list by separating it with spaces, and then the `join` method joins the list back into one string with a single space between each word.