### PR TITLE
Clarify GitLab support for blame ignore

### DIFF
--- a/docs/guides/introducing_black_to_your_project.md
+++ b/docs/guides/introducing_black_to_your_project.md
@@ -44,9 +44,9 @@ call to `git blame`.
 $ git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
-**The one caveat is that some online Git-repositories do not yet support
-ignoring revisions using their native blame UI.** So blame information will be cluttered
-with a reformatting commit on those platforms.
+**The one caveat is that some online Git-repositories do not yet support ignoring
+revisions using their native blame UI.** So blame information will be cluttered with a
+reformatting commit on those platforms.
 [GitHub supports `.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)
 by default in blame views however.
 [GitLab supports this since version 17.10](https://about.gitlab.com/releases/2025/03/20/gitlab-17-10-released/#ignore-specific-revisions-in-git-blame)


### PR DESCRIPTION
Updated information regarding support for ignoring revisions in GitLab.

Here are the relevant updated information:
https://about.gitlab.com/releases/2025/03/20/gitlab-17-10-released/#ignore-specific-revisions-in-git-blame - release docs describing this feature.
https://gitlab.com/groups/gitlab-org/-/epics/15751 - The epic which the previously linked issue was promoted into, now complete but staying open for enhancements.

I did not go into depth into which enhancements are missing, yet the current description warrants updating the docs here IMO.

Thank you!