### PR TITLE
[Github Action] Directly install from repo. if `export-subst` is skipped

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Github Action now works even when `git archive` is skipped (#4313)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+
 - Github Action now works even when `git archive` is skipped (#4313)
 
 ### Documentation

--- a/action/main.py
+++ b/action/main.py
@@ -19,6 +19,7 @@ USE_PYPROJECT = os.getenv("INPUT_USE_PYPROJECT") == "true"
 
 BLACK_VERSION_RE = re.compile(r"^black([^A-Z0-9._-]+.*)$", re.IGNORECASE)
 EXTRAS_RE = re.compile(r"\[.*\]")
+EXPORT_SUBST_FAIL_RE = re.compile(r"\$Format:.*\$")
 
 
 def determine_version_specifier() -> str:
@@ -135,7 +136,11 @@ else:
     # expected format is one of:
     # - 23.1.0
     # - 23.1.0-51-g448bba7
-    if describe_name.count("-") < 2:
+    # - $Format:%(describe:tags=true,match=*[0-9]*)$ (if export-subst fails)
+    if (
+        describe_name.count("-") < 2
+        and EXPORT_SUBST_FAIL_RE.match(describe_name) is None
+    ):
         # the action's commit matches a tag exactly, install exact version from PyPI
         req = f"black{extra_deps}=={describe_name}"
     else:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

I noticed that, if the github action is called in an unexpected way (such as from https://github.com/nektos/act), substitution of `.git_archival.txt` can be skipped.
For that cases, the action tries to execute `pip install black[colorama]==$Format:%(describe:tags=true,match=*[0-9]*)$`, which is not making any sense.
This PR is trying to fix this behavior.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->


<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
