### PR TITLE
feat: add schema and validate-pyproject support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,8 @@ jobs:
       - name: Format ourselves
         run: |
           tox -e run_self
+
+      - name: Regenerate schema
+        run: |
+          tox -e generate_schema
+          git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,4 +106,4 @@ jobs:
           python -m pip install -e ".[uvloop]"
 
       - name: Format ourselves
-        run: python -m black --check .
+        run: python -m black --check src/ tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,9 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        exclude: ^docs/conf.py
-        args: ["--config-file", "pyproject.toml"]
-        additional_dependencies:
+        exclude: ^(docs/conf.py|scripts/generate_schema.py)$
+        args: []
+        additional_dependencies: &mypy_deps
           - types-PyYAML
           - tomli >= 0.2.6, < 2.0.0
           - click >= 8.1.0, != 8.1.4, != 8.1.5
@@ -56,6 +56,11 @@ repos:
           - types-commonmark
           - urllib3
           - hypothesmith
+      - id: mypy
+        name: mypy (Python 3.10)
+        files: scripts/generate_schema.py
+        args: ["--python-version=3.10"]
+        additional_dependencies: *mypy_deps
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Add a JSONSchema and provide a validate-pyproject entry-point (#4181)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ jupyter = [
 black = "black:patched_main"
 blackd = "blackd:patched_main [d]"
 
+[project.entry-points."validate_pyproject.tool_schema"]
+black = "black.schema:get_schema"
+
 [project.urls]
 Changelog = "https://github.com/psf/black/blob/main/CHANGES.md"
 Homepage = "https://github.com/psf/black"

--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -1,0 +1,64 @@
+import json
+from typing import IO, Any
+
+import click
+
+import black
+
+
+def generate_schema_from_click(
+    cmd: click.Command,
+) -> dict[str, Any]:
+    result = {}
+    for param in cmd.params:
+        if not isinstance(param, click.Option) or param.is_eager:
+            continue
+        assert param.name
+        name = param.name.replace("_", "-")
+        default = {"default": param.default} if param.default is not None else {}
+        json_type: dict[str, Any]
+        match param.type:
+            case click.types.IntParamType():
+                json_type = {"type": "integer"}
+            case click.types.StringParamType() | click.types.Path():
+                json_type = {"type": "string"}
+            case click.types.Choice(choices=choices):
+                json_type = {"enum": choices}
+            case click.types.BoolParamType():
+                json_type = {"type": "boolean"}
+            case _:
+                msg = f"{param.type!r} not a known type for {param}"
+                raise TypeError(msg)
+
+        if param.multiple:
+            json_type = {"type": "array", "items": json_type}
+
+        result[name] = {**default, **json_type, "description": param.help}
+    return result
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--schemastore", is_flag=True, help="SchemaStore format")
+@click.option("--outfile", type=click.File(mode="w"), help="Write to file")
+def main(schemastore: bool, outfile: IO[str]) -> None:
+    properties = generate_schema_from_click(black.main)
+    del properties["line-ranges"]
+    schema: dict[str, Any] = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": (
+            "https://github.com/psf/black/blob/main/black/resources/black.schema.json"
+        ),
+        "$comment": "black table in pyproject.toml",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": properties,
+    }
+    if schemastore:
+        schema["$id"] = ("https://json.schemastore.org/partial-black.json",)
+        schema["properties"]["enable-unstable-feature"]["items"] = {"type": "string"}
+
+    print(json.dumps(schema, indent=2), file=outfile)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -55,7 +55,7 @@ def main(schemastore: bool, outfile: IO[str]) -> None:
         "$id": (
             "https://github.com/psf/black/blob/main/black/resources/black.schema.json"
         ),
-        "$comment": "black table in pyproject.toml",
+        "$comment": "tool.black table in pyproject.toml",
         "type": "object",
         "additionalProperties": False,
         "properties": properties,
@@ -63,6 +63,8 @@ def main(schemastore: bool, outfile: IO[str]) -> None:
 
     if schemastore:
         schema["$id"] = ("https://json.schemastore.org/partial-black.json",)
