### PR TITLE
GitHub Action: Allow reading version from pyproject.toml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- Add a new option `use_pyproject` to the GitHub Action `psf/black`. This will read the
+  Black version from `pyproject.toml`.
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
 - Add a new option `use_pyproject` to the GitHub Action `psf/black`. This will read the
-  Black version from `pyproject.toml`.
+  Black version from `pyproject.toml`. (#4294)
 
 ### Documentation
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: ""
   use_pyproject:
-    description: Read black version specifier from pyproject.toml if `true`.
+    description: Read Black version specifier from pyproject.toml if `true`.
     required: false
     default: "false"
   summary:

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Python Version specifier (PEP440) - e.g. "21.5b1"'
     required: false
     default: ""
+  use_pyproject:
+    description: Read black version specifier from pyproject.toml if `true`.
+    required: false
+    default: "false"
   summary:
     description: "Whether to add the output to the workflow summary"
     required: false
@@ -70,5 +74,6 @@ runs:
         INPUT_JUPYTER: ${{ inputs.jupyter }}
         INPUT_BLACK_ARGS: ${{ inputs.black_args }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_USE_PYPROJECT: ${{ inputs.use_pyproject }}
         pythonioencoding: utf-8
       shell: bash

--- a/action/main.py
+++ b/action/main.py
@@ -98,7 +98,13 @@ def find_black_version_in_array(array: object) -> Union[str, None]:
             item = item.split(";")[0]
             item = EXTRAS_RE.sub("", item).strip()
             if item == "black":
-                return ""
+                print(
+                    "::error::Version specifier missing for 'black' dependency in "
+                    "pyproject.toml.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                sys.exit(1)
             elif m := BLACK_VERSION_RE.match(item):
                 return m.group(1).strip()
     except TypeError:

--- a/action/main.py
+++ b/action/main.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 from pathlib import Path
 from subprocess import PIPE, STDOUT, run
+from typing import Union
 
 ACTION_PATH = Path(os.environ["GITHUB_ACTION_PATH"])
 ENV_PATH = ACTION_PATH / ".black-env"
@@ -85,7 +86,7 @@ def read_version_specifier_from_pyproject() -> str:
     return version
 
 
-def find_black_version_in_array(array: object) -> str | None:
+def find_black_version_in_array(array: object) -> Union[str, None]:
     if not isinstance(array, list):
         return None
     try:

--- a/action/main.py
+++ b/action/main.py
@@ -51,7 +51,7 @@ def read_version_specifier_from_pyproject() -> str:
         )
         sys.exit(1)
 
-    import tomllib
+    import tomllib  # type: ignore[import-not-found,unreachable]
 
     try:
         with Path("pyproject.toml").open("rb") as fp:

--- a/action/main.py
+++ b/action/main.py
@@ -29,7 +29,8 @@ def determine_version_specifier() -> str:
     """
     if USE_PYPROJECT and VERSION:
         print(
-            "::error::'with.version' and 'with.use_pyproject' inputs are mutually exclusive.",
+            "::error::'with.version' and 'with.use_pyproject' inputs are "
+            "mutually exclusive.",
             file=sys.stderr,
             flush=True,
         )

--- a/action/main.py
+++ b/action/main.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shlex
 import shutil
 import sys
@@ -13,12 +14,90 @@ SRC = os.getenv("INPUT_SRC", default="")
 JUPYTER = os.getenv("INPUT_JUPYTER") == "true"
 BLACK_ARGS = os.getenv("INPUT_BLACK_ARGS", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
+USE_PYPROJECT = os.getenv("INPUT_USE_PYPROJECT") == "true"
+
+BLACK_VERSION_RE = re.compile(r"^black([^A-Z0-9._-]+)", re.IGNORECASE)
+EXTRAS_RE = re.compile(r"\[.*\]")
+
+
+def determine_version_specifier() -> str:
+    """Determine the version of Black to install.
+
+    The version can be specified either via the `with.version` input or via the
+    pyproject.toml file if `with.use_pyproject` is set to `true`.
+    """
+    if USE_PYPROJECT and VERSION:
+        print(
+            "::error::'with.version' and 'with.use_pyproject' inputs are mutually exclusive.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+    if USE_PYPROJECT:
+        return read_version_specifier_from_pyproject()
+    elif VERSION and VERSION[0] in "0123456789":
+        return f"=={VERSION}"
+    else:
+        return VERSION
+
+
+def read_version_specifier_from_pyproject() -> str:
+    if sys.version_info < (3, 11):
+        print(
+            "::error::'with.use_pyproject' input requires Python 3.11 or later.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
+    import tomllib
+
+    try:
+        with Path("pyproject.toml").open("rb") as fp:
+            pyproject = tomllib.load(fp)
+    except FileNotFoundError:
+        print(
+            "::error::'with.use_pyproject' input requires a pyproject.toml file.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
+    try:
+        deps = pyproject["project"]["dependencies"]
+        if not isinstance(deps, list):
+            raise TypeError()
+    except (KeyError, TypeError):
+        print(
+            "::error::'project.dependencies' table missing from pyproject.toml.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
+    try:
+        for item in deps:
+            # Rudimentary PEP 508 parsing.
+            item = item.split(";")[0]
+            item = EXTRAS_RE.sub("", item).strip()
+            if item == "black":
+                return ""
+            elif m := BLACK_VERSION_RE.match(item):
+                return m.group(1).strip()
+    except TypeError:
+        pass
+
+    print(
+        "::error::'black' dependency missing from pyproject.toml.",
+        file=sys.stderr,
+        flush=True,
+    )
+    sys.exit(1)
+
 
 run([sys.executable, "-m", "venv", str(ENV_PATH)], check=True)
 
-version_specifier = VERSION
-if VERSION and VERSION[0] in "0123456789":
-    version_specifier = f"=={VERSION}"
+version_specifier = determine_version_specifier()
 if JUPYTER:
     extra_deps = "[colorama,jupyter]"
 else:

--- a/action/main.py
+++ b/action/main.py
@@ -17,7 +17,7 @@ BLACK_ARGS = os.getenv("INPUT_BLACK_ARGS", default="")
 VERSION = os.getenv("INPUT_VERSION", default="")
 USE_PYPROJECT = os.getenv("INPUT_USE_PYPROJECT") == "true"
 
-BLACK_VERSION_RE = re.compile(r"^black([^A-Z0-9._-]+)", re.IGNORECASE)
+BLACK_VERSION_RE = re.compile(r"^black([^A-Z0-9._-]+.*)$", re.IGNORECASE)
 EXTRAS_RE = re.compile(r"\[.*\]")
 
 

--- a/action/main.py
+++ b/action/main.py
@@ -65,6 +65,10 @@ def read_version_specifier_from_pyproject() -> str:
         )
         sys.exit(1)
 
+    version = pyproject.get("tool", {}).get("black", {}).get("required-version")
+    if version is not None:
+        return f"=={version}"
+
     arrays = [
         pyproject.get("project", {}).get("dependencies"),
         *pyproject.get("project", {}).get("optional-dependencies", {}).values(),

--- a/action/main.py
+++ b/action/main.py
@@ -64,16 +64,14 @@ def read_version_specifier_from_pyproject() -> str:
         )
         sys.exit(1)
 
-    version = find_black_version_in_array(
-        pyproject.get("project", {}).get("dependencies")
-    )
-    if version is None:
-        for deps in (
-            pyproject.get("project", {}).get("optional-dependencies", {}).values()
-        ):
-            version = find_black_version_in_array(deps)
-            if version is not None:
-                break
+    arrays = [
+        pyproject.get("project", {}).get("dependencies"),
+        *pyproject.get("project", {}).get("optional-dependencies", {}).values(),
+    ]
+    for array in arrays:
+        version = find_black_version_in_array(array)
+        if version is not None:
+            break
 
     if version is None:
         print(

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -32,10 +32,11 @@ We recommend the use of the `@stable` tag, but per version tags also exist if yo
 that. Note that the action's version you select is independent of the version of _Black_
 the action will use.
 
-The version of _Black_ the action will use can be configured via `version`. This can be
-any
+The version of _Black_ the action will use can be configured via `version` or read from
+the pyproject.toml file. `version` can be any
 [valid version specifier](https://packaging.python.org/en/latest/glossary/#term-Version-Specifier)
-or just the version number if you want an exact version. The action defaults to the
+or just the version number if you want an exact version. To read the version from the
+pyproject.toml file instead, set `use_pyproject` to `true`. The action defaults to the
 latest release available on PyPI. Only versions available from PyPI are supported, so no
 commit SHAs or branch names.
 
@@ -69,4 +70,14 @@ If you want to match versions covered by Black's
     options: "--check --verbose"
     src: "./src"
     version: "~= 22.0"
+```
+
+If you want to read the version from pyproject.toml, set `use_pyproject` to `true`:
+
+```yaml
+- uses: psf/black@stable
+  with:
+    options: "--check --verbose"
+    src: "./src"
+    use_pyproject: true
 ```

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -33,10 +33,10 @@ that. Note that the action's version you select is independent of the version of
 the action will use.
 
 The version of _Black_ the action will use can be configured via `version` or read from
-the pyproject.toml file. `version` can be any
+the `pyproject.toml` file. `version` can be any
 [valid version specifier](https://packaging.python.org/en/latest/glossary/#term-Version-Specifier)
 or just the version number if you want an exact version. To read the version from the
-pyproject.toml file instead, set `use_pyproject` to `true`. The action defaults to the
+`pyproject.toml` file instead, set `use_pyproject` to `true`. The action defaults to the
 latest release available on PyPI. Only versions available from PyPI are supported, so no
 commit SHAs or branch names.
 
@@ -72,7 +72,7 @@ If you want to match versions covered by Black's
     version: "~= 22.0"
 ```
 
-If you want to read the version from pyproject.toml, set `use_pyproject` to `true`:
+If you want to read the version from `pyproject.toml`, set `use_pyproject` to `true`:
 
 ```yaml
 - uses: psf/black@stable

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -37,10 +37,10 @@ the `pyproject.toml` file. `version` can be any
 [valid version specifier](https://packaging.python.org/en/latest/glossary/#term-Version-Specifier)
 or just the version number if you want an exact version. To read the version from the
 `pyproject.toml` file instead, set `use_pyproject` to `true`. This will first look into
-the `tool.black.required-version` field, then the `project.dependencies` array and finally
-the `project.optional-dependencies` table. The action defaults to the
-latest release available on PyPI. Only versions available from PyPI are supported, so no
-commit SHAs or branch names.
+the `tool.black.required-version` field, then the `project.dependencies` array and
+finally the `project.optional-dependencies` table. The action defaults to the latest
+release available on PyPI. Only versions available from PyPI are supported, so no commit
+SHAs or branch names.
 
 If you want to include Jupyter Notebooks, _Black_ must be installed with the `jupyter`
 extra. Installing the extra and including Jupyter Notebook files can be configured via

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -36,7 +36,9 @@ The version of _Black_ the action will use can be configured via `version` or re
 the `pyproject.toml` file. `version` can be any
 [valid version specifier](https://packaging.python.org/en/latest/glossary/#term-Version-Specifier)
 or just the version number if you want an exact version. To read the version from the
-`pyproject.toml` file instead, set `use_pyproject` to `true`. The action defaults to the
+`pyproject.toml` file instead, set `use_pyproject` to `true`. This will first look into
+the `tool.black.required-version` field, then the `project.dependencies` array and finally
+the `project.optional-dependencies` table. The action defaults to the
 latest release available on PyPI. Only versions available from PyPI are supported, so no
 commit SHAs or branch names.
 


### PR DESCRIPTION
### Description

This adds an `use_pyproject` input to the GitHub Action that – when set to `true` – will read the black version from pyproject.toml file. Either from the `project.dependencies` array or one of the arrays from the `project.optional-dependencies` table.

Closes: #4285

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

Trial runs at: https://github.com/srittau/python-asserts/actions/runs/8490172420, using this branch of one of my projects: https://github.com/srittau/python-asserts/tree/black-test
