### PR TITLE
Aggregate escape counts across all f-string segments in normalize_fstring_quotes

### DIFF
--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -288,9 +288,11 @@ def normalize_fstring_quotes(
         # edge case:
         new_segments[-1] = new_segments[-1][:-1] + '\\"'
 
+    orig_escape_count = 0
+    new_escape_count = 0
     for middle, new_segment in zip(middles, new_segments, strict=True):
-        orig_escape_count = middle.value.count("\\")
-        new_escape_count = new_segment.count("\\")
+        orig_escape_count += middle.value.count("\\")
+        new_escape_count += new_segment.count("\\")
 
     if new_escape_count > orig_escape_count:
         return middles, quote  # Do not introduce more escaping


### PR DESCRIPTION
In `normalize_fstring_quotes`, the loop that checks whether quote normalization would introduce more escaping overwrites `orig_escape_count` and `new_escape_count` on each iteration:

```python
for middle, new_segment in zip(middles, new_segments, strict=True):
    orig_escape_count = middle.value.count("\\")
    new_escape_count = new_segment.count("\\")

if new_escape_count > orig_escape_count:
    return middles, quote  # Do not introduce more escaping
```

After the loop finishes, both variables only hold the counts from the **last** segment. For an f-string with multiple text segments (e.g. `f'text1{expr}text2'`), a newly-introduced escape in an earlier segment is ignored entirely.

This changes the loop to aggregate the counts across all segments:

```python
orig_escape_count = 0
new_escape_count = 0
for middle, new_segment in zip(middles, new_segments, strict=True):
    orig_escape_count += middle.value.count("\\")
    new_escape_count += new_segment.count("\\")
```

Note: this function is currently only referenced in a commented-out block in `linegen.py`, so there's no runtime impact today. But the fix is worth having before f-string quote normalization is enabled.
