### PR TITLE
fix: replace 15 bare except clauses with except Exception

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1463,7 +1463,7 @@ def get_features_used(
         ):
             is_star_except = n.children[1].type == token.STAR
 
-            if is_star_except:
+            if is_star_except Exception:
                 features.add(Feature.EXCEPT_STAR)
 
             # Presence of except* pushes as clause 1 index back

--- a/tests/data/cases/allow_empty_first_line.py
+++ b/tests/data/cases/allow_empty_first_line.py
@@ -32,7 +32,7 @@ def foo():
 
             # this should be ok
             a = 123
-        except:
+        except Exception:
 
             """also this"""
             a = 123
@@ -117,7 +117,7 @@ def foo():
 
             # this should be ok
             a = 123
-        except:
+        except Exception:
 
             """also this"""
             a = 123

--- a/tests/data/cases/pep_654.py
+++ b/tests/data/cases/pep_654.py
@@ -16,7 +16,7 @@ except* ValueError:
 try:
     try:
         raise ValueError(42)
-    except:
+    except Exception:
         try:
             raise TypeError(int)
         except* Exception:

--- a/tests/data/cases/pep_654_style.py
+++ b/tests/data/cases/pep_654_style.py
@@ -16,7 +16,7 @@ except *ValueError:
 try:
     try:
         raise ValueError(42)
-    except:
+    except Exception:
         try:
             raise TypeError(int)
         except *(Exception):
@@ -74,7 +74,7 @@ except* ValueError:
 try:
     try:
         raise ValueError(42)
-    except:
+    except Exception:
         try:
             raise TypeError(int)
         except* Exception:

--- a/tests/data/cases/remove_except_types_parens.py
+++ b/tests/data/cases/remove_except_types_parens.py
@@ -3,7 +3,7 @@
 # remains unchanged
 try:
     pass
-except:
+except Exception:
     pass
 
 # remains unchanged
@@ -128,7 +128,7 @@ except* (ValueError,):
 # remains unchanged
 try:
     pass
-except:
+except Exception:
     pass
 
 # remains unchanged

--- a/tests/data/cases/remove_except_types_parens_pre_py314.py
+++ b/tests/data/cases/remove_except_types_parens_pre_py314.py
@@ -3,7 +3,7 @@
 # remains unchanged
 try:
     pass
-except:
+except Exception:
     pass
 
 # remains unchanged
@@ -116,7 +116,7 @@ except* (ValueError,):
 # remains unchanged
 try:
     pass
-except:
+except Exception:
     pass
 
 # remains unchanged


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.