### PR TITLE
Improve function definition wrapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Improve wrapping of function definitions in edge-cases (#4272)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -34,6 +34,8 @@ Currently, the following features are included in the preview style:
   quotes of a docstring
 - `remove_redundant_guard_parens`: Removes redundant parentheses in `if` guards for
   `case` blocks.
+- `function_def_wrap_order`: extends function definition wrapping logic to avoid
+  suboptimal formatting, especially for PEP 695 type parameters
 
 (labels/unstable-features)=
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -180,6 +180,7 @@ class Preview(Enum):
     is_simple_lookup_for_doublestar_expression = auto()
     docstring_check_for_newline = auto()
     remove_redundant_guard_parens = auto()
+    function_def_wrap_order = auto()
 
 
 UNSTABLE_FEATURES: Set[Preview] = {

--- a/tests/data/cases/preview_function_def_wrap_order.py
+++ b/tests/data/cases/preview_function_def_wrap_order.py
@@ -1,0 +1,232 @@
+# flags: --preview --minimum-version=3.12
+
+# https://github.com/psf/black/issues/3929
+def sum_backward[T: SupportedDataTypes](a: Tensor[T], grad: Tensor[T]) -> dict[Tensor[T], Tensor[T]]: ...
+
+
+# https://github.com/psf/black/issues/4071
+def func[T](a: T, b: T,) -> T: return a + b
+
+# Combinations of type params, function params and return types with trailing commas
+def func0(a): pass
+
+def func1(a,): pass
+
+def func00[T](a): pass
+
+def func01[T](a,): pass
+
+def func10[T,](a): pass
+
+def func11[T,](a,): pass
+
+def func0_0(a) -> List[A, B]: pass
+
+def func0_1(a) -> List[A, B,]: pass
+
+def func1_0(a,) -> List[A, B]: pass
+
+def func1_1(a,) -> List[A, B,]: pass
+
+def func000[T](a) -> list[A, B]: pass
+
+def func010[T](a,) -> list[A, B]: pass
+
+def func100[T,](a) -> list[A, B]: pass
+
+def func110[T,](a,) -> list[A, B]: pass
+
+def func001[T](a) -> list[A, B,]: pass
+
+def func011[T](a,) -> list[A, B,]: pass
+
+def func101[T,](a) -> list[A, B,]: pass
+
+def func111[T,](a,) -> list[A, B,]: pass
+
+def long_func_params[T, U](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) -> R | S: pass
+
+def long_type_params[TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT, UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU](a, b) -> R | S: pass
+
+def long_return_type[T, U](a, b) -> RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR | SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS: pass
+
+def long_func_param2[T, U](aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) -> R | S: pass
+
+def long_type_param2[TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU](a, b) -> R | S: pass
+
+def long_return_type2[T, U](a, b) -> RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS: pass
+
+# output
+
+# https://github.com/psf/black/issues/3929
+def sum_backward[T: SupportedDataTypes](
+    a: Tensor[T], grad: Tensor[T]
+) -> dict[Tensor[T], Tensor[T]]: ...
+
+
+# https://github.com/psf/black/issues/4071
+def func[T](
+    a: T,
+    b: T,
+) -> T:
+    return a + b
+
+
+# Combinations of type params, function params and return types with trailing commas
+def func0(a):
+    pass
+
+
+def func1(
+    a,
+):
+    pass
+
+
+def func00[T](a):
+    pass
+
+
+def func01[T](
+    a,
+):
+    pass
+
+
+def func10[
+    T,
+](a):
+    pass
+
+
+def func11[
+    T,
+](
+    a,
+):
+    pass
+
+
+def func0_0(a) -> List[A, B]:
+    pass
+
+
+def func0_1(a) -> List[
+    A,
+    B,
+]:
+    pass
+
+
+def func1_0(
+    a,
+) -> List[A, B]:
+    pass
+
+
+def func1_1(
+    a,
+) -> List[
+    A,
+    B,
+]:
+    pass
+
+
+def func000[T](a) -> list[A, B]:
+    pass
+
+
+def func010[T](
+    a,
+) -> list[A, B]:
+    pass
+
+
+def func100[
+    T,
+](a) -> list[A, B]:
+    pass
+
+
+def func110[
+    T,
+](
+    a,
+) -> list[A, B]:
+    pass
+
+
+def func001[T](a) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func011[T](
+    a,
+) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func101[
+    T,
+](a) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def func111[
+    T,
+](
+    a,
+) -> list[
+    A,
+    B,
+]:
+    pass
+
+
+def long_func_params[T, U](
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+) -> R | S:
+    pass
+
+
+def long_type_params[
+    TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT,
+    UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU,
+](a, b) -> R | S:
+    pass
+
+
+def long_return_type[T, U](a, b) -> (
+    RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR
+    | SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+):
+    pass
+
+
+def long_func_param2[T, U](
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+) -> R | S:
+    pass
+
+
+def long_type_param2[
+    TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU
+](a, b) -> R | S:
+    pass
+
+
+def long_return_type2[T, U](
+    a, b
+) -> RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS:
+    pass


### PR DESCRIPTION
### Description

This is intended to fix issues like #3929, #4071, and #4254, where the addition of the new type parameter syntax in Python 3.12 has caused suboptimal formatting of function definitions.

The new transformer for function definition inspects the given function definition, then splits at the first thing found from the following list:
  - function parameters with magic trailing comma
  - return type with magic trailing comma
  - type parameters with magic trailing comma
  - return type longer than max line length
  - type parameters longer than max line length
  - function parameters (as default)
  
For example, assuming a very small max line length
```py
def f[T](a): ...
```
is formatted as
```py
def f[T](
    a
): ...
```
but
```py
def f[T,](a): ...
```
becomes
```py
def f[
    T,
](a): ...
```
because the trailing comma gives the type parameters a higher priority.

This only really changes how functions with type parameters are split compared to the stable style.

A function that only has one of type params, function params or a return type is just passed to `left_hand_split`.

#### Possible issues

One test is currently failing, in `funcdef_return_type_trailing_comma.py`:
```py
def foo(a) -> list[
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
]:  # abpedeifnore
    pass
```
```py
# output
def foo(
    a,
) -> list[
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
]:  # abpedeifnore
    pass
```
With the new formatter, the test input is kept as is, which I feel is better.

I added the part with the long strings because it seems logical and some comments were considering going in that direction.
`line_to_string` has a warning about being computationally expensive, but I would think it should be fine for two lines.
A longer character width than the max line length might not be the most useful check though.

If the choice for splitting falls on return type, the line is passed to `right_hand_split`. That was my solution to not duplicate any more code, but that could maybe introduce inconsistencies? I couldn't think of any, but it feels a bit off.

I'm grateful for any feedback and suggestions!

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
