### PR TITLE
Fix bug where module docstrings would be treated as normal strings if preceded by comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix bug where module doc strings would be treated as normal strings if preceeded by
+  comments (#4764)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Fix bug where module doc strings would be treated as normal strings if preceeded by
+- Fix bug where module docstrings would be treated as normal strings if preceeded by
   comments (#4764)
 
 ### Configuration

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,12 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Fix bug where module doc strings would be treated as normal strings if preceeded by
-  comments (#4764)
-
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
+
+- Fix bug where module doc strings would be treated as normal strings if preceeded by
+  comments (#4764)
 
 ### Configuration
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -35,6 +35,8 @@ Currently, the following features are included in the preview style:
   types in `except` and `except*` without `as`. See PEP 758 for details.
 - `normalize_cr_newlines`: Add `\r` style newlines to the potential newlines to
   normalize file newlines both from and to.
+- `fix_module_docstring_detection`: Fix module doc strings being treated as normal
+  strings if preceeded by comments.
 
 (labels/unstable-features)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -35,7 +35,7 @@ Currently, the following features are included in the preview style:
   types in `except` and `except*` without `as`. See PEP 758 for details.
 - `normalize_cr_newlines`: Add `\r` style newlines to the potential newlines to
   normalize file newlines both from and to.
-- `fix_module_docstring_detection`: Fix module doc strings being treated as normal
+- `fix_module_docstring_detection`: Fix module docstrings being treated as normal
   strings if preceeded by comments.
 
 (labels/unstable-features)=

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -559,9 +559,20 @@ class EmptyLineTracker:
         before, after = self._maybe_empty_lines(current_line)
         previous_after = self.previous_block.after if self.previous_block else 0
         before = max(0, before - previous_after)
-        # Always have one empty line after a module docstring
-        if self._line_is_module_docstring(current_line):
-            before = 1
+        if Preview.fix_module_docstring_detection in self.Mode:
+            # Always have one empty line after a module docstring
+            if self._line_is_module_docstring(current_line):
+                before = 1
+        else:
+            if (
+                # Always have one empty line after a module docstring
+                self.previous_block
+                and self.previous_block.previous_block is None
+                and len(self.previous_block.original_line.leaves) == 1
+                and self.previous_block.original_line.is_docstring
+                and not (current_line.is_class or current_line.is_def)
+            ):
+                before = 1
 
         block = LinesBlock(
             mode=self.mode,

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -559,7 +559,7 @@ class EmptyLineTracker:
         before, after = self._maybe_empty_lines(current_line)
         previous_after = self.previous_block.after if self.previous_block else 0
         before = max(0, before - previous_after)
-        if Preview.fix_module_docstring_detection in self.Mode:
+        if Preview.fix_module_docstring_detection in self.mode:
             # Always have one empty line after a module docstring
             if self._line_is_module_docstring(current_line):
                 before = 1

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -236,6 +236,7 @@ class Preview(Enum):
     # except* without as. See PEP 758 for details.
     remove_parens_around_except_types = auto()
     normalize_cr_newlines = auto()
+    fix_module_docstring_detection = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -88,7 +88,8 @@
           "fix_fmt_skip_in_one_liners",
           "wrap_comprehension_in",
           "remove_parens_around_except_types",
-          "normalize_cr_newlines"
+          "normalize_cr_newlines",
+          "fix_module_docstring_detection"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/src/blib2to3/pgen2/parse.py
+++ b/src/blib2to3/pgen2/parse.py
@@ -9,6 +9,7 @@ See Parser/parser.c in the Python distribution for additional info on
 how this parsing engine works.
 
 """
+
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Union, cast

--- a/tests/data/cases/module_docstring_after_comment.py
+++ b/tests/data/cases/module_docstring_after_comment.py
@@ -1,0 +1,21 @@
+#!/python
+
+# regression test for #4762
+"""
+docstring
+"""
+from __future__ import annotations
+
+import os
+
+# output
+#!/python
+
+# regression test for #4762
+"""
+docstring
+"""
+
+from __future__ import annotations
+
+import os

--- a/tests/data/cases/module_docstring_after_comment.py
+++ b/tests/data/cases/module_docstring_after_comment.py
@@ -1,3 +1,4 @@
+# flags: --preview
 #!/python
 
 # regression test for #4762


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This happened because the code didn't account for comments before module docstrings. Since there can be arbitrarily many, this PR pulls the check into a new function so a while loop could go through all the previous blocks until either the start of the file is found, or a non comment block is reached.

A new test was added.

Fixes #4762

Code put in preview to not change the stable style.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [x] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
