### PR TITLE
Add FAQ entry about doctest formatting

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -106,7 +106,7 @@ Yes, Black cleans up the indentation of docstrings and removes superfluous white
 but it does not format the code inside docstrings (including doctests).
 
 If you need to format doctests, consider using a dedicated tool such as
-[doctestfmt](https://github.com/itsafely/doctestfmt) or
+[blacken-docs](https://github.com/adamchainz/blacken-docs) or
 [pytest-doctestplus](https://pypi.org/project/pytest-doctestplus/) with
 `pytest --doctest-modules --doctest-format=pep8`.
 


### PR DESCRIPTION
Black doesn't format doctests in docstrings. This PR adds a FAQ entry explaining this limitation and pointing users to dedicated doctest formatting tools.

Fixes #3083