### PR TITLE
fix: resolve symlinks when checking which files to format

### DIFF
--- a/src/black/files.py
+++ b/src/black/files.py
@@ -283,7 +283,7 @@ def get_root_relative_path(
 ) -> Optional[str]:
     """Returns the file path relative to the 'root' directory"""
     try:
-        root_relative_path = path.absolute().relative_to(root).as_posix()
+        root_relative_path = path.resolve().relative_to(root).as_posix()
     except ValueError:
         if report:
             report.path_ignored(path, f"is a symbolic link that points outside {root}")
@@ -341,7 +341,7 @@ def gen_python_files(
 
     assert root.is_absolute(), f"INTERNAL ERROR: `root` must be absolute but is {root}"
     for child in paths:
-        root_relative_path = child.absolute().relative_to(root).as_posix()
+        root_relative_path = child.resolve().relative_to(root).as_posix()
 
         # First ignore files matching .gitignore, if passed
         if gitignore_dict and _path_is_ignored(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Currently `find_project_root()` resolves symlinks, but `get_sources()` doesn't, so trying to format a file that contains symlinks will fail:
```
$ python -m black --check /home/nfvs/code/black/src/black/files.py
No Python files are present to be formatted. Nothing to do 😴
```

This commit changes methods used in `get_sources()` to, like `find_project_root()`, use `Path.resolve()` instead of `Path.absolute()`, which will follow symlinks.

Also fixes:
- https://github.com/microsoft/vscode-black-formatter/issues/444
- https://github.com/psf/black/issues/4205

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
