### PR TITLE
Fix bug where # fmt: skip is not being respected with one-liner functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Fix a bug where one-liner functions/conditionals marked with `# fmt: skip`
+  would still be formatted (#4552)
+
 ### Configuration
 
 <!-- Changes to how Black can be configured -->

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -26,6 +26,9 @@ Currently, the following features are included in the preview style:
   statements, except when the line after the import is a comment or an import statement
 - `wrap_long_dict_values_in_parens`: Add parentheses around long values in dictionaries
   ([see below](labels/wrap-long-dict-values))
+- `fix_fmt_skip_in_one_liners`: Fix `# fmt: skip` behaviour on one-liner declarations,
+  such as `def foo(): return "mock"  # fmt: skip`, where previously the declaration
+  would have been incorrectly collapsed.
 
 (labels/unstable-features)=
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -270,7 +270,7 @@ def generate_ignored_nodes(
     Stops at the end of the block.
     """
     if _contains_fmt_skip_comment(comment.value, mode):
-        yield from _generate_ignored_nodes_from_fmt_skip(leaf, comment)
+        yield from _generate_ignored_nodes_from_fmt_skip(leaf, comment, mode)
         return
     container: Optional[LN] = container_of(leaf)
     while container is not None and container.type != token.ENDMARKER:
@@ -309,11 +309,12 @@ def generate_ignored_nodes(
 
 
 def _generate_ignored_nodes_from_fmt_skip(
-    leaf: Leaf, comment: ProtoComment
+    leaf: Leaf, comment: ProtoComment, mode: Mode
 ) -> Iterator[LN]:
     """Generate all leaves that should be ignored by the `# fmt: skip` from `leaf`."""
     prev_sibling = leaf.prev_sibling
     parent = leaf.parent
+    ignored_nodes: list[LN] = []
     # Need to properly format the leaf prefix to compare it to comment.value,
     # which is also formatted
     comments = list_comments(leaf.prefix, is_endmarker=False)
@@ -321,11 +322,54 @@ def _generate_ignored_nodes_from_fmt_skip(
         return
     if prev_sibling is not None:
         leaf.prefix = ""
-        siblings = [prev_sibling]
-        while "\n" not in prev_sibling.prefix and prev_sibling.prev_sibling is not None:
-            prev_sibling = prev_sibling.prev_sibling
-            siblings.insert(0, prev_sibling)
-        yield from siblings
+
+        if Preview.fix_fmt_skip_in_one_liners not in mode:
+            siblings = [prev_sibling]
+            while (
+                "\n" not in prev_sibling.prefix
+                and prev_sibling.prev_sibling is not None
+            ):
+                prev_sibling = prev_sibling.prev_sibling
+                siblings.insert(0, prev_sibling)
+            yield from siblings
+            return
+
+        # Generates the nodes to be ignored by `fmt: skip`.
+
+        # Nodes to ignore are the ones on the same line as the
+        # `# fmt: skip` comment, excluding the `# fmt: skip`
+        # node itself.
+
+        # Traversal process (starting at the `# fmt: skip` node):
+        # 1. Move to the `prev_sibling` of the current node.
+        # 2. If `prev_sibling` has children, go to its rightmost leaf.
+        # 3. If there’s no `prev_sibling`, move up to the parent
+        # node and repeat.
+        # 4. Continue until:
+        #    a. You encounter an `INDENT` or `NEWLINE` node (indicates
+        #       start of the line).
+        #    b. You reach the root node.
+
+        # Include all visited LEAVES in the ignored list, except INDENT
+        # or NEWLINE leaves.
+
+        current_node = prev_sibling
+        ignored_nodes = [current_node]
+        if current_node.prev_sibling is None and current_node.parent is not None:
+            current_node = current_node.parent
+        while "\n" not in current_node.prefix and current_node.prev_sibling is not None:
+            leaf_nodes = list(current_node.prev_sibling.leaves())
+            current_node = leaf_nodes[-1] if leaf_nodes else current_node
+
+            if current_node.type in (token.NEWLINE, token.INDENT):
+                current_node.prefix = ""
+                break
+
+            ignored_nodes.insert(0, current_node)
+
+            if current_node.prev_sibling is None and current_node.parent is not None:
+                current_node = current_node.parent
+        yield from ignored_nodes
     elif (
         parent is not None and parent.type == syms.suite and leaf.type == token.NEWLINE
     ):
@@ -333,7 +377,6 @@ def _generate_ignored_nodes_from_fmt_skip(
         # statements. The ignored nodes should be previous siblings of the
         # parent suite node.
         leaf.prefix = ""
-        ignored_nodes: list[LN] = []
         parent_sibling = parent.prev_sibling
         while parent_sibling is not None and parent_sibling.type != syms.suite:
             ignored_nodes.insert(0, parent_sibling)

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Final, Optional, Union
 
-from black.mode import Mode
+from black.mode import Mode, Preview
 from black.nodes import (
     CLOSING_BRACKETS,
     STANDALONE_COMMENT,

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -203,6 +203,7 @@ class Preview(Enum):
     wrap_long_dict_values_in_parens = auto()
     multiline_string_handling = auto()
     always_one_newline_after_import = auto()
+    fix_fmt_skip_in_one_liners = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -83,7 +83,8 @@
           "hug_parens_with_braces_and_square_brackets",
           "wrap_long_dict_values_in_parens",
           "multiline_string_handling",
-          "always_one_newline_after_import"
+          "always_one_newline_after_import",
+          "fix_fmt_skip_in_one_liners"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/fmtskip10.py
+++ b/tests/data/cases/fmtskip10.py
@@ -1,0 +1,9 @@
+# flags: --preview
+def foo(): return "mock"  # fmt: skip
+if True: print("yay")  # fmt: skip
+for i in range(10): print(i)  # fmt: skip
+
+j =     1 # fmt: skip
+while j < 10: j += 1  # fmt: skip
+
+b = [c for c in "A very long string that would normally generate some kind of collapse, since it is this long"] # fmt: skip


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Fixes https://github.com/psf/black/issues/3682
Fixes https://github.com/psf/black/issues/4535

The fix involves modifying the algorithm that determines which nodes to ignore in the `_generate_ignored_nodes_from_fmt_skip` function. Specifically, the adjustment applies to cases where the `# fmt: skip` comment is **not** immediately after the colon in an `if`, `while`, `def`, `class`, etc.

#### Previous Algorithm
The previous algorithm for selecting ignored nodes worked as follows:
1. Add the *previous sibling* of the current node to the list of ignored nodes.
2. Set the current node to its previous sibling.
3. Stop if the current node has no previous sibling or its previous sibling contains a `\n` in its prefix.

This approach worked well when the node with the comment existed at a tree level that covered the entire line. However, it failed in cases where this assumption was invalid. For example, consider the tree produced for the code in #4535:

```
Node(funcdef)
├── Leaf(NAME, 'def')   ─┐
├── Leaf(NAME, 'foo')    │
├── Node(parameters)     │
 │   ├── Leaf(LPAR, '(') │
 │   └── Leaf(RPAR, ')') ┣── This level is never reachable, so they won't be ignored by # fmt: skip.
├── Leaf(COLON, ':')     │
└── Node(simple_stmt)   ─┘
    ├── Leaf(STANDALONE_COMMENT, 'return "mock"  # fmt: skip') <-- The algorithm begins here.
    └── Leaf(NEWLINE, '\n')
Leaf(ENDMARKER, '')
```

As shown, only the content of the `return "mock"  # fmt: skip` would be ignored.  
This can be tested with the following input (note the single quotes):
```python
def foo(): return 'mock' # fmt: skip
```
The resulting output would be:
```python
def foo():
    return 'mock' # fmt: skip
```

Here, the single quotes are protected by the skip statement.

### New Algorithm

The new algorithm traverses the tree differently, ensuring it can visit all leaves in the order they appear in the source code (but in reverse). For the example tree:

1. The traversal moves from the comment to the colon (`:`), then to the `RPAR`, `LPAR`, and so on.
2. It stops when encountering a `NEWLINE` or `INDENT` node.
3. All visited leaves are ignored by `# fmt: skip`, expect the `NEWLINE` or `INDENT` node.

This approach ensures all relevant nodes are included in the ignored list.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
