### PR TITLE
Remove redundant parentheses in `case` statement `if` guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
   expression (#4154)
 - Checking for newline before adding one on docstring that is almost at the line limit
   (#4185)
+- Remove redundant parentheses in `case` statement `if` guards (#4214).
 
 ### Configuration
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -32,6 +32,8 @@ Currently, the following features are included in the preview style:
   expressions that involve the power operator
 - `docstring_check_for_newline`: checks if there is a newline before the terminating
   quotes of a docstring
+- `remove_redundant_guard_parens`: Removes redundant parentheses in `if` guards for
+  `case` blocks.
 
 (labels/unstable-features)=
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -529,6 +529,8 @@ class LineGenerator(Visitor[Line]):
         # PEP 634
         self.visit_match_stmt = self.visit_match_case
         self.visit_case_block = self.visit_match_case
+        if Preview.remove_redundant_guard_parens in self.mode:
+            self.visit_guard = partial(v, keywords=Ø, parens={"if"})
 
 
 def _hugging_power_ops_line_to_string(

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -179,6 +179,7 @@ class Preview(Enum):
     typed_params_trailing_comma = auto()
     is_simple_lookup_for_doublestar_expression = auto()
     docstring_check_for_newline = auto()
+    remove_redundant_guard_parens = auto()
 
 
 UNSTABLE_FEATURES: Set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -87,7 +87,8 @@
           "multiline_string_handling",
           "typed_params_trailing_comma",
           "is_simple_lookup_for_doublestar_expression",
-          "docstring_check_for_newline"
+          "docstring_check_for_newline",
+          "remove_redundant_guard_parens"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/remove_redundant_parens_in_case_guard.py
+++ b/tests/data/cases/remove_redundant_parens_in_case_guard.py
@@ -1,4 +1,4 @@
-# flags: --minimum-version=3.10 --preview
+# flags: --minimum-version=3.10 --preview --line-length=79
 
 match 1:
     case _ if (True):
@@ -12,6 +12,53 @@ match 1:
         pass
 
 
+match 1:
+    case _ if (
+        # this is a comment
+        True
+    ):
+        pass
+
+
+match 1:
+    case _ if (
+        True
+        # this is a comment
+    ):
+        pass
+
+
+match 1:
+    case _ if (
+        True  # this is a comment
+    ):
+        pass
+
+
+match 1:
+    case _ if (  # this is a comment
+        True
+    ):
+        pass
+
+
+match 1:
+    case _ if (
+        True
+    ):  # this is a comment
+        pass
+
+
+match 1:
+    case _ if (True):  # comment over the line limit unless parens are removed x
+        pass
+
+
+match 1:
+    case _ if (True):  # comment over the line limit and parens should go to next line
+        pass
+
+
 # output
 
 match 1:
@@ -21,4 +68,47 @@ match 1:
 
 match 1:
     case _ if True:
+        pass
+
+
+match 1:
+    case _ if (
+        # this is a comment
+        True
+    ):
+        pass
+
+
+match 1:
+    case _ if (
+        True
+        # this is a comment
+    ):
+        pass
+
+
+match 1:
+    case _ if True:  # this is a comment
+        pass
+
+
+match 1:
+    case _ if True:  # this is a comment
+        pass
+
+
+match 1:
+    case _ if True:  # this is a comment
+        pass
+
+
+match 1:
+    case _ if True:  # comment over the line limit unless parens are removed x
+        pass
+
+
+match 1:
+    case (
+        _
+    ) if True:  # comment over the line limit and parens should go to next line
         pass

--- a/tests/data/cases/remove_redundant_parens_in_case_guard.py
+++ b/tests/data/cases/remove_redundant_parens_in_case_guard.py
@@ -1,0 +1,24 @@
+# flags: --minimum-version=3.10 --preview
+
+match 1:
+    case _ if (True):
+        pass
+
+
+match 1:
+    case _ if (
+        True
+    ):
+        pass
+
+
+# output
+
+match 1:
+    case _ if True:
+        pass
+
+
+match 1:
+    case _ if True:
+        pass


### PR DESCRIPTION
### Description

A follow up to #4024 but for `if` guards in `case` statements. I noticed this when #4024 was made stable, and noticed I had some code that had extra parens around the `if` guard.

There might be some edge cases I am not thinking of, but all tests are passing. I put these new changes under the `remove_redundant_guard_parens` preview name.

### Checklist

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?