### PR TITLE
Fix backslash cr nl bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Handle `# fmt: skip` followed by a comment at the end of file (#4635)
 - Fix crash when a tuple appears in the `as` clause of a `with` statement (#4634)
 - Fix crash when tuple is used as a context manager inside a `with` statement (#4646)
+- Fix crash on a `\\r\n` (#4673)
 
 ### Preview style
 

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -113,7 +113,17 @@ def transform_whitespace(
         and prev_token.type not in (TokenType.nl, TokenType.newline)
     ):
         token_str = source[token.start_index : token.end_index]
-        if token_str.startswith("\\\n"):
+        if token_str.startswith("\\\r\n"):
+            return pytokens.Token(
+                TokenType.nl,
+                token.start_index,
+                token.start_index + 3,
+                token.start_line,
+                token.start_col,
+                token.start_line,
+                token.start_col + 3,
+            )
+        elif token_str.startswith("\\\n") or token_str.startswith("\\\r"):
             return pytokens.Token(
                 TokenType.nl,
                 token.start_index,


### PR DESCRIPTION
### Description

This fixes another one of the hypothesis errors. It took me a long time to track down, but it was again in this translation layer: 

Since `transform_whitespace` only checked for `\\\n`, any `\\\r\n` whitespace token would break everything. This is because since the offset adjustments never happened, on the token after the `\\\r\n` there would be a position mismatch, triggering the code to add a `\n` to the prefix of that token. This is fine for the first pass, but after getting converted to code this causes the second pass to crash.
Input Code:
```py
x=\<carriage return><newline>
1
```
After first pass:
```py
x=<newline>
1
```
Crashes on second pass due to invalid code.

I also included the `\\\r` check for completeness, since even though code with `\\\r` seemed to work before it sounded to me like a bug waiting to happen, and has not caused any test failures (at least for me when running the tests locally).

### Checklist - did you ...

- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
  - I didn't add a test, still I'm not certain how to handle these newline specific tests, and hypothesis should hopefully have this covered, but if someone else could write a test that would be great.
- [x] Add new / update outdated documentation?
  - N/A crash fix, no docs changed