+        # The precise list of unstable features may change frequently, so don't
+        # bother putting it in SchemaStore
         schema["properties"]["enable-unstable-feature"]["items"] = {"type": "string"}
 
     print(json.dumps(schema, indent=2), file=outfile)

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -10,9 +10,9 @@
       "description": "Format the code passed in as a string."
     },
     "line-length": {
-      "default": 88,
       "type": "integer",
-      "description": "How many characters per line to allow."
+      "description": "How many characters per line to allow.",
+      "default": 88
     },
     "target-version": {
       "type": "array",
@@ -33,17 +33,16 @@
       "description": "Python versions that should be supported by Black's output. You should include all versions that your code supports. By default, Black will infer target versions from the project metadata in pyproject.toml. If this does not yield conclusive results, Black will use per-file auto-detection."
     },
     "pyi": {
-      "default": false,
       "type": "boolean",
-      "description": "Format all input files like typing stubs regardless of file extension. This is useful when piping source on standard input."
+      "description": "Format all input files like typing stubs regardless of file extension. This is useful when piping source on standard input.",
+      "default": false
     },
     "ipynb": {
-      "default": false,
       "type": "boolean",
-      "description": "Format all input files like Jupyter Notebooks regardless of file extension. This is useful when piping source on standard input."
+      "description": "Format all input files like Jupyter Notebooks regardless of file extension. This is useful when piping source on standard input.",
+      "default": false
     },
     "python-cell-magics": {
-      "default": [],
       "type": "array",
       "items": {
         "type": "string"
@@ -51,29 +50,29 @@
       "description": "When processing Jupyter Notebooks, add the given magic to the list of known python-magics (capture, prun, pypy, python, python3, time, timeit). Useful for formatting cells with custom python magics."
     },
     "skip-source-first-line": {
-      "default": false,
       "type": "boolean",
-      "description": "Skip the first line of the source code."
+      "description": "Skip the first line of the source code.",
+      "default": false
     },
     "skip-string-normalization": {
-      "default": false,
       "type": "boolean",
-      "description": "Don't normalize string quotes or prefixes."
+      "description": "Don't normalize string quotes or prefixes.",
+      "default": false
     },
     "skip-magic-trailing-comma": {
-      "default": false,
       "type": "boolean",
-      "description": "Don't use trailing commas as a reason to split lines."
+      "description": "Don't use trailing commas as a reason to split lines.",
+      "default": false
     },
     "preview": {
-      "default": false,
       "type": "boolean",
-      "description": "Enable potentially disruptive style changes that may be added to Black's main functionality in the next major release."
+      "description": "Enable potentially disruptive style changes that may be added to Black's main functionality in the next major release.",
+      "default": false
     },
     "unstable": {
-      "default": false,
       "type": "boolean",
-      "description": "Enable potentially disruptive style changes that have known bugs or are not currently expected to make it into the stable style Black's next major release. Implies --preview."
+      "description": "Enable potentially disruptive style changes that have known bugs or are not currently expected to make it into the stable style Black's next major release. Implies --preview.",
+      "default": false
     },
     "enable-unstable-feature": {
       "type": "array",
@@ -92,24 +91,24 @@
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."
     },
     "check": {
-      "default": false,
       "type": "boolean",
-      "description": "Don't write the files back, just return the status. Return code 0 means nothing would change. Return code 1 means some files would be reformatted. Return code 123 means there was an internal error."
+      "description": "Don't write the files back, just return the status. Return code 0 means nothing would change. Return code 1 means some files would be reformatted. Return code 123 means there was an internal error.",
+      "default": false
     },
     "diff": {
-      "default": false,
       "type": "boolean",
-      "description": "Don't write the files back, just output a diff to indicate what changes Black would've made. They are printed to stdout so capturing them is simple."
+      "description": "Don't write the files back, just output a diff to indicate what changes Black would've made. They are printed to stdout so capturing them is simple.",
+      "default": false
     },
     "color": {
-      "default": false,
       "type": "boolean",
-      "description": "Show (or do not show) colored diff. Only applies when --diff is given."
+      "description": "Show (or do not show) colored diff. Only applies when --diff is given.",
+      "default": false
     },
     "fast": {
-      "default": false,
       "type": "boolean",
-      "description": "By default, Black performs an AST safety check after formatting your code. The --fast flag turns off this check and the --safe flag explicitly enables it. [default: --safe]"
+      "description": "By default, Black performs an AST safety check after formatting your code. The --fast flag turns off this check and the --safe flag explicitly enables it. [default: --safe]",
+      "default": false
     },
     "required-version": {
       "type": "string",
@@ -128,23 +127,23 @@
       "description": "Like --exclude, but files and directories matching this regex will be excluded even when they are passed explicitly as arguments. This is useful when invoking Black programmatically on changed files, such as in a pre-commit hook or editor plugin."
     },
     "include": {
-      "default": "(\\.pyi?|\\.ipynb)$",
       "type": "string",
-      "description": "A regular expression that matches files and directories that should be included on recursive searches. An empty value means all files are included regardless of the name. Use forward slashes for directories on all platforms (Windows, too). Overrides all exclusions, including from .gitignore and command line options."
+      "description": "A regular expression that matches files and directories that should be included on recursive searches. An empty value means all files are included regardless of the name. Use forward slashes for directories on all platforms (Windows, too). Overrides all exclusions, including from .gitignore and command line options.",
+      "default": "(\\.pyi?|\\.ipynb)$"
     },
     "workers": {
       "type": "integer",
       "description": "When Black formats multiple files, it may use a process pool to speed up formatting. This option controls the number of parallel workers. This can also be specified via the BLACK_NUM_WORKERS environment variable. Defaults to the number of CPUs in the system."
     },
     "quiet": {
-      "default": false,
       "type": "boolean",
-      "description": "Stop emitting all non-critical output. Error messages will still be emitted (which can silenced by 2>/dev/null)."
+      "description": "Stop emitting all non-critical output. Error messages will still be emitted (which can silenced by 2>/dev/null).",
+      "default": false
     },
     "verbose": {
-      "default": false,
       "type": "boolean",
-      "description": "Emit messages about files that were not changed or were ignored due to exclusion patterns. If Black is using a configuration file, a message detailing which one it is using will be emitted."
+      "description": "Emit messages about files that were not changed or were ignored due to exclusion patterns. If Black is using a configuration file, a message detailing which one it is using will be emitted.",
+      "default": false
     }
   }
 }

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/psf/black/blob/main/black/resources/black.schema.json",
+  "$comment": "black table in pyproject.toml",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "type": "string",
+      "description": "Format the code passed in as a string."
+    },
+    "line-length": {
+      "default": 88,
+      "type": "integer",
+      "description": "How many characters per line to allow."
+    },
+    "target-version": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "py33",
+          "py34",
+          "py35",
+          "py36",
+          "py37",
+          "py38",
+          "py39",
+          "py310",
+          "py311",
+          "py312"
+        ]
+      },
+      "description": "Python versions that should be supported by Black's output. You should include all versions that your code supports. By default, Black will infer target versions from the project metadata in pyproject.toml. If this does not yield conclusive results, Black will use per-file auto-detection."
+    },
+    "pyi": {
+      "default": false,
+      "type": "boolean",
+      "description": "Format all input files like typing stubs regardless of file extension. This is useful when piping source on standard input."
+    },
+    "ipynb": {
+      "default": false,
+      "type": "boolean",
+      "description": "Format all input files like Jupyter Notebooks regardless of file extension. This is useful when piping source on standard input."
+    },
+    "python-cell-magics": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "When processing Jupyter Notebooks, add the given magic to the list of known python-magics (capture, prun, pypy, python, python3, time, timeit). Useful for formatting cells with custom python magics."
+    },
+    "skip-source-first-line": {
+      "default": false,
+      "type": "boolean",
+      "description": "Skip the first line of the source code."
+    },
+    "skip-string-normalization": {
+      "default": false,
+      "type": "boolean",
+      "description": "Don't normalize string quotes or prefixes."
+    },
+    "skip-magic-trailing-comma": {
+      "default": false,
+      "type": "boolean",
+      "description": "Don't use trailing commas as a reason to split lines."
+    },
+    "preview": {
+      "default": false,
+      "type": "boolean",
+      "description": "Enable potentially disruptive style changes that may be added to Black's main functionality in the next major release."
+    },
+    "unstable": {
+      "default": false,
+      "type": "boolean",
+      "description": "Enable potentially disruptive style changes that have known bugs or are not currently expected to make it into the stable style Black's next major release. Implies --preview."
+    },
+    "enable-unstable-feature": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "hex_codes_in_unicode_sequences",
+          "string_processing",
+          "hug_parens_with_braces_and_square_brackets",
+          "unify_docstring_detection",
+          "no_normalize_fmt_skip_whitespace",
+          "wrap_long_dict_values_in_parens",
+          "multiline_string_handling",
+          "typed_params_trailing_comma"
+        ]
+      },
+      "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."
+    },
+    "check": {
+      "default": false,
+      "type": "boolean",
+      "description": "Don't write the files back, just return the status. Return code 0 means nothing would change. Return code 1 means some files would be reformatted. Return code 123 means there was an internal error."
+    },
+    "diff": {
+      "default": false,
+      "type": "boolean",
+      "description": "Don't write the files back, just output a diff to indicate what changes Black would've made. They are printed to stdout so capturing them is simple."
+    },
+    "color": {
+      "default": false,
+      "type": "boolean",
+      "description": "Show (or do not show) colored diff. Only applies when --diff is given."
+    },
+    "fast": {
+      "default": false,
+      "type": "boolean",
+      "description": "By default, Black performs an AST safety check after formatting your code. The --fast flag turns off this check and the --safe flag explicitly enables it. [default: --safe]"
+    },
+    "required-version": {
+      "type": "string",
+      "description": "Require a specific version of Black to be running. This is useful for ensuring that all contributors to your project are using the same version, because different versions of Black may format code a little differently. This option can be set in a configuration file for consistent results across environments."
+    },
+    "exclude": {
+      "type": "string",
+      "description": "A regular expression that matches files and directories that should be excluded on recursive searches. An empty value means no paths are excluded. Use forward slashes for directories on all platforms (Windows, too). By default, Black also ignores all paths listed in .gitignore. Changing this value will override all default exclusions. [default: /(\\.direnv|\\.eggs|\\.git|\\.hg|\\.ipynb_checkpoints|\\.mypy_cache|\\.nox|\\.pytest_cache|\\.ruff_cache|\\.tox|\\.svn|\\.venv|\\.vscode|__pypackages__|_build|buck-out|build|dist|venv)/]"
+    },
+    "extend-exclude": {
+      "type": "string",
+      "description": "Like --exclude, but adds additional files and directories on top of the default values instead of overriding them."
+    },
+    "force-exclude": {
+      "type": "string",
+      "description": "Like --exclude, but files and directories matching this regex will be excluded even when they are passed explicitly as arguments. This is useful when invoking Black programmatically on changed files, such as in a pre-commit hook or editor plugin."
+    },
+    "include": {
+      "default": "(\\.pyi?|\\.ipynb)$",
+      "type": "string",
+      "description": "A regular expression that matches files and directories that should be included on recursive searches. An empty value means all files are included regardless of the name. Use forward slashes for directories on all platforms (Windows, too). Overrides all exclusions, including from .gitignore and command line options."
+    },
+    "workers": {
+      "type": "integer",
+      "description": "When Black formats multiple files, it may use a process pool to speed up formatting. This option controls the number of parallel workers. This can also be specified via the BLACK_NUM_WORKERS environment variable. Defaults to the number of CPUs in the system."
+    },
+    "quiet": {
+      "default": false,
+      "type": "boolean",
+      "description": "Stop emitting all non-critical output. Error messages will still be emitted (which can silenced by 2>/dev/null)."
+    },
+    "verbose": {
+      "default": false,
+      "type": "boolean",
+      "description": "Emit messages about files that were not changed or were ignored due to exclusion patterns. If Black is using a configuration file, a message detailing which one it is using will be emitted."
+    }
+  }
+}

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/psf/black/blob/main/black/resources/black.schema.json",
-  "$comment": "black table in pyproject.toml",
+  "$comment": "tool.black table in pyproject.toml",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/black/schema.py
+++ b/src/black/schema.py
@@ -8,12 +8,13 @@ def get_schema(tool_name: str = "black") -> Any:
     """Get the stored complete schema for black's settings."""
     assert tool_name == "black", "Only black is supported."
 
