### PR TITLE
Update deprecated type aliases

### DIFF
--- a/gallery/gallery.py
+++ b/gallery/gallery.py
@@ -7,10 +7,11 @@ import traceback
 import venv
 import zipfile
 from argparse import ArgumentParser, Namespace
+from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import Generator, NamedTuple, Optional, Union, cast
+from typing import NamedTuple, Optional, Union, cast
 from urllib.request import urlopen, urlretrieve
 
 PYPI_INSTANCE = "https://pypi.org/pypi"

--- a/scripts/make_width_table.py
+++ b/scripts/make_width_table.py
@@ -17,8 +17,8 @@ You can do this by running:
 """
 
 import sys
+from collections.abc import Iterable
 from os.path import basename, dirname, join
-from typing import Iterable
 
 import wcwidth  # type: ignore[import-not-found]
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -5,24 +5,22 @@ import re
 import sys
 import tokenize
 import traceback
+from collections.abc import (
+    Collection,
+    Generator,
+    Iterator,
+    MutableMapping,
+    Sequence,
+    Sized,
+)
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
 from enum import Enum
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import (
-    Any,
-    Collection,
-    Generator,
-    Iterator,
-    MutableMapping,
-    Optional,
-    Pattern,
-    Sequence,
-    Sized,
-    Union,
-)
+from re import Pattern
+from typing import Any, Optional, Union
 
 import click
 from click.core import ParameterSource

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -1,7 +1,8 @@
 """Builds on top of nodes.py to track brackets."""
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Final, Iterable, Optional, Sequence, Union
+from typing import Final, Optional, Union
 
 from black.nodes import (
     BRACKET,

--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -5,9 +5,10 @@ import os
 import pickle
 import sys
 import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, NamedTuple
+from typing import NamedTuple
 
 from platformdirs import user_cache_dir
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -1,7 +1,8 @@
 import re
+from collections.abc import Collection, Iterator
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Collection, Final, Iterator, Optional, Union
+from typing import Final, Optional, Union
 
 from black.mode import Mode, Preview
 from black.nodes import (

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -10,10 +10,11 @@ import os
 import signal
 import sys
 import traceback
+from collections.abc import Iterable
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from multiprocessing import Manager
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 from mypy_extensions import mypyc_attr
 

--- a/src/black/debug.py
+++ b/src/black/debug.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any, Iterator, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from black.nodes import Visitor
 from black.output import out

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -1,18 +1,11 @@
 import io
 import os
 import sys
+from collections.abc import Iterable, Iterator, Sequence
 from functools import lru_cache
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Iterator,
-    Optional,
-    Pattern,
-    Sequence,
-    Union,
-)
+from re import Pattern
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from mypy_extensions import mypyc_attr
 from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -4,10 +4,11 @@ Generating lines of code.
 
 import re
 import sys
+from collections.abc import Collection, Iterator
 from dataclasses import replace
 from enum import Enum, auto
 from functools import partial, wraps
-from typing import Collection, Iterator, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from black.brackets import (
     COMMA_PRIORITY,

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1,7 +1,8 @@
 import itertools
 import math
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import Callable, Iterator, Optional, Sequence, TypeVar, Union, cast
+from typing import Optional, TypeVar, Union, cast
 
 from black.brackets import COMMA_PRIORITY, DOT_PRIORITY, BracketTracker
 from black.mode import Mode, Preview

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -3,7 +3,8 @@ blib2to3 Node/Leaf transformation-related utility functions.
 """
 
 import sys
-from typing import Final, Generic, Iterator, Literal, Optional, TypeVar, Union
+from collections.abc import Iterator
+from typing import Final, Generic, Literal, Optional, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -5,7 +5,7 @@ Parse Python code and perform AST validation.
 import ast
 import sys
 import warnings
-from typing import Collection, Iterator
+from collections.abc import Collection, Iterator
 
 from black.mode import VERSION_TO_FEATURES, Feature, TargetVersion, supports_feature
 from black.nodes import syms

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -1,8 +1,9 @@
 """Functions related to Black's formatting by line ranges feature."""
 
 import difflib
