### PR TITLE
Fix 4399 `ASTSafetyError`  on comment in return type annotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+Fix `ASTSafetyError` crash when return type contains one element and comments spanning
+multiple lines.
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 <!-- Changes that affect Black's stable style -->
 
 Fix `ASTSafetyError` crash when return type contains one element and comments spanning
-multiple lines.
+multiple lines. (#4444)
 
 ### Preview style
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1116,6 +1116,14 @@ def bracket_split_build_line(
                 )
                 # Don't add one inside parenthesized return annotations
                 and get_annotation_type(leaves[0]) != "return"
+                # Don't add comment for single element return type with comments
+                and not (
+                    sum(leaf.type is not STANDALONE_COMMENT for leaf in leaves) < 2
+                    and any(
+                        leaf.parent is not None and leaf.parent.type != syms.parameters
+                        for leaf in leaves
+                    )
+                )
                 # Don't add one inside PEP 604 unions
                 and not (
                     leaves[0].parent

--- a/tests/data/cases/single_element_parametized_return_type.py
+++ b/tests/data/cases/single_element_parametized_return_type.py
@@ -1,0 +1,50 @@
+def MyClass():
+    pass
+
+
+def create_my_nested_class() -> (
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    int
+):
+    class MyNestedClass(MyClass):
+        pass
+    return MyNestedClass
+
+
+def create_my_nested_class() -> (
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    int
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+):
+    class MyNestedClass(MyClass):
+        pass
+    return MyNestedClass
+
+# output
+
+
+def MyClass():
+    pass
+
+
+def create_my_nested_class() -> (
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    int
+):
+    class MyNestedClass(MyClass):
+        pass
+
+    return MyNestedClass
+
+
+def create_my_nested_class() -> (
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+    int
+    # test asnkdasldnsalkdnaskldnaklsdnsakln
+):
+    class MyNestedClass(MyClass):
+        pass
+
+    return MyNestedClass


### PR DESCRIPTION
### Description

Resolves #4399 

Added an extra check before adding commas to the elements in the body of a bracket split.

The check ensures that there is more than just one non-comment item in the list of return elements. It only performs this check for a bracket split in return annotations as it's non-problematic for parameter annotations. 

The extra comment was causing the `ASTSafetyError` (it led to the return type being interpreted as a tuple). 

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?