### PR TITLE
Fix formatting wording in split heuristics comments

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -904,7 +904,7 @@ def can_be_split(line: Line) -> bool:
     """Return False if the line cannot be split *for sure*.
 
     This is not an exhaustive search but a cheap heuristic that we can use to
-    avoid some unfortunate formattings (mostly around wrapping unsplittable code
+    avoid some unfortunate formatting (mostly around wrapping unsplittable code
     in unnecessary parentheses).
     """
     leaves = line.leaves
@@ -942,7 +942,7 @@ def can_omit_invisible_parens(
 ) -> bool:
     """Does `rhs.body` have a shape safe to reformat without optional parens around it?
 
-    Returns True for only a subset of potentially nice looking formattings but
+    Returns True for only a subset of potentially nice looking formatting but
     the point is to not return false positives that end up producing lines that
     are too long.
     """


### PR DESCRIPTION
### Description

Fix the wording in two nearby comments/docstrings by changing `formattings` to `formatting`.

Summary
- Correct a non-user-facing typo in `src/black/lines.py`.

Related issue
- N/A, trivial wording fix.

Guideline alignment
- Non-user-facing change, so no `CHANGES.md` entry is needed.

Validation/testing note
- Not run; comment/docstring-only change.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?