### PR TITLE
Make sure Black doesn't crash when `fmt:off` is used before a closing paren

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash when `# fmt: off` is used before a closing parenthesis or bracket. (#4363)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/tests/data/cases/fmtonoff6.py
+++ b/tests/data/cases/fmtonoff6.py
@@ -1,0 +1,13 @@
+# Regression test for https://github.com/psf/black/issues/2478.
+def foo():
+    arr = (
+        (3833567325051000, 5, 1, 2, 4229.25, 6, 0),
+        # fmt: off
+    )
+
+
+# Regression test for https://github.com/psf/black/issues/3458.
+dependencies = {
+    a: b,
+    # fmt: off
+}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

When a `# fmt: off` is used before a closing paren, it's invalid as _Black_ demands that the `# fmt: on/off` pairs [_must be on the same level of indentation and in the same block_](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#ignoring-sections). So this PR choses to ignore it. Previously it would crash as it ends up with one extra closing paren.

- Fix #2478
- Fix #3458

(Also refactored the `convert_one_fmt_off_pair` function a little bit.)

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
