### PR TITLE
Add 2248 tests

### DIFF
--- a/tests/data/cases/anti_regression_2248.py
+++ b/tests/data/cases/anti_regression_2248.py
@@ -1,0 +1,19 @@
+aaa = my_function(
+    foo="test, this is a sample value",
+    bar=some_long_value_name_foo_bar_baz
+    if some_boolean_variable
+    else some_fallback_value_foo_bar_baz,
+    baz="hello, this is a another value",
+)
+
+# output
+
+aaa = my_function(
+    foo="test, this is a sample value",
+    bar=(
+        some_long_value_name_foo_bar_baz
+        if some_boolean_variable
+        else some_fallback_value_foo_bar_baz
+    ),
+    baz="hello, this is a another value",
+)


### PR DESCRIPTION
It looks like #2248 was fixed at some point, probably as part of the 2024 release. This adds an anti-regression test for, and closes #2248.