### PR TITLE
Add `*.py diff=python` to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .git_archival.txt  export-subst
+*.py text diff=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 .git_archival.txt  export-subst
-*.py text diff=python
+*.py text=auto diff=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 .git_archival.txt  export-subst
-*.py text=auto diff=python
+*.py diff=python


### PR DESCRIPTION
This adds the line `*.py text diff=python` to `.gitattributes`. I'm not 100% certain on all the effects this has, but it makes function name based finding git commands options like `git log -L :<function_name>:<file_path>` or `git blame -L :<function_name> <file_path>` work out of the box, which is a nice convenience.