### PR TITLE
Fix f string expr split after

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
 
 - Fix a bug where one-liner functions/conditionals marked with `# fmt: skip` would still
   be formatted (#4552)
+- Fix a bug where `string_processing` would not split f-strings directly after
+  expressions (#4680)
 
 ### Configuration
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1307,6 +1307,7 @@ class BaseStringSplitter(StringTransformer):
 def iter_fexpr_spans(s: str) -> Iterator[tuple[int, int]]:
     """
     Yields spans corresponding to expressions in a given f-string.
+    Spans are closed ranges (left and right inclusive).
     Assumes the input string is a valid f-string, but will not crash if the input
     string is invalid.
     """

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1307,7 +1307,6 @@ class BaseStringSplitter(StringTransformer):
 def iter_fexpr_spans(s: str) -> Iterator[tuple[int, int]]:
     """
     Yields spans corresponding to expressions in a given f-string.
-    Spans are half-open ranges (left inclusive, right exclusive).
     Assumes the input string is a valid f-string, but will not crash if the input
     string is invalid.
     """
@@ -1755,7 +1754,7 @@ class StringSplitter(BaseStringSplitter, CustomSplitMapMixin):
         ]
         for it in iterators:
             for begin, end in it:
-                illegal_indices.update(range(begin, end + 1))
+                illegal_indices.update(range(begin, end))
         return illegal_indices
 
     def _get_break_idx(self, string: str, max_break_idx: int) -> Optional[int]:

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1307,7 +1307,7 @@ class BaseStringSplitter(StringTransformer):
 def iter_fexpr_spans(s: str) -> Iterator[tuple[int, int]]:
     """
     Yields spans corresponding to expressions in a given f-string.
-    Spans are closed ranges (left and right inclusive).
+    Spans are half-open ranges (left inclusive, right exclusive).
     Assumes the input string is a valid f-string, but will not crash if the input
     string is invalid.
     """

--- a/tests/data/cases/preview_long_strings.py
+++ b/tests/data/cases/preview_long_strings.py
@@ -883,43 +883,43 @@ code = (
 call(body="%s %s" % (",".join(items), suffix))
 
 log.info(
-    "Skipping:"
-    f' {desc["db_id"]=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]=} {desc["exposure_max"]=}'
+    f'Skipping: {desc["db_id"]=} {desc["ms_name"]} {money=} {dte=} {pos_share=}'
+    f' {desc["status"]=} {desc["exposure_max"]=}'
 )
 
 log.info(
-    "Skipping:"
-    f" {desc['db_id']=} {desc['ms_name']} {money=} {dte=} {pos_share=} {desc['status']=} {desc['exposure_max']=}"
+    f"Skipping: {desc['db_id']=} {desc['ms_name']} {money=} {dte=} {pos_share=}"
+    f" {desc['status']=} {desc['exposure_max']=}"
 )
 
 log.info(
-    "Skipping:"
-    f' {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {foo("bar",x=123)} {"foo" != "bar"} {(x := "abc=")}'
+    f' {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
-    "Skipping:"
-    f' {desc["db_id"]} {desc["ms_name"]} {money=} {(x := "abc=")=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {desc["ms_name"]} {money=} {(x := "abc=")=}'
+    f' {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
-    "Skipping:"
-    f' {desc["db_id"]} {foo("bar",x=123)=} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {desc["db_id"]} {foo("bar",x=123)=} {money=} {dte=} {pos_share=}'
+    f' {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
-    "Skipping:"
-    f' {foo("asdf")=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {foo("asdf")=} {desc["ms_name"]} {money=} {dte=} {pos_share=}'
+    f' {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
-    "Skipping:"
-    f' {"a" == "b" == "c" == "d"} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {"a" == "b" == "c" == "d"} {desc["ms_name"]} {money=} {dte=}'
+    f' {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(
-    "Skipping:"
-    f' {"a" == "b" == "c" == "d"=} {desc["ms_name"]} {money=} {dte=} {pos_share=} {desc["status"]} {desc["exposure_max"]}'
+    f'Skipping: {"a" == "b" == "c" == "d"=} {desc["ms_name"]} {money=} {dte=}'
+    f' {pos_share=} {desc["status"]} {desc["exposure_max"]}'
 )
 
 log.info(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Fixes #4677

~~My assumption on how the issue started is from a documentation issue on `iter_fexpr_spans` - the docs said "Spans are half-open ranges (left inclusive, right exclusive)", but it actually returns closed ranges. I assume the author of `_get_illegal_split_indices` then saw that, and added one to the range, making the ranges include the char after the f-string expr.~~

Update: Wrong, the spans are actually half-open, and I also got confused by it like the original author.

To fix this, I just removed that +1 on the ranges.

I looked at the other usages of `iter_fexpr_spans`, but all of them seem to properly use the ranges ~~as closed~~ as half-open.

I updated the tests that were changed by this, it was a small subsection that looks fine, and since no other code tests were effected that supports that everything else uses the spans ~~as closed~~ as half-open. I also fixed the docs for `iter_fexpr_spans` to prevent this in the future.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
