### PR TITLE
Move hug_parens_with_braces_and_square_brackets into the unstable style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Move the `hug_parens_with_braces_and_square_brackets` feature to the unstable style
+  due to an outstanding crash and proposed formatting tweaks (#4198)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -22,8 +22,6 @@ Currently, the following features are included in the preview style:
   strings
 - `unify_docstring_detection`: fix inconsistencies in whether certain strings are
   detected as docstrings
-- `hug_parens_with_braces_and_square_brackets`: more compact formatting of nested
-  brackets ([see below](labels/hug-parens))
 - `no_normalize_fmt_skip_whitespace`: whitespace before `# fmt: skip` comments is no
   longer normalized
 - `typed_params_trailing_comma`: consistently add trailing commas to typed function
@@ -39,6 +37,8 @@ The unstable style additionally includes the following features:
   ([see below](labels/wrap-long-dict-values))
 - `multiline_string_handling`: more compact formatting of expressions involving
   multiline strings ([see below](labels/multiline-string-handling))
+- `hug_parens_with_braces_and_square_brackets`: more compact formatting of nested
+  brackets ([see below](labels/hug-parens))
 
 (labels/hug-parens)=
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -179,8 +179,6 @@ class Preview(Enum):
     typed_params_trailing_comma = auto()
 
 
-# See https://github.com/psf/black/issues?q=is%3Aissue+is%3Aopen+label%3A%22C%3A+preview+style%22
-# for all open issues with the preview and unstable style.
 UNSTABLE_FEATURES: Set[Preview] = {
     # Many issues, see summary in https://github.com/psf/black/issues/4042
     Preview.string_processing,

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -179,6 +179,8 @@ class Preview(Enum):
     typed_params_trailing_comma = auto()
 
 
+# See https://github.com/psf/black/issues?q=is%3Aissue+is%3Aopen+label%3A%22C%3A+preview+style%22
+# for all open issues with the preview and unstable style.
 UNSTABLE_FEATURES: Set[Preview] = {
     # Many issues, see summary in https://github.com/psf/black/issues/4042
     Preview.string_processing,
@@ -186,6 +188,8 @@ UNSTABLE_FEATURES: Set[Preview] = {
     Preview.wrap_long_dict_values_in_parens,
     # See issue #4159
     Preview.multiline_string_handling,
+    # See issue #4036 (crash), #4098, #4099 (proposed tweaks)
+    Preview.hug_parens_with_braces_and_square_brackets,
 }
 
 

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets.py
@@ -1,4 +1,4 @@
-# flags: --preview
+# flags: --unstable
 def foo_brackets(request):
     return JsonResponse(
         {

--- a/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
+++ b/tests/data/cases/preview_hug_parens_with_braces_and_square_brackets_no_ll1.py
@@ -1,4 +1,4 @@
-# flags: --preview --no-preview-line-length-1
+# flags: --unstable --no-preview-line-length-1
 # split out from preview_hug_parens_with_brackes_and_square_brackets, as it produces
 # different code on the second pass with line-length 1 in many cases.
 # Seems to be about whether the last string in a sequence gets wrapped in parens or not.


### PR DESCRIPTION
Primarily because of #4036 (a crash) but also because of the feedback
in #4098 and #4099.

<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
