### PR TITLE
Mark first block before matching content as changed in line ranges mapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 <!-- Changes that affect Black's stable style -->
 
 - Don't double-decode input, causing non-UTF-8 files to be corrupted (#4964)
+- Fix `--line-ranges` not marking the first block as changed when it contains
+  modifications before the first matching content (#4997)
 
 ### Preview style
 

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -492,7 +492,7 @@ def _calculate_lines_mappings(
                         original_end=block.a,
                         modified_start=1,
                         modified_end=block.b,
-                        is_changed_block=False,
+                        is_changed_block=True,
                     )
                 )
         else:

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -183,6 +183,23 @@ def test_diffs(lines: list[tuple[int, int]], adjusted: list[tuple[int, int]]) ->
     assert adjusted == adjusted_lines(lines, original_source, modified_source)
 
 
+def test_first_block_changed() -> None:
+    """Changes in the first block (before any matching content) should be included."""
+    original_source = """\
+x = 1
+y = 2
+z = 3
+"""
+    modified_source = """\
+x = 10
+y = 2
+z = 3
+"""
+    # Line 1 was changed, so range (1, 1) should map to (1, 1) in the output.
+    result = adjusted_lines([(1, 1)], original_source, modified_source)
+    assert result == [(1, 1)]
+
+
 @pytest.mark.parametrize(
     "lines,sanitized",
     [


### PR DESCRIPTION
In `_calculate_lines_mappings`, when the first `matching_blocks` entry doesn't start at offset 0, the content before it is different between original and modified. This block should be marked as `is_changed_block=True`, but it's currently marked `False`.

**What goes wrong**

The `adjusted_lines` function uses `is_changed_block` to decide how to remap line ranges:
- For unchanged blocks, it applies a linear offset
- For changed blocks, it expands to the full block extent

When the first changed block is mislabeled as unchanged, a linear offset is applied instead of block expansion. For example, if the original file has 5 lines changed at the top that become 3 lines after formatting, a `--line-ranges 1-5` would compute the new range as `(1, 5)` via offset instead of the correct `(1, 3)` via block expansion. The range extends past the actual modified content.

The `else` branch (for `i > 0`) correctly marks inter-block gaps as `is_changed_block=True` — this first-block case was just missed.
