### PR TITLE
Fix skipping Jupyter cells with unknown %% magic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 
 - Fix crashes involving comments in parenthesised return types or `X | Y` style unions.
   (#4453)
+- Fix skipping Jupyter cells with unknown `%%` magic (#4462)
 
 ### Preview style
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -59,6 +59,7 @@ from black.handle_ipynb_magics import (
     put_trailing_semicolon_back,
     remove_trailing_semicolon,
     unmask_cell,
+    validate_cell,
 )
 from black.linegen import LN, LineGenerator, transform_line
 from black.lines import EmptyLineTracker, LinesBlock
@@ -1082,32 +1083,6 @@ def format_file_contents(
             src_contents, dst_contents, mode=mode, lines=lines
         )
     return dst_contents
-
-
-def validate_cell(src: str, mode: Mode) -> None:
-    """Check that cell does not already contain TransformerManager transformations,
-    or non-Python cell magics, which might cause tokenizer_rt to break because of
-    indentations.
-
-    If a cell contains ``!ls``, then it'll be transformed to
-    ``get_ipython().system('ls')``. However, if the cell originally contained
-    ``get_ipython().system('ls')``, then it would get transformed in the same way:
-
-        >>> TransformerManager().transform_cell("get_ipython().system('ls')")
-        "get_ipython().system('ls')\n"
-        >>> TransformerManager().transform_cell("!ls")
-        "get_ipython().system('ls')\n"
-
-    Due to the impossibility of safely roundtripping in such situations, cells
-    containing transformed magics will be ignored.
-    """
-    if any(transformed_magic in src for transformed_magic in TRANSFORMED_MAGICS):
-        raise NothingChanged
-    if (
-        src[:2] == "%%"
-        and src.split()[0][2:] not in PYTHON_CELL_MAGICS | mode.python_cell_magics
-    ):
-        raise NothingChanged
 
 
 def format_cell(src: str, *, fast: bool, mode: Mode) -> str:

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -53,7 +53,6 @@ from black.files import (
 )
 from black.handle_ipynb_magics import (
     PYTHON_CELL_MAGICS,
-    TRANSFORMED_MAGICS,
     jupyter_dependencies_are_installed,
     mask_cell,
     put_trailing_semicolon_back,

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -208,6 +208,22 @@ def test_cell_magic_with_custom_python_magic(
         assert result == expected_output
 
 
+@pytest.mark.parametrize(
+    "src",
+    (
+        "   %%custom_magic \nx=2",
+        "\n\n%%custom_magic\nx=2",
+        "# comment\n%%custom_magic\nx=2",
+        "\n  \n # comment with %%time\n\t\n %%custom_magic # comment \nx=2",
+    ),
+)
+def test_cell_magic_with_custom_python_magic_after_spaces_and_comments_noop(
+    src: str,
+) -> None:
+    with pytest.raises(NothingChanged):
+        format_cell(src, fast=True, mode=JUPYTER_MODE)
+
+
 def test_cell_magic_nested() -> None:
     src = "%%time\n%%time\n2+2"
     result = format_cell(src, fast=True, mode=JUPYTER_MODE)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This CL fixes an inconsistency of when to skip formatting of Jupyter cells with unknown magic methods.

Black correctly skips formatting in this case:
```Python
%%unknown_custom_magic
<code in another language that black shouldn't format>
```
However if the cell started with some empty lines black still tried to format it and failed:
```


%%unknown_custom_magic
<code in another language that black shouldn't format>
```
Also if the cell started with a comment black tried to format it:
```Python
# Some comment
%%unknown_custom_magic
<code in another language that black shouldn't format>
```
(This example isn't possible in normal Jupyter notebooks but it works in Colab.)

This PR ensures that black will skip formatting cells with a custom magic function which is preceded by any number of empty lines and lines with comments.

Additional notes:
- I moved `validate_cell` function from `__init__.py` to `handle_ipynb_magics.py` module because it belongs there. (It also makes my maintenance of [Pyink fork](https://github.com/google/pyink) a bit easier if there are less things in `__init__.py` module.) But if there is a reason to keep it in `__init__.py` I can move it back.
- Function `_get_code_start` could also be implemented like this:

  ```Python
  def _get_code_start(src: str) -> str:
      match = re.search(r"^[\s\n]*([^#\s\n].*)$", src, flags=re.M)
      return match.group(1) if match else ""
  ```
  It might be a bit more efficient but it is also less readable. Let me know if you would prefer this implementation. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] ~~Add new / update outdated documentation?~~

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
