### PR TITLE
ci: add label for running all builds on a pull request

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -53,7 +53,8 @@ jobs:
           pipx install cibuildwheel==3.2.1
           pipx install pypyp==1.3.0
       - name: generate matrix
-        if: github.event_name != 'pull_request'
+        if: |
+          github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci: build all wheels')
         run: |
           {
             cibuildwheel --print-build-identifiers --platform linux \
@@ -68,7 +69,8 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64
       - name: generate matrix (PR)
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci: build all wheels')
         run: |
           {
             cibuildwheel --print-build-identifiers --platform linux \


### PR DESCRIPTION
We currently don't run all builds on a pull request and only run them on main. This changes it to run all builds on a pull request when the 'ci: build all' label is added.

This is currently implemented in a hotfix manner which will only work once a commit is pushed *after* the label is added.
