### PR TITLE
Use W503 instead of E704 in examples

### DIFF
--- a/docs/guides/using_black_with_other_tools.md
+++ b/docs/guides/using_black_with_other_tools.md
@@ -145,7 +145,7 @@ There are a few deviations that cause incompatibilities with _Black_.
 
 ```
 max-line-length = 88
-extend-ignore = E203, E704
+extend-ignore = E203, W503
 ```
 
 #### Why those options above?
@@ -173,7 +173,7 @@ limit of `88`, _Black_'s default. This explains `max-line-length = 88`.
 ```ini
 [flake8]
 max-line-length = 88
-extend-ignore = E203, E704
+extend-ignore = E203, W503
 ```
 
 </details>
@@ -184,7 +184,7 @@ extend-ignore = E203, E704
 ```ini
 [flake8]
 max-line-length = 88
-extend-ignore = E203, E704
+extend-ignore = E203, W503
 ```
 
 </details>
@@ -195,7 +195,7 @@ extend-ignore = E203, E704
 ```ini
 [flake8]
 max-line-length = 88
-extend-ignore = E203, E704
+extend-ignore = E203, W503
 ```
 
 </details>


### PR DESCRIPTION
The docs explains why E203 and W503 are used, but then uses E203 and E704 in the config snippets