### PR TITLE
Fix GitHub capitalization in diff-shades helper docstring

### DIFF
--- a/scripts/diff_shades_gha_helper.py
+++ b/scripts/diff_shades_gha_helper.py
@@ -1,4 +1,4 @@
-"""Helper script for psf/black's diff-shades Github Actions integration.
+"""Helper script for psf/black's diff-shades GitHub Actions integration.
 
 diff-shades is a tool for analyzing what happens when you run Black on
 OSS code capturing it for comparisons or other usage. It's used here to


### PR DESCRIPTION
### Description

Fix the capitalization of GitHub in the diff-shades helper docstring.

Summary
- Fix a non-user-facing typo in an internal helper docstring.

Related issue
- N/A, trivial wording fix.

Guideline alignment
- Non-user-facing change, so no `CHANGES.md` entry is needed.

Validation/testing note
- Not run; comment/docstring-only change.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?