### PR TITLE
Use regex where we ignore case on windows

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, redirect_stderr
 from dataclasses import replace
 from io import BytesIO
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from platform import system
 from tempfile import TemporaryDirectory
 from typing import (
@@ -2473,7 +2473,11 @@ class TestFileCollection:
         assert result.stderr_bytes is not None
 
         gitignore = path / ".gitignore"
-        assert f"Could not parse {gitignore}" in result.stderr_bytes.decode()
+        assert re.search(
+            f"Could not parse {gitignore}".replace("\\", "\\\\"),
+            result.stderr_bytes.decode(),
+            re.IGNORECASE if isinstance(gitignore, WindowsPath) else 0,
+        )
 
     def test_invalid_nested_gitignore(self) -> None:
         path = THIS_DIR / "data" / "invalid_nested_gitignore_tests"
@@ -2485,7 +2489,11 @@ class TestFileCollection:
         assert result.stderr_bytes is not None
 
         gitignore = path / "a" / ".gitignore"
-        assert f"Could not parse {gitignore}" in result.stderr_bytes.decode()
+        assert re.search(
+            f"Could not parse {gitignore}".replace("\\", "\\\\"),
+            result.stderr_bytes.decode(),
+            re.IGNORECASE if isinstance(gitignore, WindowsPath) else 0,
+        )
 
     def test_gitignore_that_ignores_subfolders(self) -> None:
         # If gitignore with */* is in root


### PR DESCRIPTION
### Description

I was just about to start testing things, and was running into failed tests on `main`. Both `test_invalid_gitignore` and `test_invalid_nested_gitignore` both threw errors because of the case-sensitivity of `"s" in "STRING"` with `gitignore` being `c:\\...` and the output having `C:\\...`.

On windows the path `FoObAR` is the same as `foobar`, so the output of `black` on a windows machine could output the path to `.gitignore` with upper or lower-case portions of the path. In this change we use the regex `re.IGNORECASE` flag to get it to match properly. We do not do this when the `gitignore` path is not a `pathlib.WindowsPath` object.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary? - not necessary
- [x] Add / update tests if necessary? - these are the tests 😅 
- [x] Add new / update outdated documentation? - don't think any documentation is needed

### Updated test output

```
Running pytest with args: ['-p', 'vscode_pytest', '--rootdir', 'c:\\Users\\kai\\git\\black', 'c:\\Users\\kai\\git\\black\\tests\\test_black.py::TestFileCollection::test_invalid_nested_gitignore', 'c:\\Users\\kai\\git\\black\\tests\\test_black.py::TestFileCollection::test_invalid_gitignore']
============================= test session starts =============================
platform win32 -- Python 3.11.4, pytest-8.0.2, pluggy-1.4.0
rootdir: c:\Users\kai\git\black
configfile: pyproject.toml
plugins: cov-4.1.0, xdist-3.5.0
collected 2 items

tests\test_black.py ..                                                   [100%]

============================== 2 passed in 0.14s ==============================
Finished running tests!
```