### PR TITLE
Lingering CI/CD pins, add cooldowns, remove template injections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,13 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["skip news", "C: dependencies"]
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "docs/"
     schedule:
       interval: "weekly"
     labels: ["skip news", "C: dependencies", "T: documentation"]
+    cooldown:
+      default-days: 7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,4 +68,6 @@ jobs:
           tags: pyfound/black:latest_prerelease
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${STEPS_DOCKER_BUILD_OUTPUTS_DIGEST}
+        env:
+          STEPS_DOCKER_BUILD_OUTPUTS_DIGEST: ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -8,9 +8,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  id-token: write # Required for PyPI trusted publishing
+permissions: {}
 
 jobs:
   main:
@@ -20,6 +18,9 @@ jobs:
     environment:
       name: release
       url: https://pypi.org/p/black
+
+    permissions:
+      id-token: write # Required for PyPI trusted publishing
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -42,7 +43,7 @@ jobs:
 
       - if: github.event_name == 'release'
         name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           verbose: true
 
@@ -99,6 +100,8 @@ jobs:
     environment:
       name: release
       url: https://pypi.org/p/black
+    permissions:
+      id-token: write # Required for PyPI trusted publishing
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +124,7 @@ jobs:
 
       - if: github.event_name == 'release'
         name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: wheelhouse/
           verbose: true
@@ -145,5 +148,7 @@ jobs:
       - if: github.event_name == 'release'
         name: Update stable branch to release tag & push
         run: |
-          git reset --hard ${{ github.event.release.tag_name }}
+          git reset --hard "${TAG_NAME}"
           git push
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         # Display the raw output in the step
         echo "${out}"
 
-        if [ "${{ inputs.summary }}" == "true" ]; then
+        if [ "${INPUT_SUMMARY}" == "true" ]; then
           # Display the Markdown output in the job summary
           echo "\`\`\`python" >> $GITHUB_STEP_SUMMARY
           echo "${out}" >> $GITHUB_STEP_SUMMARY
@@ -81,6 +81,7 @@ runs:
         INPUT_BLACK_ARGS: ${{ inputs.black_args }}
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_USE_PYPROJECT: ${{ inputs.use_pyproject }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
         OUTPUT_FILE: ${{ inputs.output-file }}
         pythonioencoding: utf-8
       shell: bash


### PR DESCRIPTION
### Description

This follows #4901 and #4905 with some more small CI/CD security improvements. It hash-pins some of the dependencies added with #4611, minimizes more workflow/job permissions, and eliminates a few template injections (which probably aren't exploitable in practice in this context, but are still good to remove IMO!)

Following this, there's only one finding left from zizmor (which will unfortunately be nontrivial to fix, since it involves a `workflow_run` trigger). I'm happy to try and take a look at that, but the "fix" might be a removal of functionality so I'll file an issue for consultation first.

Separately, I'm happy to send a PR enabling zizmor in your CI, either through pre-commit or [zizmor-action](https://github.com/zizmorcore/zizmor-action). Let me know if either of these would be helpful; there's plenty of PSF / PyPA / PyPI / etc. reference material I can share for others using it!

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

Like with the other PRs, I think none of the above apply 🙂 

