### PR TITLE
Bump cibuildwheel to 2.19.2

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel and pypyp
         run: |
-          pipx install cibuildwheel==2.15.0
+          pipx install cibuildwheel==2.19.2
           pipx install pypyp==1
       - name: generate matrix
         if: github.event_name != 'pull_request'
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v2.18.1
+      - uses: pypa/cibuildwheel@v2.19.2
         with:
           only: ${{ matrix.only }}
 


### PR DESCRIPTION
Fixes #4383, fixes #4381, removes a (basically harmless) version skew