### PR TITLE
Warn when target version exceeds runtime Python version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@
 - Emit a clear warning when the target Python version is newer than the running Python
   version, since AST safety checks cannot parse newer syntax. Also replace the
   misleading "INTERNAL ERROR" message with an actionable error explaining the version
-  mismatch (#4980)
+  mismatch (#4983)
 
 ### _Blackd_
 


### PR DESCRIPTION
## Summary

Fixes #4980

When `--target-version` is set to a newer Python than the one running Black, the AST safety check fails with a misleading "INTERNAL ERROR: produced invalid code. Please report a bug" message. This PR:

- Emits a clear **warning at startup** explaining that the running Python cannot parse syntax for the target version, with three actionable workarounds: (1) run Black with the target Python, (2) lower the target version, or (3) use `--fast`
- Replaces the misleading "INTERNAL ERROR" message in `check_stability_and_equivalence()` with an **actionable error** pointing to the version mismatch

### Before

```
error: cannot format test.py: INTERNAL ERROR: Black on Python 3.12 produced invalid code: ...
Please report a bug on https://github.com/psf/black/issues.
```

### After

```
Warning: target version Python 3.14 is newer than the running Python 3.12. Black's safety check
verifies that formatted code is equivalent to the original by parsing the AST, but Python 3.12
cannot parse Python 3.14 syntax. To fix this: (1) run Black with Python 3.14 instead, (2) set
--target-version to py312, or (3) use --fast to skip the safety check.

error: cannot format test.py: failed to verify equivalence of the formatted output: Python 3.12
cannot parse code generated for Python 3.14. To fix this: run Black with Python 3.14, set
--target-version to py312, or use --fast to skip this check.
```

## Test plan

- [x] 4 new tests in `TestASTSafety` covering: warning emitted, no warning with `--fast`, no warning when target <= runtime, clear error message (no "INTERNAL ERROR")
- [x] Full test suite passes (155 tests)
- [x] pre-commit passes (isort, flake8, mypy, prettier)
- [x] CHANGES.md entry added under Output section