### PR TITLE
fix: Stop moving multiline strings to a new line unless inside brackets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 
 - `if` guards in `case` blocks are now wrapped in parentheses when the line is too long.
   (#4269)
+- Stop moving multiline strings to a new line unless inside brackets (#4289)
 
 ### Configuration
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -862,9 +862,9 @@ def is_line_short_enough(  # noqa: C901
             # directly after MLS/MLS-containing expression
             ignore_ctxs: List[Optional[LN]] = [None]
             ignore_ctxs += multiline_string_contexts
-            if (
-                line.inside_brackets or leaf.bracket_depth > 0
-            ) and (i != len(line.leaves) - 1 or leaf.prev_sibling not in ignore_ctxs):
+            if (line.inside_brackets or leaf.bracket_depth > 0) and (
+                i != len(line.leaves) - 1 or leaf.prev_sibling not in ignore_ctxs
+            ):
                 commas[leaf.bracket_depth] += 1
         if max_level_to_update != math.inf:
             max_level_to_update = min(max_level_to_update, leaf.bracket_depth)

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -858,11 +858,13 @@ def is_line_short_enough(  # noqa: C901
                     return False
 
         if leaf.bracket_depth <= max_level_to_update and leaf.type == token.COMMA:
-            # Ignore non-nested trailing comma
+            # Inside brackets, ignore trailing comma
             # directly after MLS/MLS-containing expression
             ignore_ctxs: List[Optional[LN]] = [None]
             ignore_ctxs += multiline_string_contexts
-            if not (leaf.prev_sibling in ignore_ctxs and i == len(line.leaves) - 1):
+            if (
+                line.inside_brackets or leaf.bracket_depth > 0
+            ) and (i != len(line.leaves) - 1 or leaf.prev_sibling not in ignore_ctxs):
                 commas[leaf.bracket_depth] += 1
         if max_level_to_update != math.inf:
             max_level_to_update = min(max_level_to_update, leaf.bracket_depth)

--- a/tests/data/cases/preview_multiline_strings.py
+++ b/tests/data/cases/preview_multiline_strings.py
@@ -175,6 +175,13 @@ this_will_also_become_one_line = (  # comment
     "c"
 )
 
+assert some_var == expected_result, """
+test
+"""
+assert some_var == expected_result, f"""
+expected: {expected_result}
+actual: {some_var}"""
+
 # output
 """cow
 say""",
@@ -385,3 +392,10 @@ this_will_stay_on_three_lines = (
 )
 
 this_will_also_become_one_line = "abc"  # comment
+
+assert some_var == expected_result, """
+test
+"""
+assert some_var == expected_result, f"""
+expected: {expected_result}
+actual: {some_var}"""


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Resolves #4247

I fixed it by not wrapping around multiline strings outside brackets. This keeps all existing tests passing while allowing `assert` statements to not be reformatted. This is currently gated under the `multiline_string_handling` unstable style, since it's the smallest solution to just add it in there.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [y] Add an entry in `CHANGES.md` if necessary?
- [y] Add / update tests if necessary?
- [-] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
