### PR TITLE
Fix formatting for `if` clauses in `match-case` blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 <!-- Changes that affect Black's preview style -->
 
 - Fixed a bug where `if` clauses in `match-case` blocks are not wrapped with parenthesis
-  when the line is too long (#4269)
+  when the line is too long. (#4269)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Fixed a bug where `if` clauses in `match-case` blocks are not wrapped with parenthesis
+- `if` guards in `case` blocks are now wrapped in parentheses
   when the line is too long. (#4269)
 
 ### Configuration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Don't move comments along with delimiters, which could cause crashes (#4248)
-- Fixed a bug where long `if` clauses in `match-case` blocks are not wrapped with
-  parenthesis (#4269)
+- Fixed a bug where `if` clauses in `match-case` blocks are not wrapped with parenthesis
+  when the line is too long (#4269)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Don't move comments along with delimiters, which could cause crashes (#4248)
+- Fixed a bug where long `if` clauses in `match-case` blocks are not wrapped with
+  parenthesis (#4269)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- `if` guards in `case` blocks are now wrapped in parentheses
-  when the line is too long. (#4269)
+- `if` guards in `case` blocks are now wrapped in parentheses when the line is too long.
+  (#4269)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,13 @@
 <!-- Changes that affect Black's stable style -->
 
 - Don't move comments along with delimiters, which could cause crashes (#4248)
-- Fixed a bug where `if` clauses in `match-case` blocks are not wrapped with parenthesis
-  when the line is too long (#4269)
 
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
+
+- Fixed a bug where `if` clauses in `match-case` blocks are not wrapped with parenthesis
+  when the line is too long (#4269)
 
 ### Configuration
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,8 +34,8 @@ Currently, the following features are included in the preview style:
   quotes of a docstring
 - `remove_redundant_guard_parens`: Removes redundant parentheses in `if` guards for
   `case` blocks.
-- `parens_for_long_if_clauses_in_case_block`: Adds parentheses to `if` clauses in
-  `case` blocks when the the line is too long
+- `parens_for_long_if_clauses_in_case_block`: Adds parentheses to `if` clauses in `case`
+  blocks when the the line is too long
 
 (labels/unstable-features)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,6 +34,8 @@ Currently, the following features are included in the preview style:
   quotes of a docstring
 - `remove_redundant_guard_parens`: Removes redundant parentheses in `if` guards for
   `case` blocks.
+- `parens_for_long_if_clauses_in_case_block`: Fixed a bug where `if` clauses in
+  `match-case` blocks are not wrapped with parenthesis when the line is too long
 
 (labels/unstable-features)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,8 +34,8 @@ Currently, the following features are included in the preview style:
   quotes of a docstring
 - `remove_redundant_guard_parens`: Removes redundant parentheses in `if` guards for
   `case` blocks.
-- `parens_for_long_if_clauses_in_case_block`: Fixed a bug where `if` clauses in
-  `match-case` blocks are not wrapped with parenthesis when the line is too long
+- `parens_for_long_if_clauses_in_case_block`: Adds parentheses to `if` clauses in
+  `case` blocks when the the line is too long
 
 (labels/unstable-features)=
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1310,6 +1310,13 @@ def normalize_invisible_parens(  # noqa: C901
                 child, parens_after={"case"}, mode=mode, features=features
             )
 
+        # Fixes a bug where invisible parens are not properly wrapped around
+        # if statement.
+        if isinstance(child, Node) and child.type == syms.guard:
+            normalize_invisible_parens(
+                child, parens_after={"if"}, mode=mode, features=features
+            )
+
         # Add parentheses around long tuple unpacking in assignments.
         if (
             index == 0

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1310,8 +1310,7 @@ def normalize_invisible_parens(  # noqa: C901
                 child, parens_after={"case"}, mode=mode, features=features
             )
 
-        # Fixes a bug where invisible parens are not properly wrapped around
-        # if statement when line is too long.
+        # Add parentheses around if guards in case blocks
         if (
             isinstance(child, Node)
             and child.type == syms.guard

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1311,8 +1311,12 @@ def normalize_invisible_parens(  # noqa: C901
             )
 
         # Fixes a bug where invisible parens are not properly wrapped around
-        # if statement.
-        if isinstance(child, Node) and child.type == syms.guard:
+        # if statement when line is too long.
+        if (
+            isinstance(child, Node)
+            and child.type == syms.guard
+            and Preview.parens_for_long_if_clauses_in_case_block in mode
+        ):
             normalize_invisible_parens(
                 child, parens_after={"if"}, mode=mode, features=features
             )

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -180,6 +180,7 @@ class Preview(Enum):
     is_simple_lookup_for_doublestar_expression = auto()
     docstring_check_for_newline = auto()
     remove_redundant_guard_parens = auto()
+    parens_for_long_if_clauses_in_case_block = auto()
 
 
 UNSTABLE_FEATURES: Set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -88,7 +88,8 @@
           "typed_params_trailing_comma",
           "is_simple_lookup_for_doublestar_expression",
           "docstring_check_for_newline",
-          "remove_redundant_guard_parens"
+          "remove_redundant_guard_parens",
+          "parens_for_long_if_clauses_in_case_block"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/pattern_matching_complex.py
+++ b/tests/data/cases/pattern_matching_complex.py
@@ -83,7 +83,7 @@ match (0, 1, 2):
 match x:
     case [0]:
         y = 0
-    case [1, 0] if (x := x[:0]):
+    case [1, 0] if x := x[:0]:
         y = 1
     case [1, 0]:
         y = 2

--- a/tests/data/cases/pattern_matching_with_if_stmt.py
+++ b/tests/data/cases/pattern_matching_with_if_stmt.py
@@ -1,4 +1,4 @@
-# flags: --minimum-version=3.10
+# flags: --preview --minimum-version=3.10
 match "test":
     case "test" if "first long condition" != "some loooooooooooooooooooooooooooooooooooooog condition":
         print("Test")

--- a/tests/data/cases/pattern_matching_with_if_stmt.py
+++ b/tests/data/cases/pattern_matching_with_if_stmt.py
@@ -1,0 +1,56 @@
+# flags: --minimum-version=3.10
+match "test":
+    case "test" if "first long condition" != "some loooooooooooooooooooooooooooooooooooooog condition":
+        print("Test")
+
+match match:
+    case "test" if case != "not very loooooooooooooog condition":
+        print("No format change")
+
+match "test":
+    case "test" if "any long condition" != "another long condition" and "this is a long condition":
+        print("Test")
+
+match "test":
+    case "test" if "any long condition" != "another long condition" and "this is a looooong condition":
+        print("Test")
+
+# case black_test_patma_052 (originally in the pattern_matching_complex test case)
+match x:
+    case [1, 0] if x := x[:0]:
+        y = 1
+    case [1, 0] if (x := x[:0]):
+        y = 1
+
+# output
+
+match "test":
+    case "test" if (
+        "first long condition"
+        != "some loooooooooooooooooooooooooooooooooooooog condition"
+    ):
+        print("Test")
+
+match match:
+    case "test" if case != "not very loooooooooooooog condition":
+        print("No format change")
+
+match "test":
+    case "test" if (
+        "any long condition" != "another long condition" and "this is a long condition"
+    ):
+        print("Test")
+
+match "test":
+    case "test" if (
+        "any long condition" != "another long condition"
+        and "this is a looooong condition"
+    ):
+        print("Test")
+
+# case black_test_patma_052 (originally in the pattern_matching_complex test case)
+match x:
+    case [1, 0] if x := x[:0]:
+        y = 1
+    case [1, 0] if x := x[:0]:
+        y = 1

--- a/tests/data/cases/pattern_matching_with_if_stmt.py
+++ b/tests/data/cases/pattern_matching_with_if_stmt.py
@@ -1,19 +1,29 @@
 # flags: --preview --minimum-version=3.10
-match "test":
-    case "test" if "first long condition" != "some loooooooooooooooooooooooooooooooooooooog condition":
-        print("Test")
-
 match match:
-    case "test" if case != "not very loooooooooooooog condition":
-        print("No format change")
+    case "test" if case != "not very loooooooooooooog condition":  # comment
+        pass
 
-match "test":
+match smth:
     case "test" if "any long condition" != "another long condition" and "this is a long condition":
-        print("Test")
-
-match "test":
-    case "test" if "any long condition" != "another long condition" and "this is a looooong condition":
-        print("Test")
+        pass
+    case test if "any long condition" != "another long condition" and "this is a looooong condition":
+        pass
+    case test if "any long condition" != "another long condition" and "this is a looooong condition":  # some additional comments
+        pass
+    case test if (True): # some comment
+        pass
+    case test if (False
+        ): # some comment
+        pass
+    case test if (True  # some comment
+        ):
+        pass  # some comment
+    case cases if (True  # some comment
+                   ): # some other comment
+        pass  # some comment
+    case match if (True  # some comment
+                   ):
+        pass  # some comment
 
 # case black_test_patma_052 (originally in the pattern_matching_complex test case)
 match x:
@@ -24,29 +34,35 @@ match x:
 
 # output
 
-match "test":
-    case "test" if (
-        "first long condition"
-        != "some loooooooooooooooooooooooooooooooooooooog condition"
-    ):
-        print("Test")
-
 match match:
-    case "test" if case != "not very loooooooooooooog condition":
-        print("No format change")
+    case "test" if case != "not very loooooooooooooog condition":  # comment
+        pass
 
-match "test":
+match smth:
     case "test" if (
         "any long condition" != "another long condition" and "this is a long condition"
     ):
-        print("Test")
-
-match "test":
-    case "test" if (
+        pass
+    case test if (
         "any long condition" != "another long condition"
         and "this is a looooong condition"
     ):
-        print("Test")
+        pass
+    case test if (
+        "any long condition" != "another long condition"
+        and "this is a looooong condition"
+    ):  # some additional comments
+        pass
+    case test if True:  # some comment
+        pass
+    case test if False:  # some comment
+        pass
+    case test if True:  # some comment
+        pass  # some comment
+    case cases if True:  # some comment  # some other comment
+        pass  # some comment
+    case match if True:  # some comment
+        pass  # some comment
 
 # case black_test_patma_052 (originally in the pattern_matching_complex test case)
 match x:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Fixes #3793.

Now the `if` clauses in the `case-match` blocks will be correctly wrapped with parenthesis. 

The previous problem of having redundant parentheses being added to `case` statement when it's accompanied by an `if` clause that was too long, like the example mentioned in #3793 discussion, is also resolved.



### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?