### PR TITLE
Fix crash when formatting `case case if ...:` with short line lengths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash when formatting `case case if ...:` (match/case with a pattern named `case`
+  and a guard clause) at short line lengths (#4280)
 - Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
   both new syntactic features in Python 3.15 (#5048)
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1589,6 +1589,20 @@ def normalize_invisible_parens(
 
             elif (
                 isinstance(child, Leaf)
+                and child.value == "case"
+                and child.next_sibling is not None
+                and child.next_sibling.type == syms.guard
+            ):
+                # A special patch for "case case if ...:" scenario. The pattern
+                # "case" must be wrapped for line splitting, but we must not
+                # also wrap the guard at the case_block level, which produces
+                # invalid syntax like "case case (\n if True\n):".
+                wrap_in_parentheses(node, child, visible=False)
+                check_lpar = False
+                continue
+
+            elif (
+                isinstance(child, Leaf)
                 and child.next_sibling is not None
                 and child.next_sibling.type == token.COLON
                 and child.value == "case"

--- a/tests/data/cases/pattern_matching_case_guard_crash.py
+++ b/tests/data/cases/pattern_matching_case_guard_crash.py
@@ -1,0 +1,38 @@
+# flags: --minimum-version=3.10 --line-length=1
+
+# Regression test for https://github.com/psf/black/issues/4280
+# "case case if ...:" crashed with short line lengths.
+
+match test:
+    case case if True:
+        pass
+
+match test:
+    case case if x and y:
+        pass
+
+match test:
+    case case if (some_func()):
+        pass
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/4280
+# "case case if ...:" crashed with short line lengths.
+
+match test:
+    case case if True:
+        pass
+
+match test:
+    case case if (
+        x
+        and y
+    ):
+        pass
+
+match test:
+    case case if (
+        some_func()
+    ):
+        pass


### PR DESCRIPTION
### Description

Fixes #4280.

When a match/case statement uses the soft keyword `case` as a pattern name with a guard clause (`case case if True:`), Black crashed with `Cannot parse` at short line lengths (≤11).

**Root cause:** In `normalize_invisible_parens`, after the keyword `case` sets `check_lpar=True`, the pattern leaf `case` is wrapped in invisible parens. But because the pattern's value is also `"case"` (matching `parens_after`), `check_lpar` remained `True`, causing the guard node to also be incorrectly wrapped in invisible parens at the `case_block` level. This produced invalid syntax:

```python
# Before (invalid output that failed to re-parse):
match test:
    case case (
        if True
    ):
        pass

# After (correct output):
match test:
    case case if True:
        pass
```

**Fix:** Add a branch in `normalize_invisible_parens` that detects when a `"case"`-valued pattern leaf is followed by a guard node. It wraps the pattern in invisible parens (for line splitting) then resets `check_lpar` and continues, preventing the guard from being double-wrapped.

**Validation:**
- All 405 existing tests pass
- New regression test covers `case case if True:`, `case case if x and y:`, and `case case if (some_func()):` at `--line-length=1`
- Verified no crash at any line length from 1 to 88
- Verified output is valid Python at all line lengths

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?