### PR TITLE
Fix backslash carriage return comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Fix crash when a tuple appears in the `as` clause of a `with` statement
   (#4634)
 - Fix crash when tuple is used as a context manager inside a `with` statement (#4646)
+- Fix crash when formatting a `\` followed by a `\r` followed by a comment (#4663)
 
 ### Preview style
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -88,7 +88,7 @@ def list_comments(prefix: str, *, is_endmarker: bool) -> list[ProtoComment]:
     nlines = 0
     ignored_lines = 0
     form_feed = False
-    for index, full_line in enumerate(re.split("\r?\n", prefix)):
+    for index, full_line in enumerate(re.split("\r?\n|\r", prefix)):
         consumed += len(full_line) + 1  # adding the length of the split '\n'
         match = re.match(r"^(\s*)(\S.*|)$", full_line)
         assert match

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2064,6 +2064,20 @@ class BlackTestCase(BlackBaseTestCase):
         assert lines_with_leading_tabs_expanded("\t\tx") == [f"{tab}{tab}x"]
         assert lines_with_leading_tabs_expanded("\tx\n  y") == [f"{tab}x", "  y"]
 
+    def test_carrige_return_edge_cases(self) -> None:
+        # These tests are here instead of in the normal cases because
+        # of git's newline normalization and because it's hard to
+        # get `\r` vs `\r\n` vs `\n` to display properly
+        assert (
+            black.format_str(
+                "try:\\\r# type: ignore\n pass\nfinally:\n pass\n",
+                mode=black.FileMode(),
+            )
+            == "try:  # type: ignore\n    pass\nfinally:\n    pass\n"
+        )
+        assert black.format_str("{\r}", mode=black.FileMode()) == "{}\n"
+        assert black.format_str("pass #\r#\n", mode=black.FileMode()) == "pass  #\n#\n"
+
 
 class TestCaching:
     def test_get_cache_dir(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Fixes a `\` followed by a `\r` followed by a comment causing the comment to be deleted. This also fixes Hypothesis failing the CI. This originally went under the radar since the old tokenizer largely didn't support carriage returns, so this example would crash with `error: cannot format <string>: Cannot parse for target version Python 3.13: 1:4: try:\` before getting to linegen. The new tokenizer supports carriage returns much better, and so this issue was revealed. I'm not sure why Hypothesis didn't catch this on the original tokenizer switch PR.

The fix is very simple, the splitting regex for comment finding only accounted for `\r\n` and `\n`, not a lone `\r`. This PR adds `\r` as a valid case to the regex.

I added the test case to `test_black.py` instead of the cases because git would normalize the `\r`s on checkout, and it's very hard in most editors to deal with `\r` vs `\r\n` vs `\n`. While I was there I also added two of the older `\r` problematic examples as tests too.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
  - N/A, documentation not affected

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
