### PR TITLE
docs: clarify relationship between Black style and PEP 8

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -6,7 +6,8 @@ _Black_ aims for consistency, generality, readability and reducing git diffs. Si
 language constructs are formatted with similar rules. Style configuration options are
 deliberately limited and rarely added. Previous formatting is taken into account as
 little as possible, with rare exceptions like the magic trailing comma. The coding style
-used by _Black_ can be viewed as a strict subset of PEP 8.
+used by _Black_ follows PEP 8 in spirit and enforces a consistent subset of its
+formatting recommendations. It does not implement every style rule covered by PEP 8.
 
 This document describes the current formatting style. If you're interested in trying out
 where the style is heading, see [future style](./future_style.md) and try running


### PR DESCRIPTION
### Description
This updates the sentence in `current_style.md` that currently says Black's style is a "strict subset of PEP 8".

The new wording makes the intent explicit:
- Black follows PEP 8 in spirit
- it enforces a consistent subset of PEP 8 formatting recommendations
- it does not implement every style rule covered by PEP 8

This addresses ambiguity reported in #1272.

Fixes #1272

### Checklist
- [x] Add new / update outdated documentation?