### PR TITLE
Add normalizing `\r` style newlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Remove support for pre-python 3.7 `await/async` as soft keywords/variable names
   (#4676)
 - Fix crash on parenthesized expression inside a type parameter bound (#4684)
+- Normalize newlines on format to first newline in file (#4710)
 
 ### Preview style
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1030,7 +1030,7 @@ def format_stdin_to_stdout(
                 dst += newline
             f.write(dst)
         elif write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
-            now = datetime.now(tz=timezone.utc)
+            now = datetime.now(timezone.utc)
             src_name = f"STDIN\t{then}"
             dst_name = f"STDOUT\t{now}"
             d = diff(src, dst, src_name, dst_name)
@@ -1266,7 +1266,6 @@ def _format_str_once(
         if "\n" in normalized_contents:
             return newline_type
         return ""
-    # print(f"{src_contents=}\n{normalized_contents=}\n{newline_type=}\n")
     return "".join(dst_contents).replace("\n", newline_type)
 
 
@@ -1276,7 +1275,6 @@ def decode_bytes(src: bytes) -> tuple[FileContent, Encoding, NewLine]:
     `newline` is either CRLF or LF but `decoded_contents` is decoded with
     universal newlines (i.e. only contains LF).
     """
-    # breakpoint()
     srcbuf = io.BytesIO(src)
     encoding, lines = tokenize.detect_encoding(srcbuf.readline)
     if not lines:

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -129,14 +129,6 @@ async def handle(request: web.Request, executor: Executor) -> web.Response:
             executor, partial(black.format_file_contents, req_str, fast=fast, mode=mode)
         )
 
-        # Preserve CRLF line endings
-        nl = req_str.find("\n")
-        if nl > 0 and req_str[nl - 1] == "\r":
-            formatted_str = formatted_str.replace("\n", "\r\n")
-            # If, after swapping line endings, nothing changed, then say so
-            if formatted_str == req_str:
-                raise black.NothingChanged
-
         # Put the source first line back
         req_str = header + req_str
         formatted_str = header + formatted_str


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This is another way to fix the issues with `\r`, and should permanently get rid of them - currently `\r` isn't included in the normalization due to limitations with `io.BytesIO` and probably other things. This PR makes it so that they are included in the normalization to `\n`, and are a valid target for all newlines to normalize to. This should permanently fix all `\r`-related issues, since now there will be none given to the tokenizer / parser / formatter internals.

---

This PR is mostly to gauge interest on if this would be a good direction to go in. If yes, there is a good amount of work that needs done on removing `\r`-related code that would no longer be applicable.

This should also hopefully fix the fuzzing finally.

---

A more in-depth explanation of the changes made:

The key change is to `decode_bytes`. `io.BytesIO.readline` is hard-coded to ignore `\r` line ends. This means that the returned lines have to be manually double-checked for `\r`s before the newline `readline` found. The code I used for this could be more condensed with tricks, but I was having trouble conceptualizing and making sure all branches were covered, so I kept it expanded out. Note that in the `\r\n` case, we don't have to double-check for another `\r\n` on found `\r`s, since `readline` would have chopped there instead.

Changing that allowed for changes to trickle back up the calling tree - `_format_str_once` now has newlines normalized early, and also does the actual newline normalization. `format_stdin_to_stdout` also needed some changes to account for `\r`s. `blackd` previously handled some newline normalization, but since it's now part of `_format_str_once` I was able to remove that.

---

I'm not 100% sure whether this should go directly into stable, or should go into preview. I'd like it to go directly into stable for a couple of reasons:
- It would be really annoying to keep two different newline behaviors.
- I think breakage should generally be small, as most files, especially ones in a git repo, should already have only 1 newline type.
- The behavior of keeping newlines untouched on no changes is still present.

And most importantly, the docs were only partially correct before. Since the newline normalization code lived in `blackd`, newlines would only be normalized using the first encountered when running through `blackd`, but not through `black` directly. For example, running this code while having `uv` installed and in the path:
```py
import subprocess
print(repr(subprocess.run(["uvx", "black", "-c", "\r\ntest\ntest2"], capture_output=True)))
```
Gives
```
CompletedProcess(args=['uvx', 'black', '-c', '\r\ntest\ntest2'], returncode=0, stdout=b'test\ntest2\n', stderr=b'')
```
The stdout is `test\ntest2\n`, so the newlines were normalized to `\n` despite the first newline being `\r\n`. This PR makes it correctly output `test\r\ntest2\r\n`

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    All user-facing changes should get an entry. Otherwise, signal to us
    this should get the magical label to silence the CHANGELOG entry check.
    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes. -->

- [x ] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
  - Updated tests with changed behavior.
  - Added new test that permutes over all simple newline combinations.
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces including PRs
     must follow the PSF Code of Conduct (link below).

     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:

      PSF COC: https://www.python.org/psf/conduct/
      Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      Chat on Python Discord: https://discord.gg/RtVdv86PrH -->
