### PR TITLE
Store license identifier inside the License-Expression metadata field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-# Unreleased
+## Unreleased
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# Unreleased
+
+### Packaging
+
+- Store license identifier inside the `License-Expression` metadata field, see
+  [PEP 639](https://peps.python.org/pep-0639/). (#4479)
+
 ## 24.10.0
 
 ### Highlights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "hatchling.build"
 [project]
 name = "black"
 description = "The uncompromising code formatter."
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.9"
 authors = [
   { name = "Łukasz Langa", email = "lukasz@langa.pl" },


### PR DESCRIPTION
### Description
The `hatch` documentation recommends to use just `license = "MIT"` instead of `license = { text = "MIT" }`.
https://hatch.pypa.io/1.9/config/metadata/#spdx-expression

With that `hatchling` will write a compatible `License-Expression` to the package metadata.
```
...
License-Expression: MIT
...
```