### PR TITLE
Actually use result  of  best_effort_relative_path

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -756,8 +756,6 @@ def get_sources(
                 continue
 
             root_relative_path = best_effort_relative_path(path, root).as_posix()
-            root_relative_path = "/" + root_relative_path
-
             # Hard-exclude any files that matches the `--force-exclude` regex.
             if path_is_excluded(root_relative_path, force_exclude):
                 report.path_ignored(


### PR DESCRIPTION


### Description

Don't clobber result of best_effort_relative_path. Some how this was missed during but we had:
     root_relative_path = best_effort_relative_path(path, root).as_posix()
            root_relative_path = "/" + root_relative_path

Obviously not what was intended in PR #4222
### Checklist - did you ...

- [*] Add an entry in `CHANGES.md` if necessary?
- [*] Add / update tests if necessary?
- [*] Add new / update outdated documentation?
