### PR TITLE
Misc lints

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -184,9 +184,7 @@ def spellcheck_pyproject_toml_keys(
 ) -> None:
     invalid_keys: list[str] = []
     available_config_options = {param.name for param in ctx.command.params}
-    for key in config_keys:
-        if key not in available_config_options:
-            invalid_keys.append(key)
+    invalid_keys = [key for key in config_keys if key not in available_config_options]
     if invalid_keys:
         keys_str = ", ".join(map(repr, invalid_keys))
         out(

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -778,7 +778,7 @@ def get_sources(
                 continue
 
             if is_stdin:
-                path = Path(f"{STDIN_PLACEHOLDER}{str(path)}")
+                path = Path(f"{STDIN_PLACEHOLDER}{path}")
 
             if path.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
                 warn=verbose or not quiet

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1279,7 +1279,7 @@ def decode_bytes(src: bytes) -> tuple[FileContent, Encoding, NewLine]:
     if not lines:
         return "", encoding, "\n"
 
-    newline = "\r\n" if b"\r\n" == lines[0][-2:] else "\n"
+    newline = "\r\n" if lines[0][-2:] == b"\r\n" else "\n"
     srcbuf.seek(0)
     with io.TextIOWrapper(srcbuf, encoding) as tiow:
         return tiow.read(), encoding, newline

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -343,7 +343,7 @@ def _generate_ignored_nodes_from_fmt_skip(
         # Traversal process (starting at the `# fmt: skip` node):
         # 1. Move to the `prev_sibling` of the current node.
         # 2. If `prev_sibling` has children, go to its rightmost leaf.
-        # 3. If there’s no `prev_sibling`, move up to the parent
+        # 3. If there's no `prev_sibling`, move up to the parent
         # node and repeat.
         # 4. Continue until:
         #    a. You encounter an `INDENT` or `NEWLINE` node (indicates

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -154,10 +154,9 @@ def make_comment(content: str) -> str:
 
     if content[0] == "#":
         content = content[1:]
-    NON_BREAKING_SPACE = " "
     if (
         content
-        and content[0] == NON_BREAKING_SPACE
+        and content[0] == "\N{NO-BREAK SPACE}"
         and not content.lstrip().startswith("type:")
     ):
         content = " " + content[1:]  # Replace NBSP by a simple space

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -66,7 +66,7 @@ def jupyter_dependencies_are_installed(*, warn: bool) -> bool:
 
 
 def validate_cell(src: str, mode: Mode) -> None:
-    """Check that cell does not already contain TransformerManager transformations,
+    r"""Check that cell does not already contain TransformerManager transformations,
     or non-Python cell magics, which might cause tokenizer_rt to break because of
     indentations.
 
@@ -228,14 +228,14 @@ def get_token(src: str, magic: str) -> str:
 
 
 def replace_cell_magics(src: str) -> tuple[str, list[Replacement]]:
-    """Replace cell magic with token.
+    r"""Replace cell magic with token.
 
     Note that 'src' will already have been processed by IPython's
     TransformerManager().transform_cell.
 
     Example,
 
-        get_ipython().run_cell_magic('t', '-n1', 'ls =!ls\\n')
+        get_ipython().run_cell_magic('t', '-n1', 'ls =!ls\n')
 
     becomes
 
@@ -370,7 +370,7 @@ class CellMagic:
 
 # ast.NodeVisitor + dataclass = breakage under mypyc.
 class CellMagicFinder(ast.NodeVisitor):
-    """Find cell magics.
+    r"""Find cell magics.
 
     Note that the source of the abstract syntax tree
     will already have been processed by IPython's
@@ -383,7 +383,7 @@ class CellMagicFinder(ast.NodeVisitor):
 
     would have been transformed to
 
-        get_ipython().run_cell_magic('time', '', 'foo()\\n')
+        get_ipython().run_cell_magic('time', '', 'foo()\n')
 
     and we look for instances of the latter.
     """

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -40,6 +40,7 @@ from black.nodes import (
     ensure_visible,
     fstring_to_string,
     get_annotation_type,
+    has_sibling_with_type,
     is_arith_like,
     is_async_stmt_or_funcdef,
     is_atom_with_invisible_parens,
@@ -1628,6 +1629,11 @@ def maybe_make_parens_invisible_in_atom(
         or is_empty_tuple(node)
         or is_one_tuple(node)
         or (is_tuple(node) and parent.type == syms.asexpr_test)
+        or (
+            is_tuple(node)
+            and parent.type == syms.with_stmt
+            and has_sibling_with_type(node, token.COMMA)
+        )
         or (is_yield(node) and parent.type != syms.expr_stmt)
         or (
             # This condition tries to prevent removing non-optional brackets

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -573,7 +573,6 @@ class LineGenerator(Visitor[Line]):
         self.current_line = Line(mode=self.mode)
 
         v = self.visit_stmt
-        Ø: set[str] = set()
         self.visit_assert_stmt = partial(v, keywords={"assert"}, parens={"assert", ","})
         self.visit_if_stmt = partial(
             v, keywords={"if", "else", "elif"}, parens={"if", "elif"}
@@ -581,23 +580,23 @@ class LineGenerator(Visitor[Line]):
         self.visit_while_stmt = partial(v, keywords={"while", "else"}, parens={"while"})
         self.visit_for_stmt = partial(v, keywords={"for", "else"}, parens={"for", "in"})
         self.visit_try_stmt = partial(
-            v, keywords={"try", "except", "else", "finally"}, parens=Ø
+            v, keywords={"try", "except", "else", "finally"}, parens=set()
         )
         self.visit_except_clause = partial(v, keywords={"except"}, parens={"except"})
         self.visit_with_stmt = partial(v, keywords={"with"}, parens={"with"})
-        self.visit_classdef = partial(v, keywords={"class"}, parens=Ø)
+        self.visit_classdef = partial(v, keywords={"class"}, parens=set())
 
-        self.visit_expr_stmt = partial(v, keywords=Ø, parens=ASSIGNMENTS)
+        self.visit_expr_stmt = partial(v, keywords=set(), parens=ASSIGNMENTS)
         self.visit_return_stmt = partial(v, keywords={"return"}, parens={"return"})
-        self.visit_import_from = partial(v, keywords=Ø, parens={"import"})
-        self.visit_del_stmt = partial(v, keywords=Ø, parens={"del"})
+        self.visit_import_from = partial(v, keywords=set(), parens={"import"})
+        self.visit_del_stmt = partial(v, keywords=set(), parens={"del"})
         self.visit_async_funcdef = self.visit_async_stmt
         self.visit_decorated = self.visit_decorators
 
         # PEP 634
         self.visit_match_stmt = self.visit_match_case
         self.visit_case_block = self.visit_match_case
-        self.visit_guard = partial(v, keywords=Ø, parens={"if"})
+        self.visit_guard = partial(v, keywords=set(), parens={"if"})
 
 
 def _hugging_power_ops_line_to_string(

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -71,7 +71,7 @@ class Line:
         if not has_value:
             return
 
-        if token.COLON == leaf.type and self.is_class_paren_empty:
+        if leaf.type == token.COLON and self.is_class_paren_empty:
             del self.leaves[-2:]
         if self.leaves and not preformatted:
             # Note: at this point leaf.prefix should be empty except for

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -275,7 +275,7 @@ def _convert_unchanged_line_by_line(node: Node, lines_set: set[int]) -> None:
             # We will check `simple_stmt` and `stmt+` separately against the lines set
             parent_sibling = leaf.parent.prev_sibling
             nodes_to_ignore = []
-            while parent_sibling and not parent_sibling.type == syms.suite:
+            while parent_sibling and parent_sibling.type != syms.suite:
                 # NOTE: Multiple suite nodes can exist as siblings in e.g. `if_stmt`.
                 nodes_to_ignore.insert(0, parent_sibling)
                 parent_sibling = parent_sibling.prev_sibling

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -155,7 +155,7 @@ def adjusted_lines(
 
 
 def convert_unchanged_lines(src_node: Node, lines: Collection[tuple[int, int]]) -> None:
-    """Converts unchanged lines to STANDALONE_COMMENT.
+    r"""Converts unchanged lines to STANDALONE_COMMENT.
 
     The idea is similar to how `# fmt: on/off` is implemented. It also converts the
     nodes between those markers as a single `STANDALONE_COMMENT` leaf node with

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -153,7 +153,7 @@ def normalize_string_prefix(s: str) -> str:
     )
 
     # Python syntax guarantees max 2 prefixes and that one of them is "r"
-    if len(new_prefix) == 2 and "r" != new_prefix[0].lower():
+    if len(new_prefix) == 2 and new_prefix[0].lower() != "r":
         new_prefix = new_prefix[::-1]
     return f"{new_prefix}{match.group(2)}"
 

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -355,7 +355,7 @@ def char_width(char: str) -> int:
         elif codepoint > end_codepoint:
             lowest = idx + 1
         else:
-            return 0 if width < 0 else width
+            return max(width, 0)
         if highest < lowest:
             break
         idx = (highest + lowest) // 2

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -355,7 +355,7 @@ def char_width(char: str) -> int:
         elif codepoint > end_codepoint:
             lowest = idx + 1
         else:
-            return max(width, 0)
+            return 0 if width < 0 else width
         if highest < lowest:
             break
         idx = (highest + lowest) // 2

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -584,7 +584,7 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
                 <= i
                 < previous_merged_string_idx + previous_merged_num_of_strings
             ):
-                for comment_leaf in line.comments_after(LL[i]):
+                for comment_leaf in line.comments_after(leaf):
                     new_line.append(comment_leaf, preformatted=True)
                 continue
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1706,10 +1706,10 @@ class StringSplitter(BaseStringSplitter, CustomSplitMapMixin):
             yield Ok(last_line)
 
     def _iter_nameescape_slices(self, string: str) -> Iterator[tuple[Index, Index]]:
-        """
+        r"""
         Yields:
             All ranges of @string which, if @string were to be split there,
-            would result in the splitting of an \\N{...} expression (which is NOT
+            would result in the splitting of an \N{...} expression (which is NOT
             allowed).
         """
         # True - the previous backslash was unescaped


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

I was bored so I decided to run all the ruff lints against `src/black`, and only fix the ones I liked, so here's the results. I tried my best to only pick ones that I thought made a clear improvement to the code without causing too much churn. All the reasoning is in the commit messages, but I also copied it here because github cuts it off.

```
SIM201 negate-equal-op seems reasonable

RUF010 explicit-f-string-type-conversion seems reasonable

RUF003 ambiguous-unicode-character-comment churn but reasonable

RUF001 ambiguous-unicode-character-string changing the literal NBSP to using \N{} is a lot more editor friendly, good change

PLR1736 unnecessary-list-index-lookup good change, both speed and clarity improvement

PLC2401 non-ascii-name churn but good, original name takes a long time to parse that it is the empty set and is very had to type, while set() is more explicit and easy to type
Reverted since there were PRs on this before per Jelle

PERF401 manual-list-comprehension code clarity improvement

FURB136 if-expr-min-max code clarity improvement
Reverted, was on the edge with including this and is maybe worse perf per Jelle

SIM300 yoda-conditions improves readability and consistency

D301 escape-sequence-in-docstring some docstrings were broken due to having unescaped \n s, so I fixed those, as well as converted some others for consistency
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x] Add an entry in `CHANGES.md` if necessary?
  - N/A no behavior changes made
- [x] Add / update tests if necessary?
  - N/A no tests affected
- [x] Add new / update outdated documentation?
  - N/A no docs affected

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
