### PR TITLE
Fix `--target-version` flag for unit tests.

### DIFF
--- a/tests/data/cases/target_version_flag.py
+++ b/tests/data/cases/target_version_flag.py
@@ -1,0 +1,10 @@
+# flags: --minimum-version=3.12 --target-version=py312
+# this is invalid in versions below py312
+class ClassA[T: str]:
+    def method1(self) -> T:
+        ...
+
+# output
+# this is invalid in versions below py312
+class ClassA[T: str]:
+    def method1(self) -> T: ...

--- a/tests/util.py
+++ b/tests/util.py
@@ -236,8 +236,8 @@ def get_flags_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--target-version",
-        action="append",
-        type=lambda val: TargetVersion[val.upper()],
+        action="store",
+        type=lambda val: (TargetVersion[val.upper()],),
         default=(),
     )
     parser.add_argument("--line-length", default=DEFAULT_LINE_LENGTH, type=int)
@@ -258,7 +258,7 @@ def get_flags_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Minimum version of Python where this test case is parseable. If this is"
-            " set, the test case will be run twice: once with the specified"
+            " set, the test case will be run twice: once without the specified"
             " --target-version, and once with --target-version set to exactly the"
             " specified version. This ensures that Black's autodetection of the target"
             " version works correctly."


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

Fixes: #4721.
<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [ ] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
     
**Additional Info**
From what i can tell:
- When `--target-version` is passed without `--minimum-version`, the test runs across all supported Python versions, but always with the specified target version.
- When `--minimum-version` is passed on its own, tests run on all Python versions >= the specified version. For each version, the test runs twice: once with the specified version passed as target version and once without it.
- When both flags are provided, tests run on all Python versions ≥ the specified `--minimum-version`, and with the given `--target-version`. (most likely twice)

> I realize `--target-version` wasn't used in unit tests—likely because the goal is to validate Black's version detection logic. That said, I figured it wouldn't hurt to fix this anyway.