### PR TITLE
Write unchanged content to stdout when excluding formating from stdin

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -683,13 +683,12 @@ def main(  # noqa: C901
         except GitWildMatchPatternError:
             ctx.exit(1)
 
-        path_empty(
-            sources,
-            "No Python files are present to be formatted. Nothing to do 😴",
-            quiet,
-            verbose,
-            ctx,
-        )
+        if not sources:
+            if verbose or not quiet:
+                out("No Python files are present to be formatted. Nothing to do 😴")
+            if "-" in src:
+                sys.stdout.write(sys.stdin.read())
+            ctx.exit(0)
 
         if len(sources) == 1:
             reformat_one(
@@ -820,18 +819,6 @@ def get_sources(
             err(f"invalid path: {s}")
 
     return sources
-
-
-def path_empty(
-    src: Sized, msg: str, quiet: bool, verbose: bool, ctx: click.Context
-) -> None:
-    """
-    Exit if there is no `src` provided for formatting
-    """
-    if not src:
-        if verbose or not quiet:
-            out(msg)
-        ctx.exit(0)
 
 
 def reformat_code(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This change tries to fix https://github.com/psf/black/issues/4609, so you can use black piping stdin and expect the new content in the output, formatted or not. This is the way other formatters such as ruff or clang-format works too.

I'm not really sure if this is the best place to output the content, feel free to modify or make any suggestion.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
