### PR TITLE
Simplify string tokenization regexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 ### Performance
 
 <!-- Changes that improve Black's performance. -->
+- Fix bad performance on certain complex string literals (#4331)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 ### Performance
 
 <!-- Changes that improve Black's performance. -->
+
 - Fix bad performance on certain complex string literals (#4331)
 
 ### Output

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -119,13 +119,13 @@ Imagnumber = group(r"\d+(?:_\d+)*[jJ]", Floatnumber + r"[jJ]")
 Number = group(Imagnumber, Floatnumber, Intnumber)
 
 # Tail end of ' string.
-Single = r"[^'\\]*(?:\\.[^'\\]*)*'"
+Single = r"(?:\\.|[^'\\])*'"
 # Tail end of " string.
-Double = r'[^"\\]*(?:\\.[^"\\]*)*"'
+Double = r'(?:\\.|[^"\\])*"'
 # Tail end of ''' string.
-Single3 = r"[^'\\]*(?:\\.|'(?!'')|[^'\\])*'''"
+Single3 = r"(?:\\.|'(?!'')|[^'\\])*'''"
 # Tail end of """ string.
-Double3 = r'[^"\\]*(?:\\.|"(?!"")|[^"\\])*"""'
+Double3 = r'(?:\\.|"(?!"")|[^"\\])*"""'
 _litprefix = r"(?:[uUrRbB]|[rR][bB]|[bBuU][rR])?"
 _fstringlitprefix = r"(?:rF|FR|Fr|fr|RF|F|rf|f|Rf|fR)"
 Triple = group(
@@ -136,12 +136,12 @@ Triple = group(
 )
 
 # beginning of a single quoted f-string. must not end with `{{` or `\N{`
-SingleLbrace = r"[^'\\{]*(?:\\N{|\\.|{{|[^'\\{])*(?<!\\N){(?!{)"
-DoubleLbrace = r'[^"\\{]*(?:\\N{|\\.|{{|[^"\\{])*(?<!\\N){(?!{)'
+SingleLbrace = r"(?:\\N{|\\.|{{|[^'\\{])*(?<!\\N){(?!{)"
+DoubleLbrace = r'(?:\\N{|\\.|{{|[^"\\{])*(?<!\\N){(?!{)'
 
 # beginning of a triple quoted f-string. must not end with `{{` or `\N{`
-Single3Lbrace = r"[^'{]*(?:\\N{|\\[^{]|{{|'(?!'')|[^'{])*(?<!\\N){(?!{)"
-Double3Lbrace = r'[^"{]*(?:\\N{|\\[^{]|{{|"(?!"")|[^"{])*(?<!\\N){(?!{)'
+Single3Lbrace = r"(?:\\N{|\\[^{]|{{|'(?!'')|[^'{])*(?<!\\N){(?!{)"
+Double3Lbrace = r'(?:\\N{|\\[^{]|{{|"(?!"")|[^"{])*(?<!\\N){(?!{)'
 
 # ! format specifier inside an fstring brace, ensure it's not a `!=` token
 Bang = Whitespace + group("!") + r"(?!=)"

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -140,8 +140,8 @@ SingleLbrace = r"(?:\\N{|\\.|{{|[^'\\{])*(?<!\\N){(?!{)"
 DoubleLbrace = r'(?:\\N{|\\.|{{|[^"\\{])*(?<!\\N){(?!{)'
 
 # beginning of a triple quoted f-string. must not end with `{{` or `\N{`
-Single3Lbrace = r"(?:\\N{|\\[^{]|{{|'(?!'')|[^'{])*(?<!\\N){(?!{)"
-Double3Lbrace = r'(?:\\N{|\\[^{]|{{|"(?!"")|[^"{])*(?<!\\N){(?!{)'
+Single3Lbrace = r"(?:\\N{|\\[^{]|{{|'(?!'')|[^'{\\])*(?<!\\N){(?!{)"
+Double3Lbrace = r'(?:\\N{|\\[^{]|{{|"(?!"")|[^"{\\])*(?<!\\N){(?!{)'
 
 # ! format specifier inside an fstring brace, ensure it's not a `!=` token
 Bang = Whitespace + group("!") + r"(?!=)"
@@ -171,12 +171,12 @@ Bracket = "[][(){}]"
 Special = group(r"\r?\n", r"[:;.,`@]")
 Funny = group(Operator, Bracket, Special)
 
-_string_middle_single = r"[^\n'\\]*(?:\\.[^\n'\\]*)*"
-_string_middle_double = r'[^\n"\\]*(?:\\.[^\n"\\]*)*'
+_string_middle_single = r"(?:[^\n'\\]|\\.)*"
+_string_middle_double = r'(?:[^\n"\\]|\\.)*'
 
 # FSTRING_MIDDLE and LBRACE, must not end with a `{{` or `\N{`
-_fstring_middle_single = r"[^\n'{]*(?:\\N{|\\[^{]|{{|[^\n'{])*(?<!\\N)({)(?!{)"
-_fstring_middle_double = r'[^\n"{]*(?:\\N{|\\[^{]|{{|[^\n"{])*(?<!\\N)({)(?!{)'
+_fstring_middle_single = r"(?:\\N{|\\[^{]|{{|[^\n'{\\])*(?<!\\N)({)(?!{)"
+_fstring_middle_double = r'(?:\\N{|\\[^{]|{{|[^\n"{\\])*(?<!\\N)({)(?!{)'
 
 # First (or only) line of ' or " string.
 ContStr = group(
@@ -689,8 +689,6 @@ def generate_tokens(
         while pos < max:
             if fstring_level > 0 and not inside_fstring_braces:
                 endprog = endprog_stack[-1]
-                print("REGEX", endprog.pattern)
-                print(":LINE", line)
                 endmatch = endprog.match(line, pos)
                 if endmatch:  # all on one line
                     start, end = endmatch.span(0)

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -123,9 +123,9 @@ Single = r"[^'\\]*(?:\\.[^'\\]*)*'"
 # Tail end of " string.
 Double = r'[^"\\]*(?:\\.[^"\\]*)*"'
 # Tail end of ''' string.
-Single3 = r"[^'\\]*(?:(?:\\.|'(?!''))[^'\\]*)*'''"
+Single3 = r"[^'\\]*(?:\\.|'(?!'')|[^'\\])*'''"
 # Tail end of """ string.
-Double3 = r'[^"\\]*(?:(?:\\.|"(?!""))[^"\\]*)*"""'
+Double3 = r'[^"\\]*(?:\\.|"(?!"")|[^"\\])*"""'
 _litprefix = r"(?:[uUrRbB]|[rR][bB]|[bBuU][rR])?"
 _fstringlitprefix = r"(?:rF|FR|Fr|fr|RF|F|rf|f|Rf|fR)"
 Triple = group(
@@ -136,12 +136,12 @@ Triple = group(
 )
 
 # beginning of a single quoted f-string. must not end with `{{` or `\N{`
-SingleLbrace = r"[^'\\{]*(?:(?:\\N{|\\.|{{)[^'\\{]*)*(?<!\\N){(?!{)"
-DoubleLbrace = r'[^"\\{]*(?:(?:\\N{|\\.|{{)[^"\\{]*)*(?<!\\N){(?!{)'
+SingleLbrace = r"[^'\\{]*(?:\\N{|\\.|{{|[^'\\{])*(?<!\\N){(?!{)"
+DoubleLbrace = r'[^"\\{]*(?:\\N{|\\.|{{|[^"\\{])*(?<!\\N){(?!{)'
 
 # beginning of a triple quoted f-string. must not end with `{{` or `\N{`
-Single3Lbrace = r"[^'{]*(?:(?:\\N{|\\[^{]|{{|'(?!''))[^'{]*)*(?<!\\N){(?!{)"
-Double3Lbrace = r'[^"{]*(?:(?:\\N{|\\[^{]|{{|"(?!""))[^"{]*)*(?<!\\N){(?!{)'
+Single3Lbrace = r"[^'{]*(?:\\N{|\\[^{]|{{|'(?!'')|[^'{])*(?<!\\N){(?!{)"
+Double3Lbrace = r'[^"{]*(?:\\N{|\\[^{]|{{|"(?!"")|[^"{])*(?<!\\N){(?!{)'
 
 # ! format specifier inside an fstring brace, ensure it's not a `!=` token
 Bang = Whitespace + group("!") + r"(?!=)"
@@ -175,8 +175,8 @@ _string_middle_single = r"[^\n'\\]*(?:\\.[^\n'\\]*)*"
 _string_middle_double = r'[^\n"\\]*(?:\\.[^\n"\\]*)*'
 
 # FSTRING_MIDDLE and LBRACE, must not end with a `{{` or `\N{`
-_fstring_middle_single = r"[^\n'{]*(?:(?:\\N{|\\[^{]|{{)[^\n'{]*)*(?<!\\N)({)(?!{)"
-_fstring_middle_double = r'[^\n"{]*(?:(?:\\N{|\\[^{]|{{)[^\n"{]*)*(?<!\\N)({)(?!{)'
+_fstring_middle_single = r"[^\n'{]*(?:\\N{|\\[^{]|{{|[^\n'{])*(?<!\\N)({)(?!{)"
+_fstring_middle_double = r'[^\n"{]*(?:\\N{|\\[^{]|{{|[^\n"{])*(?<!\\N)({)(?!{)'
 
 # First (or only) line of ' or " string.
 ContStr = group(
@@ -689,6 +689,8 @@ def generate_tokens(
         while pos < max:
             if fstring_level > 0 and not inside_fstring_braces:
                 endprog = endprog_stack[-1]
+                print("REGEX", endprog.pattern)
+                print(":LINE", line)
                 endmatch = endprog.match(line, pos)
                 if endmatch:  # all on one line
                     start, end = endmatch.span(0)

--- a/tests/data/cases/pep_701.py
+++ b/tests/data/cases/pep_701.py
@@ -119,6 +119,8 @@ log(
     level=0,
 )
 
+f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\":\\"cluster-info\\",\\"namespace\\":\\"amazon-cloudwatch\\"}}}}'
+
 # output
 
 x = f"foo"
@@ -240,3 +242,5 @@ log(
     f"{self.writer._transport.get_extra_info('peername')}",  # type: ignore[attr-defined]
     level=0,
 )
+
+f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\":\\"cluster-info\\",\\"namespace\\":\\"amazon-cloudwatch\\"}}}}'


### PR DESCRIPTION
Fixes #4330

I found that the repro case from #4330 was hanging in applying some of the regexes used in tokenization. These regexes have a few inefficient features:
- Nested and adjacent groups instead of a single level; this leads to backtracking
- Some of the groups for "normal" characters were missing an exclusion for backslash, which was also leading to backtracking.