### PR TITLE
Fix handling of mismatched Python version in virtualenv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@
 
 - Enhance GitHub Action `psf/black` to support the `required-version` major-version-only
   "stability" format when using pyproject.toml (#4770)
+- Vim: Print the import paths when importing black fails (#4675)
+- Vim: Fix handling of virtualenvs that have a different Python version (#4675)
 
 ### Documentation
 
@@ -104,8 +106,6 @@
 - Enhance GitHub Action `psf/black` to read Black version from an additional section in
   pyproject.toml: `[project.dependency-groups]` (#4606)
 - Build gallery docker image with python3-slim and reduce image size (#4686)
-- Vim: Print the import paths when importing black fails (#4675)
-- Vim: Fix handling of virtualenvs that have a different Python version (#4675)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,8 +67,8 @@
 - Enhance GitHub Action `psf/black` to read Black version from an additional section in
   pyproject.toml: `[project.dependency-groups]` (#4606)
 - Build gallery docker image with python3-slim and reduce image size (#4686)
-- Vim: Print the import paths when importing black fails
-- Vim: Fix handling of virtualenvs that have a different Python version
+- Vim: Print the import paths when importing black fails (#4675)
+- Vim: Fix handling of virtualenvs that have a different Python version (#4675)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
   pyproject.toml: `[project.dependency-groups]` (#4606)
 - Build gallery docker image with python3-slim and reduce image size (#4686)
 - Vim: Print the import paths when importing black fails
+- Vim: Fix handling of virtualenvs that have a different Python version
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@
 - Enhance GitHub Action `psf/black` to read Black version from an additional section in
   pyproject.toml: `[project.dependency-groups]` (#4606)
 - Build gallery docker image with python3-slim and reduce image size (#4686)
+- Vim: Print the import paths when importing black fails
 
 ### Documentation
 

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -61,7 +61,16 @@ def _get_pip(venv_path):
 def _get_virtualenv_site_packages(venv_path, pyver):
   if sys.platform[:3] == "win":
     return venv_path / 'Lib' / 'site-packages'
-  return venv_path / 'lib' / f'python{pyver[0]}.{pyver[1]}' / 'site-packages'
+  if venv_path.exists() and not (venv_path / 'lib' / f'python{pyver[0]}.{pyver[1]}').exists():
+    # The virtualenv already exists but it doesn't seem to have the expected
+    # Python version, so we disregard the requested `pyver` and
+    # discover the real Python interpreter from this virtualenv
+    import subprocess
+    result = subprocess.run([_get_python_binary(venv_path, pyver), "--version"], stdout=subprocess.PIPE, text=True)
+    venv_version = result.stdout.split(" ")[1].strip().split(".")
+    return venv_path / 'lib' / f'python{venv_version[0]}.{venv_version[1]}' / 'site-packages'
+  else:
+    return venv_path / 'lib' / f'python{pyver[0]}.{pyver[1]}' / 'site-packages'
 
 def _initialize_black_env(upgrade=False):
   if vim.eval("g:black_use_virtualenv ? 'true' : 'false'") == "false":

--- a/autoload/black.vim
+++ b/autoload/black.vim
@@ -120,7 +120,10 @@ def _initialize_black_env(upgrade=False):
   return True
 
 if _initialize_black_env():
-  import black
+  try:
+    import black
+  except ImportError:
+    print(f"Could not import black from any of: {', '.join(sys.path)}.")
   import time
 
 def get_target_version(tv):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

This fixes #2547 for the (default) case when `g:black_use_virtualenv = 1`.
The fix for `g:black_use_virtualenv = 0` is a superset of these changes but is more invasive so I'll create a separate branch for it.

To trigger the bug on Linux:
- make sure you don't have `black` installed as a system package: `apt purge black`
- launch vim built with Python 3.X
- run `:BlackVersion`, let it finish creating the virtualenv, close vim
- launch vim built with Python 3.Y
- run `:BlackVersion`, you should see an error: `ModuleNotFoundError: No module named 'black'`

I usually encounter this issue when I upgrade to a new Kubuntu release which has a newer Vim built against a newer Python, since I keep the same user data so the old virtualenv created for black is still there.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
