### PR TITLE
fix: fix PEP 646 support of tuple unpacking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Fix type annotation spacing between * and more complex type variable tuple (i.e. `def
+  fn(*args: *tuple[*Ts, T]) -> None: pass`) (#4440)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -36,6 +36,8 @@ Currently, the following features are included in the preview style:
   `case` blocks.
 - `parens_for_long_if_clauses_in_case_block`: Adds parentheses to `if` clauses in `case`
   blocks when the line is too long
+- `pep646_typed_star_arg_type_var_tuple`: fix type annotation spacing between * and more
+  complex type variable tuple (i.e. `def fn(*args: *tuple[*Ts, T]) -> None: pass`)
 
 (labels/unstable-features)=
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -206,6 +206,7 @@ class Preview(Enum):
     docstring_check_for_newline = auto()
     remove_redundant_guard_parens = auto()
     parens_for_long_if_clauses_in_case_block = auto()
+    pep646_typed_star_arg_type_var_tuple = auto()
 
 
 UNSTABLE_FEATURES: Set[Preview] = {

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -254,9 +254,15 @@ def whitespace(leaf: Leaf, *, complex_subscript: bool, mode: Mode) -> str:  # no
         elif (
             prevp.type == token.STAR
             and parent_type(prevp) == syms.star_expr
-            and parent_type(prevp.parent) == syms.subscriptlist
+            and (
+                parent_type(prevp.parent) == syms.subscriptlist
+                or (
+                    Preview.pep646_typed_star_arg_type_var_tuple in mode
+                    and parent_type(prevp.parent) == syms.tname_star
+                )
+            )
         ):
-            # No space between typevar tuples.
+            # No space between typevar tuples or unpacking them.
             return NO
 
         elif prevp.type in VARARGS_SPECIALS:

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -90,7 +90,8 @@
           "is_simple_lookup_for_doublestar_expression",
           "docstring_check_for_newline",
           "remove_redundant_guard_parens",
-          "parens_for_long_if_clauses_in_case_block"
+          "parens_for_long_if_clauses_in_case_block",
+          "pep646_typed_star_arg_type_var_tuple"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/preview_pep646_typed_star_arg_type_var_tuple.py
+++ b/tests/data/cases/preview_pep646_typed_star_arg_type_var_tuple.py
@@ -1,0 +1,8 @@
+# flags: --minimum-version=3.11 --preview
+
+
+def fn(*args: *tuple[*A, B]) -> None:
+    pass
+
+
+fn.__annotations__

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -906,6 +906,9 @@ class BlackTestCase(BlackBaseTestCase):
         self.check_features_used("a[*b]", {Feature.VARIADIC_GENERICS})
         self.check_features_used("a[x, *y(), z] = t", {Feature.VARIADIC_GENERICS})
         self.check_features_used("def fn(*args: *T): pass", {Feature.VARIADIC_GENERICS})
+        self.check_features_used(
+            "def fn(*args: *tuple[*T]): pass", {Feature.VARIADIC_GENERICS}
+        )
 
         self.check_features_used("with a: pass", set())
         self.check_features_used("with a, b: pass", set())


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This change fixes unpacking a tuple or generic type when *args is a type variable tuple.


<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
