### PR TITLE
packaging metadata: link to the docs, issue tracker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
 - Packaging metadata updated: docs are explictly linked, the issue tracker is now also
-  linked. This improves the PyPI listing for Black.
+  linked. This improves the PyPI listing for Black. (#4345)
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
+- Packaging metadata updated: docs are explictly linked, the issue tracker is
+  now also linked. This improves the PyPI listing for Black.
+
 ### Parser
 
 <!-- Changes to the parser or to version autodetection -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,8 +22,8 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
-- Packaging metadata updated: docs are explictly linked, the issue tracker is
-  now also linked. This improves the PyPI listing for Black.
+- Packaging metadata updated: docs are explictly linked, the issue tracker is now also
+  linked. This improves the PyPI listing for Black.
 
 ### Parser
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,10 @@ blackd = "blackd:patched_main [d]"
 black = "black.schema:get_schema"
 
 [project.urls]
+Documentation = "https://black.readthedocs.io/"
 Changelog = "https://github.com/psf/black/blob/main/CHANGES.md"
-Homepage = "https://github.com/psf/black"
+Repository = "https://github.com/psf/black"
+Issues = "https://github.com/psf/black/issues"
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"


### PR DESCRIPTION
### Description

The Black docs are not linked from the sidebar on PyPI: https://pypi.org/project/black/

![image](https://github.com/psf/black/assets/1330696/d4ab63ae-212f-446c-85f6-87dc5903e4e9)

This PR adds the necessary metadata to link to the docs there, along with the issue tracker.

The link to the GitHub repository is change from the "Homepage" type to "Repository".

See https://github.com/pypi/warehouse/issues/5947
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
