### PR TITLE
GitHub Action: add support for the `required-version` "major-version-only" format when using pyproject.toml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,7 +45,7 @@
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
 - Enhance GitHub Action `psf/black` to support the `required-version`
-  major-version-only "stability" format when using pyproject.toml
+  major-version-only "stability" format when using pyproject.toml (#4770)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-- Enhance GitHub Action `psf/black` to support the `required-version`  
+- Enhance GitHub Action `psf/black` to support the `required-version`
   major-version-only "stability" format when using pyproject.toml
 
 ### Documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,9 +43,8 @@
 
 ### Integrations
 
-<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-- Enhance GitHub Action `psf/black` to support the `required-version`
-  major-version-only "stability" format when using pyproject.toml (#4770)
+- Enhance GitHub Action `psf/black` to support the `required-version` major-version-only
+  "stability" format when using pyproject.toml (#4770)
 
 ### Documentation
 
@@ -1677,6 +1676,7 @@ and the first release covered by our new
 ## 18.9b0
 
 - numeric literals are now formatted by _Black_ (#452, #461, #464, #469):
+
   - numeric literals are normalized to include `_` separators on Python 3.6+ code
 
   - added `--skip-numeric-underscore-normalization` to disable the above behavior and
@@ -1726,6 +1726,7 @@ and the first release covered by our new
 - typing stub files (`.pyi`) now have blank lines added after constants (#340)
 
 - `# fmt: off` and `# fmt: on` are now much more dependable:
+
   - they now work also within bracket pairs (#329)
 
   - they now correctly work across function/class boundaries (#335)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
 
 ### Integrations
 
+<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+
 - Enhance GitHub Action `psf/black` to support the `required-version` major-version-only
   "stability" format when using pyproject.toml (#4770)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1676,7 +1676,6 @@ and the first release covered by our new
 ## 18.9b0
 
 - numeric literals are now formatted by _Black_ (#452, #461, #464, #469):
-
   - numeric literals are normalized to include `_` separators on Python 3.6+ code
 
   - added `--skip-numeric-underscore-normalization` to disable the above behavior and
@@ -1726,7 +1725,6 @@ and the first release covered by our new
 - typing stub files (`.pyi`) now have blank lines added after constants (#340)
 
 - `# fmt: off` and `# fmt: on` are now much more dependable:
-
   - they now work also within bracket pairs (#329)
 
   - they now correctly work across function/class boundaries (#335)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
 ### Integrations
 
 <!-- For example, Docker, GitHub Actions, pre-commit, editors -->
+- Enhance GitHub Action `psf/black` to support the `required-version`  
+  major-version-only "stability" format when using pyproject.toml
 
 ### Documentation
 

--- a/action/main.py
+++ b/action/main.py
@@ -68,7 +68,11 @@ def read_version_specifier_from_pyproject() -> str:
 
     version = pyproject.get("tool", {}).get("black", {}).get("required-version")
     if version is not None:
-        return f"=={version}"
+        # Match the two supported usages of `required-version`:
+        if "." in version:
+            return f"=={version}"
+        else:
+            return f"~={version}"
 
     arrays = [
         *pyproject.get("dependency-groups", {}).values(),

--- a/action/main.py
+++ b/action/main.py
@@ -72,7 +72,7 @@ def read_version_specifier_from_pyproject() -> str:
         if "." in version:
             return f"=={version}"
         else:
-            return f"~={version}"
+            return f"~={version}.0"
 
     arrays = [
         *pyproject.get("dependency-groups", {}).values(),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

The `required-version` configuration param supports two different "modes": [exact version or major-version-only](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#required-version).
The GitHub Action workflow currently reads this parameter from pyproject.toml when configured with `use_pyproject: true` in order to determine what version of black to `pip install`. However, this fails when pyproject.toml is configured with the "major-version-only" format, because it tries to pip install `==MAJOR`.

This PR adds code so that when pyproject.toml `required-version` is using the "major-version-only" format, it will pip install black using the compatibility operator.

Current behavior:
```
Installing black[colorama]==22...
ERROR: Ignored the following yanked versions: 21.11b0
ERROR: Could not find a version that satisfies the requirement black==22 (from versions: 18.3a0, 18.3a1, 18.3a2, 18.3a3, 18.3a4, 18.4a0, 18.4a1, 18.4a2, 18.4a3, 18.4a4, 18.5b0, 18.5b1, 18.6b0, 18.6b1, 18.6b2, 18.6b3, 18.6b4, 18.9b0, 19.3b0, 19.10b0, 20.8b0, 20.8b1, 21.4b0, 21.4b1, 21.4b2, 21.5b0, 21.5b1, 21.5b2, 21.6b0, 21.7b0, 21.8b0, 21.9b0, 21.10b0, 21.11b1, 21.12b0, 22.1.0, 22.3.0, 22.6.0, 22.8.0, 22.10.0, 22.12.0, 23.1a1, 23.1.0, 23.3.0, 23.7.0, 23.9.0, 23.9.1, 23.10.0, 23.10.1, 23.11.0, 23.12.0, 23.12.1, 24.1a1, 24.1.0, 24.1.1, 24.2.0, 24.3.0, 24.4.0, 24.4.1, 24.4.2, 24.8.0, 24.10.0, 25.1.0, 25.9.0)
ERROR: No matching distribution found for black==22
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [ ] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
