### PR TITLE
docs: fix formatting wording in split heuristic docstring

### DIFF
--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1315,7 +1315,7 @@ def can_be_split(line: Line) -> bool:
     """Return False if the line cannot be split *for sure*.
 
     This is not an exhaustive search but a cheap heuristic that we can use to
-    avoid some unfortunate formattings (mostly around wrapping unsplittable code
+    avoid some unfortunate formatting (mostly around wrapping unsplittable code
     in unnecessary parentheses).
     """
     leaves = line.leaves


### PR DESCRIPTION
### Description

- fix `formattings` -> `formatting` in a docstring sentence

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

#### Notes
- This is a docs/comment wording fix only.
- No behavior change.
- No tests were run for this docstring-only change.
- No changelog entry needed for this non-user-facing wording correction.
