### PR TITLE
Remove `--no-cache` docs example

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -235,10 +235,6 @@ nor write to the cache. This is helpful for reproducing formatting results from 
 run, debugging cache-related issues, or ensuring CI executes a fresh formatting analysis
 every time.
 
-Example:
-
-python -m black --no-cache .
-
 #### `--color` / `--no-color`
 
 Show (or do not show) colored diff. Only applies when `--diff` is given.


### PR DESCRIPTION
### Description

An example is not needed for `--no-cache`, since as a CLI flag its usage is obvious, and there's no different in output we could show with it. This also fixes it having an inconsistent style from the rest of the examples.

### Checklist - did you ...

- [N/A] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [N/A] Add an entry in `CHANGES.md` if necessary?
- [N/A] Add / update tests if necessary?
- [x] Add new / update outdated documentation?