### PR TITLE
docs: fix macOS spelling in config path docs

### DIFF
--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -490,7 +490,7 @@ and only if _Black_ doesn't find any configuration as mentioned above. Depending
 operating system, this configuration file should be stored as:
 
 - Windows: `~\.black`
-- Unix-like (Linux, MacOS, etc.): `$XDG_CONFIG_HOME/black` (`~/.config/black` if the
+- Unix-like (Linux, macOS, etc.): `$XDG_CONFIG_HOME/black` (`~/.config/black` if the
   `XDG_CONFIG_HOME` environment variable is not set)
 
 Note that these are paths to the TOML file itself (meaning that they shouldn't be named


### PR DESCRIPTION
### Description
Fix the macOS spelling in the config path documentation.

No issue is needed for this docs-only wording fix.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?