### PR TITLE
Fix 4232

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,9 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 
+- If using stdin with `--stdin-filename` set to a force excluded path, stdin won't be
+  formatted. (#4539)
+
 ### Documentation
 
 <!-- Major changes to documentation and policies. Small docs changes

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -748,13 +748,13 @@ def get_sources(
 
     for s in src:
         if s == "-" and stdin_filename:
+            path = Path(stdin_filename)
             if path_is_excluded(stdin_filename, force_exclude):
                 report.path_ignored(
-                    stdin_filename,
+                    path,
                     "--stdin-filename matches the --force-exclude regular expression",
                 )
                 continue
-            path = Path(stdin_filename)
             is_stdin = True
         else:
             path = Path(s)

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -749,6 +749,10 @@ def get_sources(
     for s in src:
         if s == "-" and stdin_filename:
             if path_is_excluded(stdin_filename, force_exclude):
+                report.path_ignored(
+                    stdin_filename,
+                    "--stdin-filename matches the --force-exclude regular expression",
+                )
                 continue
             path = Path(stdin_filename)
             is_stdin = True

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -748,6 +748,8 @@ def get_sources(
 
     for s in src:
         if s == "-" and stdin_filename:
+            if path_is_excluded(stdin_filename, force_exclude):
+                continue
             path = Path(stdin_filename)
             is_stdin = True
         else:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This fixes #4232. This issue happening is different from what was stated. At least with the given bash script, black does correctly find and apply the settings from the `pyproject.toml`, the force exclude just doesn't get applied. This happens because the check for if formatting should be skipped when using stdin is constructed via
```py
            root_relative_path = best_effort_relative_path(path, root).as_posix()
            root_relative_path = "/" + root_relative_path
```
And in the case of the given bash script, `root_relative_path` ends up as `/testfile.py`, which obviously doesn't include `submodule`, so it passes the exclude.

If I understand the intended use case correctly, this is for use with an editor, which is why I put the changelog entry into the integrations section. This should make the behavior of black always match what the docs say,
> Tip: if you need Black to treat stdin input as a file passed directly via the CLI, use --stdin-filename. Useful to make sure Black will respect the --force-exclude option on some editors that rely on using stdin.

It also just makes sense to me, even if it's a bit redundant. If you give an input to `--stdin-filename` that matches the force exclude regex, it should get excluded. If there is something I'm missing with this please let me know.

There might be a better way to do this that doesn't end up in two different calls to `path_is_excluded`, but it's a relatively cheap function so it should be fine.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [N/A (I don't know how you would test this)] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
