### PR TITLE
Fix 3678 "problem parsing `with` statements"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 - Fix formatting cells in IPython notebooks with magic methods and starting or trailing
   empty lines (#4484)
 
+- Fix crash when formatting `with` statements containing tuple genetators/unpacking
+  (#4538)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 - Fix formatting cells in IPython notebooks with magic methods and starting or trailing
   empty lines (#4484)
 
-- Fix crash when formatting `with` statements containing tuple genetators/unpacking
+- Fix crash when formatting `with` statements containing tuple generators/unpacking
   (#4538)
 
 ### Preview style

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -45,6 +45,7 @@ from black.nodes import (
     is_atom_with_invisible_parens,
     is_docstring,
     is_empty_tuple,
+    is_generator,
     is_lpar_token,
     is_multiline_string,
     is_name_token,
@@ -55,6 +56,7 @@ from black.nodes import (
     is_rpar_token,
     is_stub_body,
     is_stub_suite,
+    is_tuple_containing_star,
     is_tuple_containing_walrus,
     is_type_ignore_comment_string,
     is_vararg,
@@ -1628,6 +1630,8 @@ def maybe_make_parens_invisible_in_atom(
             and max_delimiter_priority_in_atom(node) >= COMMA_PRIORITY
         )
         or is_tuple_containing_walrus(node)
+        or is_tuple_containing_star(node)
+        or is_generator(node)
     ):
         return False
 

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -621,6 +621,26 @@ def is_tuple_containing_walrus(node: LN) -> bool:
     return any(child.type == syms.namedexpr_test for child in gexp.children)
 
 
+def is_tuple_containing_star(node: LN) -> bool:
+    """Return True if `node` holds a tuple that contains a star operator."""
+    if node.type != syms.atom:
+        return False
+    gexp = unwrap_singleton_parenthesis(node)
+    if gexp is None or gexp.type != syms.testlist_gexp:
+        return False
+    return any(child.type == syms.star_expr for child in gexp.children)
+
+
+def is_generator(node: LN) -> bool:
+    """Return True if `node` holds a generator."""
+    if node.type != syms.atom:
+        return False
+    gexp = unwrap_singleton_parenthesis(node)
+    if gexp is None or gexp.type != syms.testlist_gexp:
+        return False
+    return any(child.type == syms.old_comp_for for child in gexp.children)
+
+
 def is_one_sequence_between(
     opening: Leaf,
     closing: Leaf,

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -628,6 +628,7 @@ def is_tuple_containing_star(node: LN) -> bool:
     gexp = unwrap_singleton_parenthesis(node)
     if gexp is None or gexp.type != syms.testlist_gexp:
         return False
+
     return any(child.type == syms.star_expr for child in gexp.children)
 
 
@@ -638,6 +639,7 @@ def is_generator(node: LN) -> bool:
     gexp = unwrap_singleton_parenthesis(node)
     if gexp is None or gexp.type != syms.testlist_gexp:
         return False
+
     return any(child.type == syms.old_comp_for for child in gexp.children)
 
 

--- a/tests/data/cases/remove_with_brackets.py
+++ b/tests/data/cases/remove_with_brackets.py
@@ -53,6 +53,19 @@ with ((((open("bla.txt")))) as f):
 with ((((CtxManager1()))) as example1, (((CtxManager2()))) as example2):
     ...
 
+# regression tests for #3678
+with (a, *b):
+    pass
+
+with (a, (b, *c)):
+    pass
+
+with (a for b in c):
+    pass
+
+with (a, (b for c in d)):
+    pass
+
 # output
 with open("bla.txt"):
     pass
@@ -117,3 +130,16 @@ with open("bla.txt") as f:
 
 with CtxManager1() as example1, CtxManager2() as example2:
     ...
+
+# regression tests for #3678
+with (a, *b):
+    pass
+
+with a, (b, *c):
+    pass
+
+with (a for b in c):
+    pass
+
+with a, (b for c in d):
+    pass


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This fixes #3678. The fix is done by adding two new functions to `node.py`, `is_tuple_containing_star` and `is_generator`, which are then added to the checks in `maybe_make_parens_invisible_in_atom` inside `linegen.py`, which is used by the function `remove_with_parens` that Jelle suggested modifying in a comment on #3678

Both functions are based on the existing `is_tuple_containing_walrus`. That makes me fairly confident in `is_tuple_containing_star`, since it does the same thing as `is_tuple_containing_walrus`, just with `syms.namedexpr_test` swapped for `syms.star_expr`. I'm less confident in `is_generator` since `for a in b` being called `syms.old_comp_for` seems weird and I don't totally understand `syms`/`_python_symbols`, but it seems to work.

Side note, `_python_symbols` is really hard to work with since `node.type` prints as an integer and the `_python_symbol` variable <--> integer relationship is done via `setattr`, so I ended up having to do `[print(x, eval(f"syms.{x}") for x in dir(syms) if x[0:2] != "__"]` to figure out what type generators get.

As usual, both names subject to bikeshedding. I chose `is_tuple_containing_star` because it compares with `syms.star_expr`, but  `is_tuple_containing_unpacking` could also work. I chose `is_generator` since the issue is with a generator, though that could be something else since it doesn't match the `syms.old_comp_for` comparison.

The tests contain both a top level case and one where the issue is nested, since the nested case caused issues for me while making the fix.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
