### PR TITLE
fix: don't try to format strings inside f-strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
 - Fix regression where Black failed to parse a multiline f-string containing another
   multiline string (#4339)
 
+- Fix regression where Black failed to parse an escaped single quote inside an f-string
+  (#4401)
+
 - Fix bug with Black incorrectly parsing empty lines with a backslash (#4343)
 
 ### Performance

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -510,13 +510,10 @@ class LineGenerator(Visitor[Line]):
         # currently we don't want to format and split f-strings at all.
         string_leaf = fstring_to_string(node)
         node.replace(string_leaf)
-        if (
-            "\\" in string_leaf.value
-            and any(
-                "\\" in str(child)
-                for child in node.children
-                if child.type == syms.fstring_replacement_field
-            )
+        if "\\" in string_leaf.value and any(
+            "\\" in str(child)
+            for child in node.children
+            if child.type == syms.fstring_replacement_field
         ):
             # string normalization doesn't account for nested quotes,
             # causing breakages. skip normalization when nested quotes exist

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -510,6 +510,18 @@ class LineGenerator(Visitor[Line]):
         # currently we don't want to format and split f-strings at all.
         string_leaf = fstring_to_string(node)
         node.replace(string_leaf)
+        if (
+            "\\" in string_leaf.value
+            and any(
+                "\\" in str(child)
+                for child in node.children
+                if child.type == syms.fstring_replacement_field
+            )
+        ):
+            # string normalization doesn't account for nested quotes,
+            # causing breakages. skip normalization when nested quotes exist
+            yield from self.visit_default(string_leaf)
+            return
         yield from self.visit_STRING(string_leaf)
 
         # TODO: Uncomment Implementation to format f-string children

--- a/tests/data/cases/pep_701.py
+++ b/tests/data/cases/pep_701.py
@@ -128,6 +128,9 @@ f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\
 f"""{'''
 '''}"""
 
+f"{'\''}"
+f"{f'\''}"
+
 # output
 
 x = f"foo"
@@ -258,3 +261,6 @@ f'{{\\"kind\\":\\"ConfigMap\\",\\"metadata\\":{{\\"annotations\\":{{}},\\"name\\
 
 f"""{'''
 '''}"""
+
+f"{'\''}"
+f"{f'\''}"


### PR DESCRIPTION
Resolves #4350 , closes #4365

If a string like `'\''` is inside a double-quoted f-string, like `f"{'\''}"` the formatter would break trying to remove the escaped `\'` quote.

This is because `normalize_string_quotes` looks at the entire `f"{'\''}"` input, and the outermost quotes `"`, hence determining that the `\'` escape is unnecessary.

To avoid these cases, we don't try to normalize inner strings inside f-string braces.