### PR TITLE
Revert "ci: Run diff-shades on unstable instead of preview (#4741)"

### DIFF
--- a/docs/contributing/gauging_changes.md
+++ b/docs/contributing/gauging_changes.md
@@ -28,7 +28,7 @@ workflow that analyzes and compares two revisions of _Black_ according to these 
 | On pushes (main only) | latest PyPI version     | the pushed commit            |
 
 For pushes to main, there's only one analysis job named `preview-new-changes` where the
-unstable style is used for all projects.
+preview style is used for all projects.
 
 For PRs they get one more analysis job: `assert-no-changes`. It's similar to
 `preview-new-changes` but runs with the stable code style. It will fail if changes were
@@ -36,7 +36,7 @@ made. This makes sure code won't be reformatted again and again within the same 
 accordance to Black's stability policy.
 
 Additionally for PRs, a PR comment will be posted embedding a summary previewing the
-changes in the unstable style and links to further information. The next time the
+changes in the preview style and links to further information. The next time the
 workflow is triggered on the same PR, it'll update the pre-existing diff-shades comment.
 
 ```{note}

--- a/scripts/diff_shades_gha_helper.py
+++ b/scripts/diff_shades_gha_helper.py
@@ -117,7 +117,7 @@ def config(event: Literal["push", "pull_request"]) -> None:
     import diff_shades  # type: ignore[import-not-found]
 
     if event == "push":
-        jobs = [{"mode": "preview-new-changes", "force-flag": "--force-unstable-style"}]
+        jobs = [{"mode": "preview-new-changes", "force-flag": "--force-preview-style"}]
         # Push on main, let's use PyPI Black as the baseline.
         baseline_name = str(get_pypi_version())
         baseline_cmd = f"git checkout {baseline_name}"
@@ -128,7 +128,7 @@ def config(event: Literal["push", "pull_request"]) -> None:
 
     elif event == "pull_request":
         jobs = [
-            {"mode": "preview-new-changes", "force-flag": "--force-unstable-style"},
+            {"mode": "preview-new-changes", "force-flag": "--force-preview-style"},
             {"mode": "assert-no-changes", "force-flag": "--force-stable-style"},
         ]
         # PR, let's use main as the baseline.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

This (partially) reverts commit 24f516961720c5578069dee30415b776359b7be5.
(The grammar changes weren't reverted)

Band-aid solution just to fix diff-shades crashing until we can get the unstable style sped up.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [y] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [-] Add an entry in `CHANGES.md` if necessary?
- [y] Add / update tests if necessary?
- [y] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
