### PR TITLE
docker: Install the compiled wheel then install extras dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,7 +42,7 @@
 
 ### _Blackd_
 
-<!-- Changes to blackd -->
+- Fix blackd (and all extras installs) for docker container (#4357)
 
 ### Integrations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN python -m venv $VIRTUAL_ENV
 RUN python -m pip install --no-cache-dir hatch hatch-fancy-pypi-readme hatch-vcs
 RUN . /opt/venv/bin/activate && pip install --no-cache-dir --upgrade pip setuptools \
     && cd /src && hatch build -t wheel \
-    && pip install --no-cache-dir dist/*-cp*[colorama,d,uvloop]
+    && pip install --no-cache-dir dist/*-cp* \
+    && pip install black[colorama,d,uvloop]
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
- Lets install black, then ask to install black with extrasC
  - pip sees black is installed and just installs extra dependencies

Test:
- Build local container
  - `docker build -t black_local .`
- Run blackd in container
  - `docker run -p 45484:45484 --rm black_local blackd --bind-host 0.0.0.0`
```
cooper@home1:~/repos/black$ docker run -p 45484:45484 --rm black_local blackd --bind-host 0.0.0.0
blackd version 24.4.3.dev11+gad60e62 listening on 0.0.0.0 port 45484
INFO:aiohttp.access:10.255.255.1 [10/May/2024:14:40:36 +0000] "GET / HTTP/1.1" 405 204 "-" "curl/8.5.0"

cooper@home1:~/repos/black$ curl http://10.6.9.2:45484
405: Method Not Allowed
```
- Test version is compiled
```
cooper@home1:~/repos/black$ docker run --rm black_local black --version
black, 24.4.3.dev11+gad60e62 (compiled: yes)
Python (CPython) 3.12.3
```

Fixes #4163