### PR TITLE
Move changelog entry to right section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash involving indented dummy functions containing newlines (#4318)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
@@ -27,9 +29,6 @@
 ### Parser
 
 <!-- Changes to the parser or to version autodetection -->
-
-- Add support to style function definitions containing newlines before function stubs
-  (#4318)
 
 ### Performance
 


### PR DESCRIPTION
Crashes are usually documented in the stable style portion of the changelog. This patch doesn't affect the parser (e.g. blib2to3). Noticed the second after I merged :-)