### PR TITLE
Revert "Bump hatch from 1.15.1 to 1.16.4"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ d = ["aiohttp>=3.10"]
 jupyter = ["ipython>=7.8.0", "tokenize-rt>=3.2.0"]
 
 [dependency-groups]
-build = ["hatch==1.16.4", "hatch-fancy-pypi-readme", "hatch-vcs>=0.3.0", "virtualenv<21.0.0"]
+build = ["hatch==1.15.1", "hatch-fancy-pypi-readme", "hatch-vcs>=0.3.0", "virtualenv<21.0.0"]
 wheels = ["cibuildwheel==3.3.1", "pypyp"]
 binary = ["pyinstaller", "wheel>=0.45.1"]
 


### PR DESCRIPTION
Reverts psf/black#5020

Bumping Hatch causes Docker builds to fail with `hatchling.plugin.exceptions.UnknownPluginError: Unknown build hook: mypyc`. I haven't been able to investigate further yet