### PR TITLE
Remove Atom/Nuclide editor integration section (Closes #5002)

### DIFF
--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -407,11 +407,6 @@ Sublime Text, Visual Studio Code and many more), you can use the
 [Python LSP Server](https://github.com/python-lsp/python-lsp-server) with the
 [python-lsp-black](https://github.com/python-lsp/python-lsp-black) plugin.
 
-## Atom/Nuclide
-
-Use [python-black](https://atom.io/packages/python-black) or
-[formatters-python](https://atom.io/packages/formatters-python).
-
 ## Gradle (the build tool)
 
 Use the [Spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle) plugin.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

Closes #5002.
Removes the Atom/Nuclide editor integration section from the documentation, as these projects have been sunset and the linked resources now resolve to the Atom sunset announcement rather than active integration tooling.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
