### PR TITLE
enhance: enhancement of the syntex error reporting

### DIFF
--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -85,9 +85,9 @@ def lib2to3_parse(
                 f"SyntaxError is in line {lineno}, column {column}:\n"
                 f"    {faulty_line}\n"
                 f"    {caret_line}"
-            )  
+            )
             errors[grammar.version] = InvalidInput(message)
-            
+
         except TokenError as te:
             # In edge cases these are raised; and typically don't have a "faulty_line".
             lineno, column = te.args[1]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

My fix improves Black's syntex error reporting when parsing fails.

I have made a test file to see the error messege that reports
<img width="851" height="242" alt="image" src="https://github.com/user-attachments/assets/a8610d58-6c58-4cae-a43d-23c750618864" />
  
currently when Black encounters invalid python syntex, it reports something like this 
<img width="831" height="103" alt="image" src="https://github.com/user-attachments/assets/1f96c6e1-80f1-4d3a-a833-bc877ad1ab00" />

The changes i have changes to enhance the error message reporting

1. Reporting by lines and column so maintainer can easily find the error
2. Displaying the error line and using caret(^) pointing to show exactly where the error is 

<img width="376" height="73" alt="image" src="https://github.com/user-attachments/assets/3d7e0403-742f-4e13-ab86-eeb79a5f8323" />   

fixes #4820 
closes #5068


<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