+from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Collection, Iterator, Sequence, Union
+from typing import Union
 
 from black.nodes import (
     LN,

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -5,7 +5,8 @@ Simple formatting on strings. Further string formatting code is in trans.py.
 import re
 import sys
 from functools import lru_cache
-from typing import Final, Match, Pattern
+from re import Match, Pattern
+from typing import Final
 
 from black._width_table import WIDTH_TABLE
 from blib2to3.pytree import Leaf

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -5,21 +5,9 @@ String transformers that can split and merge strings.
 import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Collection,
-    Final,
-    Iterable,
-    Iterator,
-    Literal,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import Any, ClassVar, Final, Literal, Optional, TypeVar, Union
 
 from mypy_extensions import trait
 

--- a/src/blackd/middlewares.py
+++ b/src/blackd/middlewares.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 
 from aiohttp.typedefs import Middleware
 from aiohttp.web_middlewares import middleware

--- a/src/blib2to3/pgen2/driver.py
+++ b/src/blib2to3/pgen2/driver.py
@@ -21,10 +21,11 @@ import logging
 import os
 import pkgutil
 import sys
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import IO, Any, Iterable, Iterator, Optional, Union, cast
+from typing import IO, Any, Optional, Union, cast
 
 from blib2to3.pgen2.grammar import Grammar
 from blib2to3.pgen2.tokenize import GoodTokenInfo

--- a/src/blib2to3/pgen2/literals.py
+++ b/src/blib2to3/pgen2/literals.py
@@ -4,7 +4,6 @@
 """Safely evaluate Python string literals without using eval()."""
 
 import re
-from typing import Match
 
 simple_escapes: dict[str, str] = {
     "a": "\a",
@@ -20,7 +19,7 @@ simple_escapes: dict[str, str] = {
 }
 
 
-def escape(m: Match[str]) -> str:
+def escape(m: re.Match[str]) -> str:
     all, tail = m.group(0, 1)
     assert all.startswith("\\")
     esc = simple_escapes.get(tail)

--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -9,8 +9,9 @@ See Parser/parser.c in the Python distribution for additional info on
 how this parsing engine works.
 
 """
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from blib2to3.pgen2.grammar import Grammar
 from blib2to3.pytree import NL, Context, Leaf, Node, RawNode, convert

--- a/src/blib2to3/pgen2/pgen.py
+++ b/src/blib2to3/pgen2/pgen.py
@@ -2,7 +2,8 @@
 # Licensed to PSF under a Contributor Agreement.
 
 import os
-from typing import IO, Any, Iterator, NoReturn, Optional, Sequence, Union
+from collections.abc import Iterator, Sequence
+from typing import IO, Any, NoReturn, Optional, Union
 
 from blib2to3.pgen2 import grammar, token, tokenize
 from blib2to3.pgen2.tokenize import GoodTokenInfo

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -29,7 +29,9 @@ each time a new token is found."""
 
 import builtins
 import sys
-from typing import Callable, Final, Iterable, Iterator, Optional, Pattern, Union
+from collections.abc import Callable, Iterable, Iterator
+from re import Pattern
+from typing import Final, Optional, Union
 
 from blib2to3.pgen2.grammar import Grammar
 from blib2to3.pgen2.token import (

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -12,7 +12,8 @@ There's also a pattern matching implementation here.
 
 # mypy: allow-untyped-defs, allow-incomplete-defs
 
-from typing import Any, Iterable, Iterator, Optional, TypeVar, Union
+from collections.abc import Iterable, Iterator
+from typing import Any, Optional, TypeVar, Union
 
 from blib2to3.pgen2.grammar import Grammar
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -10,6 +10,7 @@ import re
 import sys
 import textwrap
 import types
+from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, redirect_stderr
 from dataclasses import fields, replace
@@ -17,7 +18,7 @@ from io import BytesIO
 from pathlib import Path, WindowsPath
 from platform import system
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Iterator, Optional, Sequence, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 from unittest.mock import MagicMock, patch
 
 import click

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,9 +5,10 @@ Test that the docs are up to date.
 """
 
 import re
+from collections.abc import Sequence
 from itertools import islice
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional
 
 import pytest
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterator
 from dataclasses import replace
-from typing import Any, Iterator
+from typing import Any
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -1,9 +1,9 @@
 import contextlib
 import pathlib
 import re
+from contextlib import AbstractContextManager
 from contextlib import ExitStack as does_not_raise
 from dataclasses import replace
-from typing import ContextManager
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -213,7 +213,7 @@ def test_cell_magic_with_empty_lines(src: str, expected: str) -> None:
     ],
 )
 def test_cell_magic_with_custom_python_magic(
-    mode: Mode, expected_output: str, expectation: ContextManager[object]
+    mode: Mode, expected_output: str, expectation: AbstractContextManager[object]
 ) -> None:
     with expectation:
         result = format_cell(

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,11 +4,12 @@ import os
 import shlex
 import sys
 import unittest
+from collections.abc import Collection, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from functools import partial
 from pathlib import Path
-from typing import Any, Collection, Iterator, Optional
+from typing import Any, Optional
 
 import black
 from black.const import DEFAULT_LINE_LENGTH


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Updating the remaining deprecated type aliases according to https://docs.python.org/3/library/typing.html#deprecated-aliases

Aliases are being replaced with types from modules `collections.abc`, `contextlib`, and `re`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] ~Add an entry in `CHANGES.md` if necessary?~
- [x] Add / update tests if necessary?
- [ ] ~Add new / update outdated documentation?~

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
