### PR TITLE
docs: mention tools for doctests formatting in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -106,6 +106,20 @@ them in the right place, this detection is not and cannot be perfect. Therefore,
 sometimes have to manually move these comments to the right place after you format your
 codebase with _Black_.
 
+## Does Black format doctests?
+
+No, _Black_ does not format doctests in docstrings. This is a known limitation (see
+[issue #745](https://github.com/psf/black/issues/745) and
+[issue #144](https://github.com/psf/black/issues/144)).
+
+If you need to format doctests, consider using one of these tools:
+
+- [docformatter](https://github.com/PyCQA/docformatter) - formats docstrings to follow
+  PEP 257
+- [doctestfmt](https://github.com/Plazma/doctestfmt) - formats doctest code blocks
+
+These tools can be used alongside _Black_ in your workflow.
+
 ## Can I run Black with PyPy?
 
 Yes, there is support for PyPy 3.8 and higher.


### PR DESCRIPTION
## Summary

This PR addresses issue #3083 by adding a new FAQ entry that documents Black's limitation with doctest formatting and mentions alternative tools users can use.

## Changes

- Added new FAQ section "Does Black format doctests?"
- Explains that Black does not format doctests in docstrings (references issues #745 and #144)
- Mentions two alternative tools:
  - **docformatter** - formats docstrings to follow PEP 257
  - **doctestfmt** - formats doctest code blocks
- Notes that these tools can be used alongside Black

## Motivation

Users often expect Black to format doctests within docstrings, but this is not currently supported. This FAQ entry helps users understand this limitation and provides actionable alternatives.

Closes #3083
