### PR TITLE
Add regression tests for Black’s previous inconsistent quote formatting with adjacent string literals

### DIFF
--- a/tests/data/cases/fstring_quotations.py
+++ b/tests/data/cases/fstring_quotations.py
@@ -1,0 +1,67 @@
+# Regression tests for long f-strings, including examples from issue #3623
+
+a = (
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+)
+
+a = (
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+)
+
+a = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' + \
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+
+a = f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"' + \
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+
+a = (
+    f'bbbbbbb"{"b"}"'
+    'aaaaaaaa'
+)
+
+a = (
+    f'"{"b"}"'
+)
+
+a = (
+    f'\"{"b"}\"'
+)
+
+a = (
+    r'\"{"b"}\"'
+)
+
+# output
+
+# Regression tests for long f-strings, including examples from issue #3623
+
+a = (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+)
+
+a = (
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
+a = (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    + f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+)
+
+a = (
+    f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+    + f'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"{"b"}"'
+)
+
+a = f'bbbbbbb"{"b"}"' "aaaaaaaa"
+
+a = f'"{"b"}"'
+
+a = f'"{"b"}"'
+
+a = r'\"{"b"}\"'
+


### PR DESCRIPTION

### Description

Issue #3623 appears to be resolved, added regression tests to monitor this formatting issue and track any potential recurrence.

Regression tests were created based on Black's current stable version (25.1.0) formatting results, see [Black Playground](https://black.vercel.app/?version=stable&state=_Td6WFoAAATm1rRGAgAhARYAAAB0L-Wj4AQTANldAD2IimZxl1N_Wg0-A00Q7AStP7a3q0sqVQPWdY1xadXvajUNDqf4hsar9JsSEjvUIkO86voFmeTFwICDsImuEkAIHQ_jOFRyFZO2d_RDtELcNHSgMoIla6f1d7fosYp-0UUDHqBXTpp1hVxi74o0pjOifuHgmWTwusEhJaEv19iN9iMWzkHjOFLoqfSynpXUxVGxFI6jspSuoVAF7GaXKOCybElU0nil3Z8go4mzSS8Klg3Z6TxM4PMG7Ngm-z7eK1aCIJ08HLj6LYPz8_dG0-DxnXm-CNOyUMUAAAAAMtA_vhhXXSkAAfUBlAgAAIxSW4exxGf7AgAAAAAEWVo=).

### Checklist - did you ...

- [ ] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

