### PR TITLE
Fix blackd error handling: split SourceASTParseError from ASTSafetyError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,9 +40,16 @@
 
 <!-- Changes to Black's terminal output and error messages -->
 
+- Add `SourceASTParseError` to distinguish source parse failures from internal safety
+  errors, improving error reporting when Black's lenient parser accepts input that
+  `ast.parse()` rejects (#5080)
+
 ### _Blackd_
 
 <!-- Changes to blackd -->
+
+- Return HTTP 400 (Bad Request) for source parse failures instead of HTTP 500, keeping
+  HTTP 500 only for genuine internal safety errors (#5080)
 
 ### Integrations
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -66,6 +66,7 @@ from black.output import color_diff, diff, dump_to_file, err, ipynb_diff, out
 from black.parsing import (  # noqa F401
     ASTSafetyError,
     InvalidInput,
+    SourceASTParseError,
     lib2to3_parse,
     parse_ast,
     stringify_ast,
@@ -1086,6 +1087,8 @@ def check_stability_and_equivalence(
     """
     try:
         assert_equivalent(src_contents, dst_contents)
+    except SourceASTParseError:
+        raise
     except ASTSafetyError:
         if _target_versions_exceed_runtime(mode.target_versions):
             raise ASTSafetyError(
@@ -1632,7 +1635,7 @@ def assert_equivalent(src: str, dst: str) -> None:
     try:
         src_ast = parse_ast(src)
     except Exception as exc:
-        raise ASTSafetyError(
+        raise SourceASTParseError(
             "cannot use --safe with this file; failed to parse source file AST: "
             f"{exc}\n"
             "This could be caused by running Black with an older Python version "

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -106,6 +106,15 @@ class ASTSafetyError(Exception):
     """Raised when Black's generated code is not equivalent to the old AST."""
 
 
+class SourceASTParseError(Exception):
+    """Raised when the source file cannot be parsed by ast.parse().
+
+    This is not a bug in Black — Black's lib2to3-based parser is more lenient
+    than Python's ast.parse(), so it may accept code that ast.parse() rejects.
+    In blackd, this should be reported as a 400 Bad Request.
+    """
+
+
 def _parse_single_version(
     src: str, version: tuple[int, int], *, type_comments: bool
 ) -> ast.AST:

--- a/src/blackd/__init__.py
+++ b/src/blackd/__init__.py
@@ -206,6 +206,8 @@ async def handle(
         return web.Response(status=204, headers=headers)
     except black.InvalidInput as e:
         return web.Response(status=400, headers=headers, text=str(e))
+    except black.SourceASTParseError as e:
+        return web.Response(status=400, headers=headers, text=str(e))
     except web.HTTPException:
         raise
     except Exception as e:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -38,7 +38,7 @@ from black.cache import FileData, get_cache_dir, get_cache_file
 from black.debug import DebugVisitor
 from black.mode import Mode, Preview
 from black.output import color_diff, diff
-from black.parsing import ASTSafetyError
+from black.parsing import ASTSafetyError, SourceASTParseError
 from black.report import Report
 from black.strings import lines_with_leading_tabs_expanded
 
@@ -3212,7 +3212,7 @@ class TestASTSafety(BlackBaseTestCase):
         )
 
     def test_equivalency_ast_parse_failure_includes_error(self) -> None:
-        with pytest.raises(ASTSafetyError) as err:
+        with pytest.raises(SourceASTParseError) as err:
             black.assert_equivalent("a«»a  = 1", "a«»a  = 1")
 
         err.match("--safe")


### PR DESCRIPTION
## Summary

Per @JelleZijlstra's review feedback on #5074, this PR splits the error handling instead of treating all ASTSafetyError as 400.

### Changes

1. **New exception: `SourceASTParseError`** (`src/black/parsing.py`)
   - Raised when the source file cannot be parsed by `ast.parse()` but was accepted by Black's more lenient lib2to3 parser
   - This is a user input issue, not a Black bug

2. **Updated `assert_equivalent`** (`src/black/__init__.py`)
   - Source AST parse failure → `SourceASTParseError` (user input issue)
   - Dest AST parse failure → `ASTSafetyError` (Black bug → 500)
   - Non-equivalent output → `ASTSafetyError` (Black bug → 500)

3. **Updated blackd** (`src/blackd/__init__.py`)
   - `SourceASTParseError` → 400 Bad Request
   - `ASTSafetyError` → 500 Internal Server Error (unchanged, caught by generic Exception handler)

### Closes
Fixes #3616

### Analysis of all ASTSafetyError uses
| Location | Cause | Error type | blackd status |
|----------|-------|-----------|---------------|
| `assert_equivalent` src AST parse fail | User input (lenient parser) | `SourceASTParseError` | 400 |
| `assert_equivalent` dest AST parse fail | Black bug | `ASTSafetyError` | 500 |
| `assert_equivalent` src ≠ dst | Black bug | `ASTSafetyError` | 500 |
| `check_stability_and_equivalence` re-raise | Depends on underlying | Propagated | 400 or 500 |