### PR TITLE
Ensure `blib2to3.pygram` is initialized before use

### DIFF
--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -40,12 +40,15 @@ _type_reprs: Dict[int, Union[str, int]] = {}
 def type_repr(type_num: int) -> Union[str, int]:
     global _type_reprs
     if not _type_reprs:
-        from .pygram import python_symbols
+        from . import pygram
+
+        if not hasattr(pygram, "python_symbols"):
+            pygram.initialize(cache_dir=None)
 
         # printing tokens is possible but not as useful
         # from .pgen2 import token // token.__dict__.items():
-        for name in dir(python_symbols):
-            val = getattr(python_symbols, name)
+        for name in dir(pygram.python_symbols):
+            val = getattr(pygram.python_symbols, name)
             if type(val) == int:
                 _type_reprs[val] = name
     return _type_reprs.setdefault(type_num, type_num)


### PR DESCRIPTION
For the last week or so, I've had a frustratingly irreproducible [problem in Hypothesis CI](https://github.com/HypothesisWorks/hypothesis/actions/runs/7866766773/job/21461494063?pr=3877#step:7:182), which gives me

```python-traceback
INTERNALERROR>     pretty = black.format_str(unformatted, mode=mode)
INTERNALERROR>   File "src\black\__init__.py", line 1224, in format_str
INTERNALERROR>   File "src\black\__init__.py", line 1264, in _format_str_once
INTERNALERROR>   File "src\black\nodes.py", line 159, in visit
INTERNALERROR>   File "src\blib2to3\pytree.py", line 43, in type_repr
INTERNALERROR> ImportError: cannot import name 'python_symbols' from 'blib2to3.pygram' 
```

I'm now pretty sure that this is because [`blib2to3.pytree.type_repr()`](https://github.com/psf/black/blob/a20100395cf6179a81289452efad1d8e72b19682/src/blib2to3/pytree.py#L40-L51) tries to import `pygram.python_symbols`, _but_ this name is created by the `initialize()` function and that apparently hasn't been called yet.  Which implies that `black.nodes` hasn't been imported, which is _pretty surprising to me_, but 🤷.  Anyway, I'm working around this downstream regardless, but figured that I'd open a PR rather than a plain issue in case this was a helpful fix.

Thanks again for maintaining Black!