### PR TITLE
Docs: Add documentation for doctest formatting tools

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -22,6 +22,69 @@ Editors and tools not listed will require external contributions.
 
 Patches welcome! ✨ 🍰 ✨
 
+## Formatting doctests and docstrings
+
+While _Black_ itself does not format code within docstrings or doctests, there are
+third-party tools that can apply Black formatting to these areas:
+
+### blacken-docs
+
+[blacken-docs](https://github.com/adamchainz/blacken-docs) formats code blocks in
+documentation files (`.rst`, `.md`, `.tex`) and in docstrings. It supports:
+
+- Python code blocks in Markdown and reStructuredText
+- Doctests in Markdown/reStructuredText blocks within docstrings
+
+Installation:
+
+```sh
+pip install blacken-docs
+```
+
+Usage:
+
+```sh
+blacken-docs README.md docs/*.rst
+```
+
+**Note**: blacken-docs requires doctests to be within Markdown or reStructuredText code
+blocks (e.g., ` ```pycon ` or `.. code-block:: pycon`). It does not support plain
+doctests directly in docstrings outside of these blocks.
+
+### blackdoc
+
+[blackdoc](https://github.com/keewis/blackdoc) formats doctests in Python files,
+including plain doctests in docstrings. It supports:
+
+- Plain doctests in docstrings (no Markdown/reStructuredText blocks required)
+- Doctests in documentation files
+
+Installation:
+
+```sh
+pip install blackdoc
+```
+
+Usage:
+
+```sh
+blackdoc my_module.py
+```
+
+**Note**: blackdoc is not actively maintained, so it may not receive updates for newer
+Black features or Python syntax.
+
+### Choosing a tool
+
+- If your doctests are in **documentation files** (`.md`, `.rst`), use **blacken-docs**
+- If your doctests are in **docstrings with Markdown/reStructuredText blocks**, use
+  **blacken-docs**
+- If your doctests are **plain doctests in docstrings** (without special formatting),
+  use **blackdoc**
+
+Be aware that these tools may not format code identically in all cases. If you need both
+tools, test carefully to ensure they produce compatible results.
+
 Any tool can pipe code through _Black_ using its stdio mode (just
 [use `-` as the file name](https://www.tldp.org/LDP/abs/html/special-chars.html#DASHREF2)).
 The formatted code will be returned on stdout (unless `--check` was passed). _Black_


### PR DESCRIPTION
## Summary

This PR adds documentation about third-party tools that can format doctests and code in docstrings, addressing issue #3083.

Fixes #3083

## Changes

- Added new section "Formatting doctests and docstrings" to `docs/integrations/index.md`
- Documented **blacken-docs** tool:
  - Purpose: Formats code blocks in documentation files and docstrings
  - Supports doctests in Markdown/reStructuredText blocks
  - Installation and usage examples
  
- Documented **blackdoc** tool:
  - Purpose: Formats plain doctests in Python files
  - Supports doctests outside of formatted blocks
  - Note about maintenance status
  
- Added guidance on choosing the appropriate tool based on use case
- Included compatibility notes when using both tools

## Context

As discussed in issue #3083, Black does not format doctests within docstrings. The maintainers (@felix-hilden, @JelleZijlstra) suggested documenting third-party tools that provide this functionality instead of implementing it directly in Black.

This PR fulfills that recommendation by documenting the two main tools available:
- **blacken-docs**: Actively maintained, works with formatted docstring blocks
- **blackdoc**: Not actively maintained, works with plain doctests

## Testing

- Verified documentation formatting and syntax
- Reviewed tool descriptions against their respective repositories
- Ensured integration with existing documentation structure