### PR TITLE
Fixed is_type_comment() to handle extra spaces in type comments (#2097)

### DIFF
--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -1,7 +1,7 @@
 """
 blib2to3 Node/Leaf transformation-related utility functions.
 """
-
+import re
 import sys
 from collections.abc import Iterator
 from typing import Final, Generic, Literal, Optional, TypeVar, Union
@@ -926,7 +926,12 @@ def is_type_comment(leaf: Leaf) -> bool:
     use `is_type_ignore_comment`). Note that general type comments are no longer
     used in modern version of Python, this function may be deprecated in the future."""
     t = leaf.type
-    v = leaf.value
+    v = leaf.value.strip()
+
+    # Normalize spaces
+    v = re.sub(r"^#\s*", "# ", v)  # Ensure one space after #
+    v = re.sub(r"\s*:\s*", ": ", v)  # Ensure one space after :
+
     return t in {token.COMMENT, STANDALONE_COMMENT} and v.startswith("# type:")
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This PR fixes the is_type_comment() function to correctly handle type comments with excessive whitespace. It normalizes spacing after # and :, ensuring that type comments are properly detected, even if they have extra spaces. This improves comment detection and prevents issues with misformatted type annotations.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
