### PR TITLE
CI: add a zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0


### PR DESCRIPTION
### Description

This adds a new workflow, `zizmor.yml`, which will run `zizmor` via `zizmor-action` on each push and pull request.

See #4901, #4905, #4906 for motivating context.

Note: this adds a new workflow for zizmor, but another option here would be to integrate zizmor via pre-commit. The upside to that is that running it locally would be constant with CI; the downside is that it's not easy (possible?) to directly integrate with GitHub's SARIF consumption support for stateful finding tracking. But if that's better for you all, I'm happy to retool this PR in that direction 🙂 

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the
      stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

None of the above are applicable, I believe 🙂 
