### PR TITLE
Fix formatting cells with magic methods and starting or trailing empty lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Fix formatting cells with magic methods and starting or trailing empty lines (#4484)
+- Fix formatting cells in IPython notebooks with magic methods and starting or trailing empty lines (#4484)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Fix formatting cells in IPython notebooks with magic methods and starting or trailing empty lines (#4484)
+- Fix formatting cells in IPython notebooks with magic methods and starting or trailing
+  empty lines (#4484)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix formatting cells with magic methods and starting or trailing empty lines (#4484)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -178,12 +178,14 @@ def mask_cell(src: str) -> tuple[str, list[Replacement]]:
     from IPython.core.inputtransformer2 import TransformerManager
 
     transformer_manager = TransformerManager()
+    # A side effect of the following transformation is that it also removes any
+    # empty lines at the beginning of the cell.
     transformed = transformer_manager.transform_cell(src)
     transformed, cell_magic_replacements = replace_cell_magics(transformed)
     replacements += cell_magic_replacements
     transformed = transformer_manager.transform_cell(transformed)
     transformed, magic_replacements = replace_magics(transformed)
-    if len(transformed.splitlines()) != len(src.splitlines()):
+    if len(transformed.strip().splitlines()) != len(src.strip().splitlines()):
         # Multi-line magic, not supported.
         raise NothingChanged
     replacements += magic_replacements
@@ -269,7 +271,7 @@ def replace_magics(src: str) -> tuple[str, list[Replacement]]:
     magic_finder = MagicFinder()
     magic_finder.visit(ast.parse(src))
     new_srcs = []
-    for i, line in enumerate(src.splitlines(), start=1):
+    for i, line in enumerate(src.split("\n"), start=1):
         if i in magic_finder.magics:
             offsets_and_magics = magic_finder.magics[i]
             if len(offsets_and_magics) != 1:  # pragma: nocover

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -174,6 +174,22 @@ def test_cell_magic_with_magic() -> None:
 
 
 @pytest.mark.parametrize(
+    "src, expected",
+    (
+        ("\n\n\n%time \n\n", "%time"),
+        ("  \n\t\n%%timeit -n4 \t \nx=2  \n\r\n", "%%timeit -n4\nx = 2"),
+        (
+            "  \t\n\n%%capture \nx=2 \n%config \n\n%env\n\t  \n \n\n",
+            "%%capture\nx = 2\n%config\n\n%env",
+        ),
+    ),
+)
+def test_cell_magic_with_empty_lines(src: str, expected: str) -> None:
+    result = format_cell(src, fast=True, mode=JUPYTER_MODE)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     "mode, expected_output, expectation",
     [
         pytest.param(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This PR fixes an issue where Jupyter cells containing any magic method and at least 1 empty line at the start or at the end of the cell don't get formatted at all. 

This is an example of a cell that doesn't get formatted:
```


%time
a=1


```

But if there are no magic methods then formatting works. The following cell:
```


#No magic methods
a=1


```
gets correctly reformatted into:
```
# No magic methods
a = 1
```

It turns out the problem is in `black.handle_ipynb_magics.mask_cell` function:
1. The call to `TransformerManager.transform_cell` returns a result without empty lines at the beginning of the cell. Because this part is implemented in `ipython` I didn't investigate why this is the case.
2. The call to `replace_magics` returns a result without empty lines at the end of the cell. This is because the implementation of `replace_magics` assumes that 
   ```Python
   "\n".join(src.splitlines())
    ```
   will always produce `src` again. This is not the case, e.g. `"\n".join("\n\n".splitlines())` returns `"\n"`.

3. Because of 1. and 2. the check `len(transformed.splitlines()) != len(src.splitlines())` is triggered and `NothingChanged` is raised.

#### Solution

1. A comment about `TransformerManager.transform_cell`  removing empty lines. Future improvements in `ipython` are possible.
2. Minor update in `replace_magics` so that it won't be removing empty lines at the end anymore.
3. The number of lines in `transformed` and `src` should be compared without starting and ending empty lines. Hence `len(transformed.strip().splitlines()) != len(src.strip().splitlines())`

I also added a few unit tests that test such cases.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] ~Add new / update outdated documentation?~

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
