### PR TITLE
Document `find_project_root` ignoring `pyproject.toml` without `[tool.black]`

### DIFF
--- a/src/black/files.py
+++ b/src/black/files.py
@@ -59,6 +59,9 @@ def find_project_root(
 ) -> Tuple[Path, str]:
     """Return a directory containing .git, .hg, or pyproject.toml.
 
+    pyproject.toml files are only considered if they contain a [tool.black]
+    section and are ignored otherwise.
+
     That directory will be a common parent of all files and directories
     passed in `srcs`.
 


### PR DESCRIPTION
### Description
Extend the docstring of black's `find_project_root` to mention that it ignores `pyproject.toml` files without a `[tool.black]` section.

This is relevant because that function is also used by other python packages that use black. I found that e.g. [datamodel-code-generator](https://github.com/koxudaxi/datamodel-code-generator)  uses that function and that there the ignoring of the pyproject.toml files lead to [a degradation](https://github.com/koxudaxi/datamodel-code-generator/issues/2052). I think in that case it would be better to not use black's function for finding the pyproject.toml, but in any case this behavior should be documented.

### Checklist - did you ...

- [X] Add new / update outdated documentation? -- point of this PR