### PR TITLE
Simplify code in lines.py

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -565,13 +565,7 @@ class EmptyLineTracker:
         )
         before, after = self._maybe_empty_lines(current_line)
         previous_after = self.previous_block.after if self.previous_block else 0
-        before = (
-            # Black should not insert empty lines at the beginning
-            # of the file
-            0
-            if self.previous_line is None
-            else before - previous_after
-        )
+        before = max(0, before - previous_after)
         if (
             # Always have one empty line after a module docstring
             self.previous_block

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -734,9 +734,6 @@ class EmptyLineTracker:
                     newlines = 0
                 else:
                     newlines = 1
-            # Remove case `self.previous_line.depth > current_line.depth` below when
-            # this becomes stable.
-            #
             # Don't inspect the previous line if it's part of the body of the previous
             # statement in the same level, we always want a blank line if there's
             # something with a body preceding.
@@ -753,8 +750,6 @@ class EmptyLineTracker:
                     # Blank line between a block of functions (maybe with preceding
                     # decorators) and a block of non-functions
                     newlines = 1
-            elif self.previous_line.depth > current_line.depth:
-                newlines = 1
             else:
                 newlines = 0
         else:

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -608,7 +608,7 @@ class EmptyLineTracker:
         self.previous_block = block
         return block
 
-    def _maybe_empty_lines(self, current_line: Line) -> Tuple[int, int]:
+    def _maybe_empty_lines(self, current_line: Line) -> Tuple[int, int]:  # noqa: C901
         max_allowed = 1
         if current_line.depth == 0:
             max_allowed = 1 if self.mode.is_pyi else 2

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -623,9 +623,8 @@ class EmptyLineTracker:
         previous_def = None
         while self.previous_defs and self.previous_defs[-1].depth >= depth:
             previous_def = self.previous_defs.pop()
-        if current_line.is_decorator or current_line.is_def or current_line.is_class:
-            if not current_line.is_decorator:
-                self.previous_defs.append(current_line)
+        if current_line.is_def or current_line.is_class:
+            self.previous_defs.append(current_line)
 
         if self.previous_line is None:
             # Don't insert empty lines before the first line in the file.


### PR DESCRIPTION
This has been getting a little messy. These changes neaten things up, we don't have to keep guarding against `self.previous_line is not None`, we make it clearer what logic has side effects, we reduce the amount of code that tricky `before` could touch, etc

This change is intended to be a no-op