### PR TITLE
Combine f-strings which would be placed on the same line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Combine multiple f-strings into a single f-string when appropriate
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Combine multiple f-strings into a single f-string when appropriate
+- Combine multiple f-strings into a single f-string when appropriate (#4480)
 
 ### Preview style
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -517,9 +517,9 @@ class LineGenerator(Visitor[Line]):
                 break
         total_len = len("".join([c.value for c in node.leaves()]))
         if (
-                len(node.children) > 0
-                and is_all_fstring
-                and total_len < self.mode.line_length
+            len(node.children) > 0
+            and is_all_fstring
+            and total_len < self.mode.line_length
         ):
             new_node = Node(syms.fstring, [])
             # remove all FSTRING_START but first and all FSTRING_END but last
@@ -530,8 +530,7 @@ class LineGenerator(Visitor[Line]):
                 if (
                     not (gc.type == token.FSTRING_START and i != 0)
                     and not (
-                        gc.type == token.FSTRING_END
-                        and i != len(node.children) - 1
+                        gc.type == token.FSTRING_END and i != len(node.children) - 1
                     )
                 )
             ]

--- a/tests/data/cases/combine-fstring.py
+++ b/tests/data/cases/combine-fstring.py
@@ -1,0 +1,7 @@
+sep= " "
+FSTRING = f"many" f"{sep}" f"tiny" f"{sep}" f"fstrings"
+
+# output
+
+sep = " "
+FSTRING = f"many{sep}tiny{sep}fstrings"

--- a/tests/data/cases/combine-multi-line-fstring.py
+++ b/tests/data/cases/combine-multi-line-fstring.py
@@ -1,0 +1,13 @@
+sep= " "
+FSTRING = (
+    f"many"
+    f"{sep}"
+    f"tiny"
+    f"{sep}"
+    f"fstrings"
+)
+
+# output
+
+sep = " "
+FSTRING = f"many{sep}tiny{sep}fstrings"


### PR DESCRIPTION
### Description

Hey! First time contributing to the project so please let me know if I'm doing anything wrong here :)

I've implemented changes for the issue described here https://github.com/psf/black/issues/4389 

Esentially if we can combine multiple f-strings into a single f-string without breaking other considerations like the intended line length then I attempt to do so. This is done by breaking apart the AST of multiple f-strings into a single f-string node by only keeping the first `FSTRING_START` token and the last `FSTRING_END` token and keeping all tokens inbetween.

### Checklist - did you ...

I've added 2 new test cases showing that the examples in the issue are fixed by the change. All other tests are passing which indicates that the change does not affect other cases.

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (let me know if there's some place I should add this!)

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
