### PR TITLE
📦 Tell git archive to include numbered tags

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,3 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+describe-name: $Format:%(describe:tags=true,match=[0-9]*)$


### PR DESCRIPTION
The wildcard at the beginning used to match tags with arbitrary prefixes otherwise. This patch corrects that, making it more accurate.

It's a follow-up to #4592. The docs provide a very generic example of the `.git_archival.txt` template file, suggesting that it's tailored per project needs later [[1]]:
> Feel free to alter the `match` field in `describe-name` to match your project's tagging style.

[1]: https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives