### PR TITLE
Fix mis-synced version check in black.vim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 
 ### Packaging
 
-<!-- Changes to how Black is packaged, such as dependency requirements -->
+- Fix the version check in the vim file to reject Python 3.8 (#4567)
 
 ### Parser
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -75,7 +75,7 @@ def _initialize_black_env(upgrade=False):
       return True
 
   pyver = sys.version_info[:3]
-  if pyver < (3, 8):
+  if pyver < (3, 9):
     print("Sorry, Black requires Python 3.9+ to run.")
     return False
 


### PR DESCRIPTION
### Description

The message has been updated to indicate Python 3.9+, but the check still compared to 3.8.

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?