### PR TITLE
Fix formatting of backslash escaped quote inside f-string 

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1246,7 +1246,7 @@ def _format_str_once(
 
     context_manager_features = {
         feature
-        for feature in {Feature.PARENTHESIZED_CONTEXT_MANAGERS}
+        for feature in {Feature.PARENTHESIZED_CONTEXT_MANAGERS, Feature.FSTRING_PARSING}
         if supports_feature(versions, feature)
     }
     normalize_fmt_off(src_node, mode, lines)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -499,7 +499,9 @@ class LineGenerator(Visitor[Line]):
 
         if self.mode.string_normalization and leaf.type == token.STRING:
             leaf.value = normalize_string_prefix(leaf.value)
-            leaf.value = normalize_string_quotes(leaf.value)
+            features_set = set(self.features)
+            if Feature.FSTRING_PARSING not in features_set:
+                leaf.value = normalize_string_quotes(leaf.value)
         yield from self.visit_default(leaf)
 
     def visit_NUMBER(self, leaf: Leaf) -> Iterator[Line]:


### PR DESCRIPTION
Added FSTRING_PARSING to context_manager_features in LineGenerator. This will determine the removal of escaped quotes.
Fixes [#4350](https://github.com/psf/black/issues/4350)
