### PR TITLE
Improvements for release_process.md

### DIFF
--- a/docs/contributing/release_process.md
+++ b/docs/contributing/release_process.md
@@ -46,17 +46,17 @@ To cut a release:
    - `release.py` will calculate this and log to stderr for you copy paste pleasure
 1. File a PR editing `CHANGES.md` and the docs to version the latest changes
    - Run `python3 scripts/release.py [--debug]` to generate most changes
-1. If `release.py` fail manually edit; otherwise, yay, skip this step!
+1. If `release.py` fails manually edit; otherwise, yay, skip this step!
    1. Replace the `## Unreleased` header with the version number
    1. Remove any empty sections for the current release
    1. (_optional_) Read through and copy-edit the changelog (eg. by moving entries,
       fixing typos, or rephrasing entries)
    1. Double-check that no changelog entries since the last release were put in the
-      wrong section (e.g., run `git diff <last release> CHANGES.md`)
+      wrong section (e.g., run `git diff origin/stable CHANGES.md`)
    1. Update references to the latest version in
       {doc}`/integrations/source_version_control` and
       {doc}`/usage_and_configuration/the_basics`
-   - Example PR: [GH-3139]
+   - Example PR: [GH-4563]
 1. Once the release PR is merged, wait until all CI passes
    - If CI does not pass, **stop** and investigate the failure(s) as generally we'd want
      to fix failing CI before cutting a release
@@ -64,7 +64,8 @@ To cut a release:
    1. Click `Choose a tag` and type in the version number, then select the
       `Create new tag: YY.M.N on publish` option that appears
    1. Verify that the new tag targets the `main` branch
-   1. You can leave the release title blank, GitHub will default to the tag name
+   1. Make sure the release title is set to the version (`YY.M.N`), as otherwise the
+      default title is the last commit's title
    1. Copy and paste the _raw changelog Markdown_ for the current release into the
       description box
 1. Publish the GitHub Release, triggering [release automation](#release-workflows) that
@@ -158,7 +159,7 @@ This also runs on each push to `main`.
 [build]: https://pypa-build.readthedocs.io/
 [calver]: https://calver.org
 [cibuildwheel]: https://cibuildwheel.readthedocs.io/
-[gh-3139]: https://github.com/psf/black/pull/3139
+[gh-4563]: https://github.com/psf/black/pull/4563
 [github actions]: https://github.com/features/actions
 [github release]: https://github.com/psf/black/releases
 [new-release]: https://github.com/psf/black/releases/new

--- a/docs/contributing/release_process.md
+++ b/docs/contributing/release_process.md
@@ -70,9 +70,8 @@ To cut a release:
       description box
 1. Publish the GitHub Release, triggering [release automation](#release-workflows) that
    will handle the rest
-1. Once CI is done add + PR a new empty template for the next
-   release to CHANGES.md _(Template is able to be copy pasted from release.py should we
-   fail)_
+1. Once CI is done add + PR a new empty template for the next release to CHANGES.md
+   _(Template is able to be copy pasted from release.py should we fail)_
    1. `python3 scripts/release.py --add-changes-template|-a [--debug]`
    1. Should that fail, please return to copy + paste
 1. At this point, you're basically done. It's good practice to go and [watch and verify

--- a/docs/contributing/release_process.md
+++ b/docs/contributing/release_process.md
@@ -70,7 +70,7 @@ To cut a release:
       description box
 1. Publish the GitHub Release, triggering [release automation](#release-workflows) that
    will handle the rest
-1. Once CI is done add + commit (git push - No review) a new empty template for the next
+1. Once CI is done add + PR a new empty template for the next
    release to CHANGES.md _(Template is able to be copy pasted from release.py should we
    fail)_
    1. `python3 scripts/release.py --add-changes-template|-a [--debug]`


### PR DESCRIPTION
While cutting 25.9.0, I ran into a few snags, so this PR smooths out the issues I ran into in the docs:

- Minor typo fix
- Since the stable branch is updated by the release workflow, `git diff origin/stable CHANGES.md` should always work, which is much easier than having to find a commit hash
- The example PR given had the new template already applied, which confused me. I eventually used the 25.1.0 PR as a reference instead
- GitHub appears to now use the last commit message as the release message instead of the tag name, so it will need to be entered manually going forwards
- There looks to be a check to prevent all pushes directly to main, so a PR has to be made

<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [N/A] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [N/A] Add an entry in `CHANGES.md` if necessary?
- [N/A] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
