### PR TITLE
build: restrict to pytest 9.0 due to breakage in custom pytest_configure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ skip = ["*-manylinux_i686", "*-musllinux_*", "*-win32", "pp*"]
 # This is the bare minimum needed to run the test suite. Pulling in the full
 # test_requirements.txt would download a bunch of other packages not necessary
 # here and would slow down the testing step a fair bit.
-test-requires = ["pytest>=6.1.1"]
+test-requires = ["pytest>=6.1.1,<9.0"]
 test-command = 'pytest {project} -k "not incompatible_with_mypyc"'
 test-extras = ["d"," jupyter"]
 # Skip trying to test arm64 builds on Intel Macs. (so cross-compilation doesn't

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage >= 5.3
 pre-commit
-pytest >= 6.1.1
+pytest >= 6.1.1, <9.0
 pytest-xdist >= 3.0.2
 pytest-cov >= 4.1.0
 tox


### PR DESCRIPTION
Hotfix for getting testing back to a stable configuration without changing a bunch of the test internals right before a release :)

see GH-4826 for more details. 