### PR TITLE
docs: fix article in EPUB identifier comment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,7 +205,7 @@ epub_author = author
 epub_publisher = author
 epub_copyright = copyright
 
-# The unique identifier of the text. This can be a ISBN number
+# The unique identifier of the text. This can be an ISBN number
 # or the project homepage.
 #
 # epub_identifier = ''


### PR DESCRIPTION
### Description
Fixes a grammar typo in a documentation configuration comment in `docs/conf.py`:
- "a ISBN number" -> "an ISBN number"

### Checklist - did you ...
- [x] Implement any code style changes under the `--preview` style, following the stability policy? (N/A: no code style change)
- [x] Add an entry in `CHANGES.md` if necessary? (N/A: docs comment typo fix only)
- [x] Add / update tests if necessary? (N/A: docs comment typo fix only)
- [x] Add new / update outdated documentation?
