### PR TITLE
Normalize type comment formatting and handle extra spaces

### DIFF
--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -932,9 +932,14 @@ def is_type_comment(leaf: Leaf) -> bool:
     be used for general type comments (excluding ignore annotations, which should
     use `is_type_ignore_comment`). Note that general type comments are no longer
     used in modern version of Python, this function may be deprecated in the future."""
-    t = leaf.type
-    v = leaf.value
-    return t in {token.COMMENT, STANDALONE_COMMENT} and v.startswith("# type:")
+    if leaf.type not in {token.COMMENT, STANDALONE_COMMENT}:
+        return False
+    comment_text = leaf.value.lstrip("#").lstrip()
+    if not comment_text.startswith("type:"):
+        return False
+    type_annotation = comment_text[5:].strip()
+    leaf.value = f"# type: {type_annotation}" if type_annotation else "# type:"
+    return True
 
 
 def is_type_ignore_comment(leaf: Leaf) -> bool:


### PR DESCRIPTION
Description: This PR addresses an issue with the handling of type comments in Black. Previously, type comments with multiple spaces after # were not recognized correctly, and formatting could lead to unnecessary whitespace.

Changes:
Fixed the handling of type comments by normalizing whitespace after # and : (e.g., converting # type: str to # type: str).
The function now trims extra spaces and ensures consistent formatting for type comments.
Added a check for comments starting with type: and cleaned up the comment text accordingly.
Updated the function to format the comment as # type: if no type annotation is present.
Why:
This change improves the detection and formatting of type comments, especially in cases where users accidentally add extra spaces.
It ensures a standardized format for type comments across the codebase, reducing the likelihood of errors in formatting.
Related Issue:
If this PR addresses a specific issue, reference it here by including the issue number (e.g., Fixes #2097 ).
