### PR TITLE
docs: update SublimeText section to note sublack is archived

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,8 @@
 
 - Use "Version X.Y.Z" headings in changelog for stable permalink anchors on ReadTheDocs
   (#5063)
+- Note in the editor integrations that the SublimeText `sublack` plugin is archived
+  and unmaintained (#5082)
 
 ## Version 26.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,8 +55,8 @@
 
 - Use "Version X.Y.Z" headings in changelog for stable permalink anchors on ReadTheDocs
   (#5063)
-- Note in the editor integrations that the SublimeText `sublack` plugin is archived
-  and unmaintained (#5082)
+- Note in the editor integrations that the SublimeText `sublack` plugin is archived and
+  unmaintained (#5082)
 
 ## Version 26.3.1
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -397,8 +397,14 @@ close and reopen your File, _Black_ will be done with its job.
 
 ## SublimeText
 
-For SublimeText 3, use [sublack plugin](https://github.com/jgirardet/sublack). For
-higher versions, it is recommended to use [LSP](#python-lsp-server) as documented below.
+Use [LSP](#python-lsp-server) with the
+[python-lsp-black](https://github.com/python-lsp/python-lsp-black) plugin as documented
+below. This is the recommended approach for all versions of Sublime Text.
+
+```{note}
+The [sublack plugin](https://github.com/jgirardet/sublack) that was previously
+recommended here is no longer maintained (the repository has been archived).
+```
 
 ## Python LSP Server
 


### PR DESCRIPTION
## Summary

- The [sublack plugin](https://github.com/jgirardet/sublack) repository has been archived and is no longer maintained, but the SublimeText editor integration docs still recommend it as the primary option for SublimeText 3.
- Updated the SublimeText section in `docs/integrations/editors.md` to recommend the LSP-based approach (python-lsp-black) as the primary option for all Sublime Text versions, and added a note marking sublack as archived/unmaintained.

## Test plan

- [ ] Verify the docs build successfully (`tox -e docs` or equivalent)
- [ ] Confirm the `{note}` directive renders correctly in the built documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)