### PR TITLE
Convert PR numbers in docs/change_log to clickable links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,19 +38,19 @@ def replace_pr_numbers_with_links(content: str) -> str:
     base_url = "https://github.com/psf/black/pull/"
     pr_num_regex = re.compile(r"\(#(\d+)\)")
 
-    def num_to_link(match: re.Match) -> str:
-        full_match, number = match.group(0, 1)
+    def num_to_link(match: re.Match[str]) -> str:
+        number = match.group(1)
         url = f"{base_url}{number}"
-        return f"[{full_match}]({url})"
+        return f"([#{number}]({url}))"
 
     return pr_num_regex.sub(num_to_link, content)
 
 
 def handle_include_read(
-        app: Sphinx,
-        relative_path: Path,
-        parent_docname: str,
-        content: list[str],
+    app: Sphinx,
+    relative_path: Path,
+    parent_docname: str,
+    content: list[str],
 ) -> None:
     """Handler for the include-read sphinx event."""
     if parent_docname == "change_log":

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,12 @@
 #
 
 import os
+import re
 import string
 from importlib.metadata import version
 from pathlib import Path
+
+from sphinx.application import Sphinx
 
 CURRENT_DIR = Path(__file__).parent
 
@@ -27,6 +30,36 @@ def make_pypi_svg(version: str) -> None:
         svg: str = string.Template(f.read()).substitute(version=version)
     with open(str(target), "w", encoding="utf8") as f:
         f.write(svg)
+
+
+def replace_pr_numbers_with_links(content: str) -> str:
+    """Replaces all PR numbers with the corresponding GitHub link."""
+
+    base_url = "https://github.com/psf/black/pull/"
+    pr_num_regex = re.compile(r"\(#(\d+)\)")
+
+    def num_to_link(match: re.Match) -> str:
+        full_match, number = match.group(0, 1)
+        url = f"{base_url}{number}"
+        return f"[{full_match}]({url})"
+
+    return pr_num_regex.sub(num_to_link, content)
+
+
+def handle_include_read(
+        app: Sphinx,
+        relative_path: Path,
+        parent_docname: str,
+        content: list[str],
+) -> None:
+    """Handler for the include-read sphinx event."""
+    if parent_docname == "change_log":
+        content[0] = replace_pr_numbers_with_links(content[0])
+
+
+def setup(app: Sphinx) -> None:
+    """Sets up a minimal sphinx extension."""
+    app.connect("include-read", handle_include_read)
 
 
 # Necessary so Click doesn't hit an encode error when called by


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description
Closes #4258.

This adds a listener to the sphinx `include-read` event to find all PR numbers `(#X)` with regex and replace them with the corresponding link `[(#X)](https://github.com/psf/black/pull/X)`.

I didn't add an entry to `CHANGES.md` since this seems like a rather minor docs change.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [-] Add an entry in `CHANGES.md` if necessary?
- [-] Add / update tests if necessary?
- [-] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
