### PR TITLE
Fix inline # fmt: skip handling to prevent unwanted line splitting.

### DIFF
--- a/changelog/fmt-skip-inline.md
+++ b/changelog/fmt-skip-inline.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Inline `# fmt: skip` comments inside function calls now correctly prevent
-  Black from splitting or reformatting the affected line.
+- Inline `# fmt: skip` comments inside function calls now correctly prevent Black from
+  splitting or reformatting the affected line.

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1948,6 +1948,7 @@ def generate_trailers_to_omit(line: Line, line_length: int) -> Iterator[set[Leaf
 
 from black.comments import _contains_fmt_directive
 
+
 def run_transformer(
     line: Line,
     transform: Transformer,


### PR DESCRIPTION
### Summary -
This PR fixes an issue where an inline `# fmt: skip` comment inside a function call
did not fully prevent Black from splitting or reformatting that argument.

Example:

```python
join(
    packages,
    func.coalesce(...) == packages.c.id,  # fmt: skip
    isouter=True,
)
