### PR TITLE
mix_stderr parameter was removed from click 8.2.0

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -116,7 +116,7 @@ class BlackRunner(CliRunner):
     """Make sure STDOUT and STDERR are kept separate when testing Black via its CLI."""
 
     def __init__(self) -> None:
-        if Version(imp_version('click')) >= Version('8.2.0'):
+        if Version(imp_version("click")) >= Version("8.2.0"):
             super().__init__()
         else:
             super().__init__(mix_stderr=False)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -26,8 +26,8 @@ import click
 import pytest
 from click import unstyle
 from click.testing import CliRunner
-from pathspec import PathSpec
 from packaging.version import Version
+from pathspec import PathSpec
 
 import black
 import black.files

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, redirect_stderr
 from dataclasses import fields, replace
+from importlib.metadata import version as imp_version
 from io import BytesIO
 from pathlib import Path, WindowsPath
 from platform import system
@@ -26,6 +27,7 @@ import pytest
 from click import unstyle
 from click.testing import CliRunner
 from pathspec import PathSpec
+from packaging.version import Version
 
 import black
 import black.files
@@ -114,7 +116,10 @@ class BlackRunner(CliRunner):
     """Make sure STDOUT and STDERR are kept separate when testing Black via its CLI."""
 
     def __init__(self) -> None:
-        super().__init__()
+        if Version(imp_version('click')) >= Version('8.2.0'):
+            super().__init__()
+        else:
+            super().__init__(mix_stderr=False)
 
 
 def invokeBlack(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -114,7 +114,7 @@ class BlackRunner(CliRunner):
     """Make sure STDOUT and STDERR are kept separate when testing Black via its CLI."""
 
     def __init__(self) -> None:
-        super().__init__(mix_stderr=False)
+        super().__init__()
 
 
 def invokeBlack(


### PR DESCRIPTION
From click 8.2.0 changelog:

```
Keep stdout and stderr streams independent in CliRunner. Always collect stderr output and never raise an exception. Add a new output stream to simulate what the user sees in its terminal. Removes the mix_stderr parameter in CliRunner. [:issue:`2522`](https://github.com/pallets/click/blob/main/CHANGES.rst#id27) [:pr:`2523`](https://github.com/pallets/click/blob/main/CHANGES.rst#id29)
```

so `mix_stderr=False` throws an error and is redundant.