### PR TITLE
Move `wrap_long_dict_values_in_parens` to the preview style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ The following changes were not in any previous release:
 - Collapse multiple empty lines after an import into one (#4489)
 - Prevent `string_processing` and `wrap_long_dict_values_in_parens` from removing
   parentheses around long dictionary values (#4377)
+- Move `wrap_long_dict_values_in_parens` from the unstable to preview style (#4561)
 
 ### Configuration
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -23,6 +23,7 @@ Currently, the following features are included in the preview style:
 - `always_one_newline_after_import`: Always force one blank line after import
   statements, except when the line after the import is a comment or an import statement
 - `wrap_long_dict_values_in_parens`: Add parentheses around long values in dictionaries
+  ([see below](labels/wrap-long-dict-values))
 
 (labels/unstable-features)=
 
@@ -34,6 +35,33 @@ The unstable style additionally includes the following features:
   multiline strings ([see below](labels/multiline-string-handling))
 - `hug_parens_with_braces_and_square_brackets`: more compact formatting of nested
   brackets ([see below](labels/hug-parens))
+
+(labels/wrap-long-dict-values)=
+
+### Improved parentheses management in dicts
+
+For dict literals with long values, they are now wrapped in parentheses. Unnecessary
+parentheses are now removed. For example:
+
+```python
+my_dict = {
+    "a key in my dict": a_very_long_variable
+    * and_a_very_long_function_call()
+    / 100000.0,
+    "another key": (short_value),
+}
+```
+
+will be changed to:
+
+```python
+my_dict = {
+    "a key in my dict": (
+        a_very_long_variable * and_a_very_long_function_call() / 100000.0
+    ),
+    "another key": short_value,
+}
+```
 
 (labels/hug-parens)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -22,6 +22,7 @@ Currently, the following features are included in the preview style:
 
 - `always_one_newline_after_import`: Always force one blank line after import
   statements, except when the line after the import is a comment or an import statement
+- `wrap_long_dict_values_in_parens`: Add parentheses around long values in dictionaries
 
 (labels/unstable-features)=
 
@@ -29,8 +30,6 @@ The unstable style additionally includes the following features:
 
 - `string_processing`: split long string literals and related changes
   ([see below](labels/string-processing))
-- `wrap_long_dict_values_in_parens`: add parentheses to long values in dictionaries
-  ([see below](labels/wrap-long-dict-values))
 - `multiline_string_handling`: more compact formatting of expressions involving
   multiline strings ([see below](labels/multiline-string-handling))
 - `hug_parens_with_braces_and_square_brackets`: more compact formatting of nested
@@ -121,33 +120,6 @@ change their quotation mark style. User-made splits are respected when they do n
 exceed the line length limit. Line continuation backslashes are converted into
 parenthesized strings. Unnecessary parentheses are stripped. The stability and status of
 this feature istracked in [this issue](https://github.com/psf/black/issues/2188).
-
-(labels/wrap-long-dict-values)=
-
-### Improved parentheses management in dicts
-
-For dict literals with long values, they are now wrapped in parentheses. Unnecessary
-parentheses are now removed. For example:
-
-```python
-my_dict = {
-    "a key in my dict": a_very_long_variable
-    * and_a_very_long_function_call()
-    / 100000.0,
-    "another key": (short_value),
-}
-```
-
-will be changed to:
-
-```python
-my_dict = {
-    "a key in my dict": (
-        a_very_long_variable * and_a_very_long_function_call() / 100000.0
-    ),
-    "another key": short_value,
-}
-```
 
 (labels/multiline-string-handling)=
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -208,8 +208,6 @@ class Preview(Enum):
 UNSTABLE_FEATURES: set[Preview] = {
     # Many issues, see summary in https://github.com/psf/black/issues/4042
     Preview.string_processing,
-    # See issues #3452 and #4158
-    Preview.wrap_long_dict_values_in_parens,
     # See issue #4159
     Preview.multiline_string_handling,
     # See issue #4036 (crash), #4098, #4099 (proposed tweaks)

--- a/tests/data/cases/preview_long_dict_values.py
+++ b/tests/data/cases/preview_long_dict_values.py
@@ -287,15 +287,17 @@ my_dict = {
 
 class Random:
     def func():
-        random_service.status.active_states.inactive = make_new_top_level_state_from_dict({
-            "topLevelBase": {
-                "secondaryBase": {
-                    "timestamp": 1234,
-                    "latitude": 1,
-                    "longitude": 2,
-                    "actionTimestamp": (
-                        Timestamp(seconds=1530584000, nanos=0).ToJsonString()
-                    ),
-                }
-            },
-        })
+        random_service.status.active_states.inactive = make_new_top_level_state_from_dict(
+            {
+                "topLevelBase": {
+                    "secondaryBase": {
+                        "timestamp": 1234,
+                        "latitude": 1,
+                        "longitude": 2,
+                        "actionTimestamp": (
+                            Timestamp(seconds=1530584000, nanos=0).ToJsonString()
+                        ),
+                    }
+                },
+            }
+        )

--- a/tests/data/cases/preview_long_dict_values.py
+++ b/tests/data/cases/preview_long_dict_values.py
@@ -1,4 +1,4 @@
-# flags: --unstable
+# flags: --preview
 x = {
     "xx_xxxxx_xxxxxxxxxx_xxxxxxxxx_xx": (
         "xx:xxxxxxxxxxxxxxxxx_xxxxx_xxxxxxx_xxxxxxxxxxx{xx}xxx_xxxxx_xxxxxxxxx_xxxxxxxxxxxx_xxxx"

--- a/tests/data/cases/walrus_in_dict.py
+++ b/tests/data/cases/walrus_in_dict.py
@@ -1,9 +1,9 @@
-# flags: --unstable
-# This is testing an issue that is specific to the unstable style (wrap_long_dict_values_in_parens)
+# flags: --preview
+# This is testing an issue that is specific to the preview style (wrap_long_dict_values_in_parens)
 {
     "is_update": (up := commit.hash in update_hashes)
 }
 
 # output
-# This is testing an issue that is specific to the unstable style (wrap_long_dict_values_in_parens)
+# This is testing an issue that is specific to the preview style (wrap_long_dict_values_in_parens)
 {"is_update": (up := commit.hash in update_hashes)}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

Moves `wrap_long_dict_values_in_parens` from the unstable to the preview style. Follows-up #4377, which closed both open issues about this feature (#3452 and #4158).

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [y] Add an entry in `CHANGES.md` if necessary?
- [y] Add / update tests if necessary?
- [y] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
