### PR TITLE
Fix type param formatting in funcdef with trailing comma

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Don't move comments along with delimiters, which could cause crashes (#4248)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,12 +12,12 @@
 
 - Don't move comments along with delimiters, which could cause crashes (#4248)
 
-- Fixed a bug where lines were split incorrectly for function definitions with type
-  params and trailing commas (#4255)
-
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
+
+- Fixed a bug where lines were split incorrectly for function definitions with type
+  params and trailing commas (#4255)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 
 - Don't move comments along with delimiters, which could cause crashes (#4248)
 
+- Fixed a bug where lines were split incorrectly for function definitions with type
+  params and trailing commas (#4255)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1135,6 +1135,14 @@ def _get_last_non_comment_leaf(line: Line) -> Optional[int]:
     return None
 
 
+def _can_add_trailing_comma(leaf: Leaf, features: Collection[Feature]) -> bool:
+    if is_vararg(leaf, within={syms.typedargslist}):
+        return Feature.TRAILING_COMMA_IN_DEF in features
+    if is_vararg(leaf, within={syms.arglist, syms.argument}):
+        return Feature.TRAILING_COMMA_IN_CALL in features
+    return True
+
+
 def _safe_add_trailing_comma(safe: bool, delimiter_priority: int, line: Line) -> Line:
     if (
         safe
@@ -1156,10 +1164,9 @@ def delimiter_split(
     If the appropriate Features are given, the split will add trailing commas
     also in function signatures and calls that contain `*` and `**`.
     """
-    try:
-        last_leaf = line.leaves[-1]
-    except IndexError:
+    if len(line.leaves) == 0:
         raise CannotSplit("Line empty") from None
+    last_leaf = line.leaves[-1]
 
     bt = line.bracket_tracker
     try:
@@ -1167,9 +1174,11 @@ def delimiter_split(
     except ValueError:
         raise CannotSplit("No delimiters found") from None
 
-    if delimiter_priority == DOT_PRIORITY:
-        if bt.delimiter_count_with_priority(delimiter_priority) == 1:
-            raise CannotSplit("Splitting a single attribute from its owner looks wrong")
+    if (
+        delimiter_priority == DOT_PRIORITY
+        and bt.delimiter_count_with_priority(delimiter_priority) == 1
+    ):
+        raise CannotSplit("Splitting a single attribute from its owner looks wrong")
 
     current_line = Line(
         mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
@@ -1198,15 +1207,8 @@ def delimiter_split(
             yield from append_to_line(comment_after)
 
         lowest_depth = min(lowest_depth, leaf.bracket_depth)
-        if leaf.bracket_depth == lowest_depth:
-            if is_vararg(leaf, within={syms.typedargslist}):
-                trailing_comma_safe = (
-                    trailing_comma_safe and Feature.TRAILING_COMMA_IN_DEF in features
-                )
-            elif is_vararg(leaf, within={syms.arglist, syms.argument}):
-                trailing_comma_safe = (
-                    trailing_comma_safe and Feature.TRAILING_COMMA_IN_CALL in features
-                )
+        if trailing_comma_safe and leaf.bracket_depth == lowest_depth:
+            trailing_comma_safe = _can_add_trailing_comma(leaf, features)
 
         if last_leaf.type == STANDALONE_COMMENT and leaf_idx == last_non_comment_leaf:
             current_line = _safe_add_trailing_comma(
@@ -1220,6 +1222,7 @@ def delimiter_split(
             current_line = Line(
                 mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
             )
+
     if current_line:
         current_line = _safe_add_trailing_comma(
             trailing_comma_safe, delimiter_priority, current_line

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -672,32 +672,59 @@ def transform_line(
 def should_split_funcdef_with_rhs(line: Line, mode: Mode) -> bool:
     """If a funcdef has a magic trailing comma in the return type, then we should first
     split the line with rhs to respect the comma.
+    If it has type parameters and a trailing comma in the function parameters, we should
+    split with rhs to avoid splitting the type parameters first.
     """
+
+    type_param_leaves: List[Leaf] = []
+    func_param_leaves: List[Leaf] = []
     return_type_leaves: List[Leaf] = []
-    in_return_type = False
+    other_leaves: List[Leaf] = []
+    current = other_leaves
 
     for leaf in line.leaves:
-        if leaf.type == token.COLON:
-            in_return_type = False
-        if in_return_type:
-            return_type_leaves.append(leaf)
-        if leaf.type == token.RARROW:
-            in_return_type = True
+        if current == other_leaves:
+            if leaf.type == token.LSQB:
+                current = type_param_leaves
 
-    # using `bracket_split_build_line` will mess with whitespace, so we duplicate a
-    # couple lines from it.
-    result = Line(mode=line.mode, depth=line.depth)
-    leaves_to_track = get_leaves_inside_matching_brackets(return_type_leaves)
-    for leaf in return_type_leaves:
-        result.append(
-            leaf,
-            preformatted=True,
-            track_bracket=id(leaf) in leaves_to_track,
-        )
+            elif leaf.type == token.LPAR:
+                current = func_param_leaves
+
+            elif leaf.type == token.RARROW:
+                current = return_type_leaves
+
+        current.append(leaf)
+
+        if current == other_leaves:
+            continue
+        elif current == return_type_leaves:
+            if leaf.type == token.COLON:
+                current = other_leaves
+        elif leaf.opening_bracket is current[0]:
+            current = other_leaves
+
+    def _has_magic_comma(_leaves: List[Leaf]) -> bool:
+        # using `bracket_split_build_line` will mess with whitespace, so we duplicate a
+        # couple lines from it.
+        line_copy = Line(mode=line.mode, depth=line.depth)
+        leaves_to_track = get_leaves_inside_matching_brackets(_leaves)
+        for _leaf in _leaves:
+            line_copy.append(
+                _leaf,
+                preformatted=True,
+                track_bracket=id(_leaf) in leaves_to_track,
+            )
+
+        return line_copy.magic_trailing_comma is not None
+
+    if return_type_leaves and _has_magic_comma(return_type_leaves):
+        return True
+    if type_param_leaves and _has_magic_comma(func_param_leaves):
+        return True
 
     # we could also return true if the line is too long, and the return type is longer
     # than the param list. Or if `should_split_rhs` returns True.
-    return result.magic_trailing_comma is not None
+    return False
 
 
 class _BracketSplitComponent(Enum):

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -3,7 +3,18 @@ blib2to3 Node/Leaf transformation-related utility functions.
 """
 
 import sys
-from typing import Final, Generic, Iterator, List, Optional, Set, Tuple, TypeVar, Union
+from typing import (
+    Final,
+    Generic,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -951,16 +962,21 @@ def is_number_token(nl: NL) -> TypeGuard[Leaf]:
     return nl.type == token.NUMBER
 
 
-def is_part_of_annotation(leaf: Leaf) -> bool:
-    """Returns whether this leaf is part of type annotations."""
+def get_annotation_type(leaf: Leaf) -> Literal["return", "param", None]:
+    """Returns the type of annotation this leaf is part of, if any."""
     ancestor = leaf.parent
     while ancestor is not None:
         if ancestor.prev_sibling and ancestor.prev_sibling.type == token.RARROW:
-            return True
+            return "return"
         if ancestor.parent and ancestor.parent.type == syms.tname:
-            return True
+            return "param"
         ancestor = ancestor.parent
-    return False
+    return None
+
+
+def is_part_of_annotation(leaf: Leaf) -> bool:
+    """Returns whether this leaf is part of a type annotation."""
+    return get_annotation_type(leaf) is not None
 
 
 def first_leaf(node: LN) -> Optional[Leaf]:

--- a/tests/data/cases/split_delimiter_comments.py
+++ b/tests/data/cases/split_delimiter_comments.py
@@ -1,0 +1,51 @@
+a = (
+    1 +  # type: ignore
+    2  # type: ignore
+)
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)
+bad_split3 = (
+    "What if we have inline comments on "  # First Comment
+    "each line of a bad split? In that "  # Second Comment
+    "case, we should just leave it alone."  # Third Comment
+)
+parametrize(
+    (
+        {},
+        {},
+    ),
+    (  # foobar
+        {},
+        {},
+    ),
+)
+
+
+
+# output
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)
+a = (
+    1  # type: ignore
+    + 2  # type: ignore
+)
+bad_split3 = (
+    "What if we have inline comments on "  # First Comment
+    "each line of a bad split? In that "  # Second Comment
+    "case, we should just leave it alone."  # Third Comment
+)
+parametrize(
+    (
+        {},
+        {},
+    ),
+    (  # foobar
+        {},
+        {},
+    ),
+)
+

--- a/tests/data/cases/type_params.py
+++ b/tests/data/cases/type_params.py
@@ -13,6 +13,33 @@ def it_gets_worse[WhatIsTheLongestTypeVarNameYouCanThinkOfEnoughToMakeBlackSplit
 
 def magic[Trailing, Comma,](): pass
 
+# Combinations of type params, function params and return types
+def func00[T](a): pass
+
+def func01[T](a,): pass
+
+def func10[T,](a): pass
+
+def func11[T,](a,): pass
+
+def func000[T](a) -> list[A, B]: pass
+
+def func010[T](a,) -> list[A, B]: pass
+
+def func100[T,](a) -> list[A, B]: pass
+
+def func110[T,](a,) -> list[A, B]: pass
+
+def func001[T](a) -> list[A, B,]: pass
+
+def func011[T](a,) -> list[A, B,]: pass
+
+def func101[T,](a) -> list[A, B,]: pass
+
+def func111[T,](a,) -> list[A, B,]: pass
+
+def long_func_params[T](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb): pass
+
 # output
 
 
@@ -55,4 +82,96 @@ def magic[
     Trailing,
     Comma,
 ]():
+    pass
+
+
+# Combinations of type params, function params and return types
+def func00[T](a):
+    pass
+
+
+def func01[T](
+    a,
+):
+    pass
+
+
+def func10[
+    T,
+](a):
+    pass
+
+
+def func11[
+    T,
+](
+    a,
+):
+    pass
+
+
+def func000[T](a) -> list[A, B]:
+    pass
+
+
+def func010[T](
+    a,
+) -> list[A, B]:
+    pass
+
+
+def func100[
+    T,
+](a) -> list[A, B]:
+    pass
+
+
+def func110[
+    T,
+](
+    a,
+) -> list[A, B]:
+    pass
+
+
+def func001[T](a) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func011[T](
+    a,
+) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func101[
+    T,
+](a) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func111[
+    T,
+](
+    a,
+) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def long_func_params[T](
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+):
     pass


### PR DESCRIPTION
### Description

This change adds additional checks to the decision whether to split a funcdef from the left or right-hand side.
Specifically, this adds the following condition to `should_split_funcdef_with_rhs`:
If a funcdef has type parameters and its parameters also have a trailing comma, return `True`, to indicate that the funcdef should not be split from the left first.

This fixes the bug described in #4254.

I am currently trying to also fix #3929 and #4071 since they seem related, but that seems to require a little more work. Any suggestions are appreciated.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [-] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
