### PR TITLE
[WIP] Allow Black to use a different Python version than Vim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 
 ### Integrations
 
-<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Allow Black to use a different Python version than Vim
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
 
 ### Integrations
 
-- Allow Black to use a different Python version than Vim
+- Allow Black to use a different Python version than Vim (#4245)
 
 ### Documentation
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -55,10 +55,12 @@ def _get_python_binary(exec_prefix, pyver=sys.version_info[:3]):
     return exec_path
   raise ValueError("python executable not found")
 
-def _get_python_version(exec_path):
+def _get_python_version(exec_path, as_string=False):
   import subprocess
   version_proc = subprocess.run([exec_path, "--version"], stdout=subprocess.PIPE, text=True)
-  version = tuple(map(int, version_proc.stdout.split(" ")[1].strip().split(".")))
+  version = version_proc.stdout.split(" ")[1].strip()
+  if not as_string:
+    version = tuple(map(int, version.split(".")))
   return version
 
 def _get_pip(venv_path):
@@ -231,7 +233,9 @@ def BlackUpgrade():
   _initialize_black_env(upgrade=True)
 
 def BlackVersion():
-  print(f'Black, version {black.__version__} on Python {sys.version}.')
+  virtualenv_path = Path(vim.eval("g:black_virtualenv")).expanduser()
+  virtualenv_python_version = _get_python_version(_get_python_binary(virtualenv_path), as_string=True)
+  print(f'Black, version {black.__version__} on Python {virtualenv_python_version}.')
 
 EndPython3
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -34,7 +34,7 @@ FLAGS = [
 ]
 
 
-def _get_python_binary(exec_prefix, pyver):
+def _get_python_binary(exec_prefix, pyver=sys.version_info[:3]):
   try:
     default = vim.eval("g:pymode_python").strip()
   except vim.error:

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -120,7 +120,12 @@ def _initialize_black_env(upgrade=False):
   return True
 
 if _initialize_black_env():
-  import black
+  # TODO: Better handling of the case when import succeeds but Black doesn't
+  # work, such as when it has been uninstalled from the virtualenv
+  try:
+    import black
+  except ImportError:
+    print(f"Could not import black from any of: {', '.join(sys.path)}.")
   import time
 
 def get_target_version(tv):

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -53,6 +53,9 @@ def _get_python_binary(exec_prefix, pyver=sys.version_info[:3]):
   exec_path = (bin_path / f"python3").resolve()
   if exec_path.exists():
     return exec_path
+  # TODO: Instead of failing, try to find black in PATH first and use its
+  # exec_prefix. This can happen when black is installed systemwide and
+  # g:black_virtualenv was not updated.
   raise ValueError("python executable not found")
 
 def _get_python_version(exec_path, as_string=False):
@@ -88,6 +91,7 @@ def _initialize_black_env(upgrade=False):
         sys.path.insert(0, virtualenv_site_packages)
       return True
 
+  # TODO: Is this check about the Vim plugin, or about Black?
   pyver = sys.version_info[:3]
   if pyver < (3, 8):
     print("Sorry, Black requires Python 3.8+ to run.")

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -4,6 +4,8 @@ import os
 import sys
 import vim
 
+from pathlib import Path
+
 def strtobool(text):
   if text.lower() in ['y', 'yes', 't', 'true', 'on', '1']:
     return True
@@ -71,6 +73,8 @@ def _get_virtualenv_site_packages(venv_path):
   return venv_path / 'lib' / f'python{venv_python_version[0]}.{venv_python_version[1]}' / 'site-packages'
 
 def _initialize_black_env(upgrade=False):
+  virtualenv_path = Path(vim.eval("g:black_virtualenv")).expanduser()
+  virtualenv_site_packages = str(_get_virtualenv_site_packages(virtualenv_path))
   if vim.eval("g:black_use_virtualenv ? 'true' : 'false'") == "false":
     if upgrade:
       print("Upgrade disabled due to g:black_use_virtualenv being disabled.")
@@ -78,7 +82,8 @@ def _initialize_black_env(upgrade=False):
       print("or modify your vimrc to have 'let g:black_use_virtualenv = 1'.")
       return False
     else:
-      # Nothing needed to be done.
+      if virtualenv_site_packages not in sys.path:
+        sys.path.insert(0, virtualenv_site_packages)
       return True
 
   pyver = sys.version_info[:3]
@@ -86,11 +91,8 @@ def _initialize_black_env(upgrade=False):
     print("Sorry, Black requires Python 3.8+ to run.")
     return False
 
-  from pathlib import Path
   import subprocess
   import venv
-  virtualenv_path = Path(vim.eval("g:black_virtualenv")).expanduser()
-  virtualenv_site_packages = str(_get_virtualenv_site_packages(virtualenv_path))
   first_install = False
   if not virtualenv_path.is_dir():
     print('Please wait, one time setup for Black.')


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This branch should fix https://github.com/psf/black/issues/2547

It is sometimes the case that Vim was built with a different Python version than the one used by Black.
One such scenario is when the black virtualenv was created by an older version of Vim and then the system was upgraded in place.
Another scenario is when `g:black_use_virtualenv` is disabled and the manually created environment in `g:black_virtualenv` uses a different Python version. Right now Ubuntu 24.04 builds Vim with Python 3.12 but the system uses Python 3.11 as default, making this scenario more likely to happen:

    $ python3 --version
    Python 3.11.8

    $ vim --version | grep lpython
    Linking: gcc -Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -o vim -lm -ltinfo -lselinux -lsodium -lacl -lattr -lgpm -L/usr/lib/python3.12/config-3.12-x86_64-linux-gnu -lpython3.12 -ldl -lm

Currently, `:BlackVersion` reports Vim's Python version instead of the one found in the virtualenv. This PR fixes that inconsistency as well.

Finally, I added a few TODO comments for issues that I encountered while testing various scenarios but didn't have the time to fix in this PR.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
