### PR TITLE
ci: Run diff-shades on unstable instead of preview

### DIFF
--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -129,14 +129,14 @@ jobs:
           path: ${{ matrix.target-analysis }}
 
       - name: Generate summary file (PR only)
-        if: github.event_name == 'pull_request' && matrix.mode == 'preview-changes'
+        if: github.event_name == 'pull_request' && matrix.mode == 'preview-new-changes'
         run: >
           python helper.py comment-body ${{ matrix.baseline-analysis }}
           ${{ matrix.target-analysis }} ${{ matrix.baseline-sha }}
           ${{ matrix.target-sha }} ${{ github.event.pull_request.number }}
 
       - name: Upload summary file (PR only)
-        if: github.event_name == 'pull_request' && matrix.mode == 'preview-changes'
+        if: github.event_name == 'pull_request' && matrix.mode == 'preview-new-changes'
         uses: actions/upload-artifact@v4
         with:
           name: .pr-comment.json

--- a/docs/contributing/gauging_changes.md
+++ b/docs/contributing/gauging_changes.md
@@ -27,20 +27,20 @@ workflow that analyzes and compares two revisions of _Black_ according to these 
 | On PRs                | latest commit on `main` | PR commit with `main` merged |
 | On pushes (main only) | latest PyPI version     | the pushed commit            |
 
-For pushes to main, there's only one analysis job named `preview-changes` where the
-preview style is used for all projects.
+For pushes to main, there's only one analysis job named `preview-new-changes` where the
+unstable style is used for all projects.
 
 For PRs they get one more analysis job: `assert-no-changes`. It's similar to
-`preview-changes` but runs with the stable code style. It will fail if changes were
+`preview-new-changes` but runs with the stable code style. It will fail if changes were
 made. This makes sure code won't be reformatted again and again within the same year in
 accordance to Black's stability policy.
 
-Additionally for PRs, a PR comment will be posted embedding a summary of the preview
-changes and links to further information. If there's a pre-existing diff-shades comment,
-it'll be updated instead the next time the workflow is triggered on the same PR.
+Additionally for PRs, a PR comment will be posted embedding a summary previewing the
+changes in the unstable style and links to further information. The next time the
+workflow is triggered on the same PR, it'll update the pre-existing diff-shades comment.
 
 ```{note}
-The `preview-changes` job will only fail intentionally if while analyzing a file failed to
+The `preview-new-changes` job will only fail intentionally if while analyzing a file failed to
 format. Otherwise a failure indicates a bug in the workflow.
 ```
 

--- a/scripts/diff_shades_gha_helper.py
+++ b/scripts/diff_shades_gha_helper.py
@@ -117,7 +117,7 @@ def config(event: Literal["push", "pull_request"]) -> None:
     import diff_shades  # type: ignore[import-not-found]
 
     if event == "push":
-        jobs = [{"mode": "preview-changes", "force-flag": "--force-preview-style"}]
+        jobs = [{"mode": "preview-new-changes", "force-flag": "--force-unstable-style"}]
         # Push on main, let's use PyPI Black as the baseline.
         baseline_name = str(get_pypi_version())
         baseline_cmd = f"git checkout {baseline_name}"
@@ -128,7 +128,7 @@ def config(event: Literal["push", "pull_request"]) -> None:
 
     elif event == "pull_request":
         jobs = [
-            {"mode": "preview-changes", "force-flag": "--force-preview-style"},
+            {"mode": "preview-new-changes", "force-flag": "--force-unstable-style"},
             {"mode": "assert-no-changes", "force-flag": "--force-stable-style"},
         ]
         # PR, let's use main as the baseline.
@@ -205,7 +205,7 @@ def comment_details(run_id: str) -> None:
 
     set_output("needs-comment", "true")
     jobs = http_get(data["jobs_url"])["jobs"]
-    job = next(j for j in jobs if j["name"] == "analysis / preview-changes")
+    job = next(j for j in jobs if j["name"] == "analysis / preview-new-changes")
     diff_step = next(s for s in job["steps"] if s["name"] == DIFF_STEP_NAME)
     diff_url = job["html_url"] + f"#step:{diff_step['number']}:1"
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

This PR changes diff-shades to run on the stable and unstable styles as opposed to the stable and preview styles.

I opted to replace the preview job with the unstable job instead of adding a new job because all preview changes also exist in unstable so running both feels redundant, and it takes a long time to run so it wouldn't be worth it to have both jobs.

I wasn't sure if the "preview-changes" mode was meant to be interpreted as "Changes in the preview style" or "Preview new changes". I took it to mean the former and renamed it to `unstable-style-changes` for clarity, but I can change that if desired

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [-] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [-] Add an entry in `CHANGES.md` if necessary?
- [y] Add / update tests if necessary?
- [y] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
