### PR TITLE
Fix Type hint

### DIFF
--- a/tests/data/cases/composition.py
+++ b/tests/data/cases/composition.py
@@ -1,5 +1,5 @@
 class C:
-    def test(self) -> None:
+    def test(self) -> str:
         with patch("black.out", print):
             self.assertEqual(
                 unstyle(str(report)), "1 file reformatted, 1 file failed to reformat."


### PR DESCRIPTION
## Description
Fix type check warning reported by Pyre@Google, which was outdated after code modification.

## Detail
update the return type of `test` from `None` to `str`, since the function return a string after commit https://github.com/psf/black/commit/87b8df28c48353d3d08d7e88d178c7a567de816a