### PR TITLE
docs: label rst block with rst in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Use the badge in your project's README.md:
 
 Using the badge in README.rst:
 
-```
+```rst
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 ```


### PR DESCRIPTION
Tiny small formatting nit I noticed while chatting in Pydis a few days ago.
