### PR TITLE
fix: Don't move comments while splitting delimiters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Don't move comments along with delimiters, which could cause crashes (#4248)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1194,8 +1194,11 @@ def delimiter_split(
     for leaf_idx, leaf in enumerate(line.leaves):
         yield from append_to_line(leaf)
 
-        for comment_after in line.comments_after(leaf):
-            yield from append_to_line(comment_after)
+        previous_leaf = line.leaves[leaf_idx - 1] if leaf_idx > 0 else None
+        previous_priority = previous_leaf and bt.delimiters.get(id(previous_leaf))
+        if previous_priority != delimiter_priority:
+            for comment_after in line.comments_after(leaf):
+                yield from append_to_line(comment_after)
 
         lowest_depth = min(lowest_depth, leaf.bracket_depth)
         if leaf.bracket_depth == lowest_depth:
@@ -1215,6 +1218,10 @@ def delimiter_split(
 
         leaf_priority = bt.delimiters.get(id(leaf))
         if leaf_priority == delimiter_priority:
+            if leaf_idx + 1 < len(line.leaves):
+                for comment_after in line.comments_after(line.leaves[leaf_idx + 1]):
+                    yield from append_to_line(comment_after)
+
             yield current_line
 
             current_line = Line(

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1136,9 +1136,7 @@ def _get_last_non_comment_leaf(line: Line) -> Optional[int]:
     return None
 
 
-def _can_add_trailing_comma(
-    leaf: Leaf, features: Collection[Feature]
-) -> bool:
+def _can_add_trailing_comma(leaf: Leaf, features: Collection[Feature]) -> bool:
     if is_vararg(leaf, within={syms.typedargslist}):
         return Feature.TRAILING_COMMA_IN_DEF in features
     if is_vararg(leaf, within={syms.arglist, syms.argument}):

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1156,6 +1156,9 @@ def _safe_add_trailing_comma(safe: bool, delimiter_priority: int, line: Line) ->
     return line
 
 
+MIGRATE_COMMENT_DELIMITERS = {STRING_PRIORITY, COMMA_PRIORITY}
+
+
 @dont_increase_indentation
 def delimiter_split(
     line: Line, features: Collection[Feature], mode: Mode
@@ -1212,8 +1215,8 @@ def delimiter_split(
             id(line.leaves[leaf_idx - 1])
         )
         if (
-            delimiter_priority == STRING_PRIORITY
-            or previous_priority != delimiter_priority
+            previous_priority != delimiter_priority
+            or delimiter_priority in MIGRATE_COMMENT_DELIMITERS
         ):
             yield from append_comments(leaf)
 
@@ -1230,7 +1233,7 @@ def delimiter_split(
         if leaf_priority == delimiter_priority:
             if (
                 leaf_idx + 1 < len(line.leaves)
-                and delimiter_priority != STRING_PRIORITY
+                and delimiter_priority not in MIGRATE_COMMENT_DELIMITERS
             ):
                 yield from append_comments(line.leaves[leaf_idx + 1])
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1136,6 +1136,20 @@ def _get_last_non_comment_leaf(line: Line) -> Optional[int]:
     return None
 
 
+def _can_add_trailing_comma(leaf: Leaf, features: Collection[Feature]):
+    if (
+        is_vararg(leaf, within={syms.typedargslist})
+        and Feature.TRAILING_COMMA_IN_DEF in features
+    ):
+        return True
+    if (
+        is_vararg(leaf, within={syms.arglist, syms.argument})
+        and Feature.TRAILING_COMMA_IN_CALL in features
+    ):
+        return True
+    return False
+
+
 def _safe_add_trailing_comma(safe: bool, delimiter_priority: int, line: Line) -> Line:
     if (
         safe
@@ -1210,10 +1224,7 @@ def delimiter_split(
 
         lowest_depth = min(lowest_depth, leaf.bracket_depth)
         if trailing_comma_safe and leaf.bracket_depth == lowest_depth:
-            if is_vararg(leaf, within={syms.typedargslist}):
-                trailing_comma_safe = Feature.TRAILING_COMMA_IN_DEF in features
-            elif is_vararg(leaf, within={syms.arglist, syms.argument}):
-                trailing_comma_safe = Feature.TRAILING_COMMA_IN_CALL in features
+            trailing_comma_safe = _can_add_trailing_comma(leaf, features)
 
         if last_leaf.type == STANDALONE_COMMENT and leaf_idx == last_non_comment_leaf:
             current_line = _safe_add_trailing_comma(

--- a/tests/data/cases/split_delimiter_comments.py
+++ b/tests/data/cases/split_delimiter_comments.py
@@ -1,0 +1,18 @@
+a = (
+    1 +  # type: ignore
+    2  # type: ignore
+)
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)
+
+# output
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)

--- a/tests/data/cases/split_delimiter_comments.py
+++ b/tests/data/cases/split_delimiter_comments.py
@@ -11,6 +11,17 @@ bad_split3 = (
     "each line of a bad split? In that "  # Second Comment
     "case, we should just leave it alone."  # Third Comment
 )
+parametrize(
+    (
+        {},
+        {},
+    ),
+    (  # foobar
+        {},
+        {},
+    ),
+)
+
 
 
 # output
@@ -27,3 +38,14 @@ bad_split3 = (
     "each line of a bad split? In that "  # Second Comment
     "case, we should just leave it alone."  # Third Comment
 )
+parametrize(
+    (
+        {},
+        {},
+    ),
+    (  # foobar
+        {},
+        {},
+    ),
+)
+

--- a/tests/data/cases/split_delimiter_comments.py
+++ b/tests/data/cases/split_delimiter_comments.py
@@ -6,6 +6,12 @@ a = (
     1  # type: ignore
     + 2  # type: ignore
 )
+bad_split3 = (
+    "What if we have inline comments on "  # First Comment
+    "each line of a bad split? In that "  # Second Comment
+    "case, we should just leave it alone."  # Third Comment
+)
+
 
 # output
 a = (
@@ -15,4 +21,9 @@ a = (
 a = (
     1  # type: ignore
     + 2  # type: ignore
+)
+bad_split3 = (
+    "What if we have inline comments on "  # First Comment
+    "each line of a bad split? In that "  # Second Comment
+    "case, we should just leave it alone."  # Third Comment
 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Resolves #4220. Black moved the + at the end of the line to the start of the next line, then unintentionally moved any comments as well. This could cause comments to be merged. To fix this, I stopped Black from moving any comments with the delimiter. It only crashed when merging `type: ignore` comments, but I think it makes sense to keep *all* comments on their original line instead of following the delimiter. This does not break the stability policy since already-Blackened code will not change.

Depends on #4257 for lint to succeed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [y] Add an entry in `CHANGES.md` if necessary?
- [y] Add / update tests if necessary?
- [-] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
