### PR TITLE
Fix the fmt: skip issues. Changed a test case also

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Fix crash when `# fmt: off` is used before a closing parenthesis or bracket. (#4363)
+- Fix `# fmt: skip` issues of not formating other line when that line is connected to
+  fmt: skip line (#4380)
 
 ### Preview style
 

--- a/tests/data/cases/single_line_format_skip_with_multiple_comments.py
+++ b/tests/data/cases/single_line_format_skip_with_multiple_comments.py
@@ -11,7 +11,7 @@ skip_will_not_work2 =  "a" +  "b"  # some text; fmt:skip happens to be part of i
 
 foo =  123  # fmt: skip # noqa: E501 # pylint
 bar = (
-    123   ,
+    123,
     (        1      +           5      )  # pylint # fmt:skip
 )
 baz = "a"    +   "b"  # pylint; fmt: skip; noqa: E501


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

Fixes #4366 , #3682  , #3608 , #3603 , #3364 , #3009  

Please Review this and let me know if something need to be changed 


I have change a test file Because 

Input:- 
```
bar =    (
    123   ,
    (        1      +           5      )  # pylint # fmt:skip
)
```

Previous Output:- 
```
bar = (
    123   ,
    (        1      +           5      )  # pylint # fmt:skip
)
```


New Output:-
```
bar = (
    123,
    (        1      +           5      )  # pylint # fmt:skip
)
```



The test file ignores the previous line from skip line because it is on same parent nodes. 