### PR TITLE
Improved the Syntax error Message

### DIFF
--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -81,12 +81,9 @@ def lib2to3_parse(
             except IndexError:
                 faulty_line = "<line number missing in source>"
             errors[grammar.version] = InvalidInput(
-                f"\nSyntax Error detected by Black\n"
+                f"\nSyntax error detected by Black\n"
                 f"File: {tv_str}\n"
-                f"Line {lineno}, Column {column}\n"
-                f"\n    {faulty_line}\n"
-                f"    {' ' * (column - 1)}^\n"
-                f"\nMissing a ':' or Invalid Syntax\n"
+                f"{faulty_line}\n\t^"
             )
 
         except TokenError as te:


### PR DESCRIPTION
### Fixes #4820 

**I validated the Following error message**

<img width="1054" height="553" alt="image" src="https://github.com/user-attachments/assets/b7d2beba-2082-4d9f-9f92-a24002fdd5dd" />

**I enhanced the Error reporting message to be more clear!**

<img width="627" height="313" alt="image" src="https://github.com/user-attachments/assets/886f0d79-b527-4881-818c-f4da845de074" />

- I reproduced the Error reporting message by Creating the exact Python code file.
- Navigated to the src -> black -> parsing.py
- In parsing.py, modified the Error reporting message to be more clear

_I'm happy to revise this PR if needed. Please let me know if there are any changes or improvements you'd like._