-    loc = "resources/black.schema.json"
+    pkg = "black.resources"
+    fname = "black.schema.json"
 
     if sys.version_info < (3, 9):
-        with importlib.resources.open_text("black", loc, encoding="utf-8") as f:
+        with importlib.resources.open_text(pkg, fname, encoding="utf-8") as f:
             return json.load(f)
 
-    schema = importlib.resources.files("black").joinpath(loc)  # type: ignore[unreachable]
+    schema = importlib.resources.files(pkg).joinpath(fname)  # type: ignore[unreachable]
     with schema.open(encoding="utf-8") as f:
         return json.load(f)

--- a/src/black/schema.py
+++ b/src/black/schema.py
@@ -1,0 +1,19 @@
+import importlib.resources
+import json
+import sys
+from typing import Any
+
+
+def get_schema(tool_name: str = "cibuildwheel") -> Any:
+    "Get the stored complete schema for black's settings."
+    assert tool_name == "black", "Only black is supported."
+
+    loc = "resources/black.schema.json"
+
+    if sys.version_info < (3, 9):
+        with importlib.resources.open_text("black", loc, encoding="utf-8") as f:
+            return json.load(f)
+
+    schema = importlib.resources.files("black").joinpath(loc)  # type: ignore[unreachable]
+    with schema.open(encoding="utf-8") as f:
+        return json.load(f)

