### PR TITLE
Ignore pyproject.toml missing tool.black section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased
+
+### Configuration
+
+- _Black_ now ignores `pyproject.toml` that is missing a `tool.black` section when
+  discovering project root and configuration. Since _Black_ continues to use version
+  control as an indicator of project root, this is expected to primarily change behavior
+  for users in a monorepo setup (desirably). If you wish to preserve previous behavior,
+  simply add an empty `[tool.black]` to the previously discovered `pyproject.toml`
+  (#4204)
+
 ## 24.1.1
 
 Bugfix release to fix a bug that made Black unusable on certain file systems with strict

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -457,10 +457,10 @@ of tools like [Poetry](https://python-poetry.org/),
 ### Where _Black_ looks for the file
 
 By default _Black_ looks for `pyproject.toml` containing a `[tool.black]` section
-starting from the common base directory of
-all files and directories passed on the command line. If it's not there, it looks in
-parent directories. It stops looking when it finds the file, or a `.git` directory, or a
-`.hg` directory, or the root of the file system, whichever comes first.
+starting from the common base directory of all files and directories passed on the
+command line. If it's not there, it looks in parent directories. It stops looking when
+it finds the file, or a `.git` directory, or a `.hg` directory, or the root of the file
+system, whichever comes first.
 
 If you're formatting standard input, _Black_ will look for configuration starting from
 the current working directory.

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -456,7 +456,8 @@ of tools like [Poetry](https://python-poetry.org/),
 
 ### Where _Black_ looks for the file
 
-By default _Black_ looks for `pyproject.toml` starting from the common base directory of
+By default _Black_ looks for `pyproject.toml` containing a `[tool.black]` section
+starting from the common base directory of
 all files and directories passed on the command line. If it's not there, it looks in
 parent directories. It stops looking when it finds the file, or a `.git` directory, or a
 `.hg` directory, or the root of the file system, whichever comes first.

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1668,9 +1668,9 @@ class BlackTestCase(BlackBaseTestCase):
             src_dir.mkdir()
 
             root_pyproject = root / "pyproject.toml"
-            root_pyproject.touch()
+            root_pyproject.write_text("[tool.black]", encoding="utf-8")
             src_pyproject = src_dir / "pyproject.toml"
-            src_pyproject.touch()
+            src_pyproject.write_text("[tool.black]", encoding="utf-8")
             src_python = src_dir / "foo.py"
             src_python.touch()
 
@@ -1692,6 +1692,20 @@ class BlackTestCase(BlackBaseTestCase):
                     black.find_project_root(("-",), stdin_filename="../src/a.py"),
                     (src_dir.resolve(), "pyproject.toml"),
                 )
+
+            src_sub = src_dir / "sub"
+            src_sub.mkdir()
+
+            src_sub_pyproject = src_sub / "pyproject.toml"
+            src_sub_pyproject.touch()  # empty
+
+            src_sub_python = src_sub / "bar.py"
+
+            # we skip src_sub_pyproject since it is missing the [tool.black] section
+            self.assertEqual(
+                black.find_project_root((src_sub_python,)),
+                (src_dir.resolve(), "pyproject.toml"),
+            )
 
     @patch(
         "black.files.find_user_pyproject_toml",


### PR DESCRIPTION
Fixes #2863

This is pretty desirable in a monorepo situation where you have configuration in the root since it will mean you don't have to reconfigure every project.

The good news for backward compatibility is that `find_project_root` continues to stop at any git or hg root, so in all cases repo root coincides with a pyproject.toml missing tool.black, we'll continue to have the project root as before and end up using default config as before (i.e. we're unlikely to randomly start using the user config).

The other thing we need to be a little careful about is that changing find_project_root logic affects what `exclude` is relative to.  Since we only change in cases where there is no config, this only applies where users were using `exclude` via command line arg (and had pyproject.toml missing `tool.black` in a dir that was not repo root).

Finally, for the few who could be affected, the fix is to put an empty `[tool.black]` in pyproject.toml