--- a/src/black/schema.py
+++ b/src/black/schema.py
@@ -4,8 +4,8 @@ import sys
 from typing import Any
 
 
-def get_schema(tool_name: str = "cibuildwheel") -> Any:
-    "Get the stored complete schema for black's settings."
+def get_schema(tool_name: str = "black") -> Any:
+    """Get the stored complete schema for black's settings."""
     assert tool_name == "black", "Only black is supported."
 
     loc = "resources/black.schema.json"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,7 +5,7 @@ import sys
 def test_schema_entrypoint() -> None:
     if sys.version_info < (3, 10):
         eps = importlib.metadata.entry_points()["validate_pyproject.tool_schema"]
-        (black_ep,) = [ep for ep in eps if ep.name == "wheel"]
+        (black_ep,) = [ep for ep in eps if ep.name == "black"]
     else:
         (black_ep,) = importlib.metadata.entry_points(
             group="validate_pyproject.tool_schema", name="black"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,17 @@
+import importlib.metadata
+import sys
+
+
+def test_schema_entrypoint() -> None:
+    if sys.version_info < (3, 10):
+        eps = importlib.metadata.entry_points()["validate_pyproject.tool_schema"]
+        (black_ep,) = [ep for ep in eps if ep.name == "wheel"]
+    else:
+        (black_ep,) = importlib.metadata.entry_points(
+            group="validate_pyproject.tool_schema", name="black"
+        )
+
+    black_fn = black_ep.load()
+    schema = black_fn()
+    assert schema == black_fn("black")
+    assert schema["properties"]["line-length"]["type"] == "integer"

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,9 @@ commands =
     black --check {toxinidir}/src {toxinidir}/tests
 
 [testenv:generate_schema]
-skip_install = False
+setenv = PYTHONWARNDEFAULTENCODING =
+skip_install = True
 deps =
 commands =
+    pip install -e .
     python {toxinidir}/scripts/generate_schema.py --outfile {toxinidir}/src/black/resources/black.schema.json

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = {,ci-}py{38,39,310,311,py3},fuzz,run_self
+envlist = {,ci-}py{38,39,310,311,py3},fuzz,run_self,generate_schema
 
 [testenv]
 setenv =
@@ -96,3 +96,9 @@ skip_install = True
 commands =
     pip install -e .
     black --check {toxinidir}/src {toxinidir}/tests
+
+[testenv:generate_schema]
+skip_install = False
+deps =
+commands =
+    python {toxinidir}/scripts/generate_schema.py --outfile {toxinidir}/src/black/resources/black.schema.json


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This adds a script (Python 3.10+ required) to produce a JSONSchema. I've added it to the package, and provided a helper function / entrypoint to allow [validate-pyproject](https://github.com/abravalheri/validate-pyproject) to use it. You can try it out like this:

```console
$ virtualenv .venv
$ py -m pip install -e . validate-pyproject[all]
$ validate-pyproject -v pyproject.toml
[INFO] black.schema.get_schema defines `tool.black` schema
[INFO] validate_pyproject.api.load_builtin_plugin defines `tool.distutils` schema
[INFO] validate_pyproject.api.load_builtin_plugin defines `tool.setuptools` schema
[WARNING] `blackd:patched_main [d]` - using extras for entry points is not recommended
Valid file: pyproject.toml
```

You can also adjust the tool.black section and see the validation errors. :)

I've also included a `--schemastore` option, which adjusts the output a little for SchemaStore. After this goes in, I'll make a PR to SchemaStore with the schema. The main difference is `enable-unstable-feature` is simplified to just be any string. If someone is getting the schema directly from black, then they get the exact enum of options, but SchemaStore is not versioned.

Closes #4160.

This goes along with #4178 and doesn't include all the interesting ways to set things that are technically currently supported, like using strings instead of bools and using `_` instead of `-`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

I'll adjust those things after I see how much/little is needed here. I could add (re)generation of the schema file to CI, some tests using validate-pyproject, etc. Or I could remove parts too.

I also realize I forgot to see if this works on Python 3.8, as the importlib logic is different there.

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
