### PR TITLE
Prevent string merger from creating unsplittable long lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Prevent string merger from creating unsplittable long lines when a pragma comment
+  (e.g. `# type: ignore`) follows the closing bracket (#5096)
 - Improve heuristics around whether blank lines should appear before, within and after
   groups of same-name decorated functions (such as `@overload` groups) in `.pyi` stub
   files (#5021)

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -845,6 +845,24 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
                 f"Not enough strings to merge (num_of_strings={num_of_strings})."
             )
 
+        # Also check for pragma comments on tokens that follow the string
+        # group (e.g. a closing bracket).  Merging strings when a pragma
+        # comment like `# type: ignore` follows would produce an unsplittable
+        # long line.
+        is_valid_index = is_valid_index_factory(line.leaves)
+        next_idx = string_idx + num_of_strings
+        while is_valid_index(next_idx):
+            next_leaf = line.leaves[next_idx]
+            if id(next_leaf) in line.comments:
+                if contains_pragma_comment(line.comments[id(next_leaf)]):
+                    return TErr(
+                        "Cannot merge strings when a pragma comment follows"
+                        " the string group."
+                    )
+            if next_leaf.type not in CLOSING_BRACKETS:
+                break
+            next_idx += 1
+
         if num_of_inline_string_comments > 1:
             return TErr(
                 f"Too many inline string comments ({num_of_inline_string_comments})."

--- a/tests/data/cases/preview_long_strings__regression.py
+++ b/tests/data/cases/preview_long_strings__regression.py
@@ -562,6 +562,14 @@ s = (
 
 s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:\'{my_dict["foo"]}\''
 
+# Regression test for https://github.com/psf/black/issues/4510.
+# Don't merge multi-line strings when a pragma comment follows.
+(
+    "A very very very very very very very very very very very very long string "
+    "annotated with a type ignore pragma gets merged into a single very long line "
+    "which is against the line length rule."
+)  # type: ignore
+
 
 # output
 
@@ -1252,3 +1260,11 @@ s = (
     "Lorem Ipsum is simply dummy text of the printing and typesetting"
     f' industry:\'{my_dict["foo"]}\''
 )
+
+# Regression test for https://github.com/psf/black/issues/4510.
+# Don't merge multi-line strings when a pragma comment follows.
+(
+    "A very very very very very very very very very very very very long string "
+    "annotated with a type ignore pragma gets merged into a single very long line "
+    "which is against the line length rule."
+)  # type: ignore


### PR DESCRIPTION
## Summary

Fixes #4510.

When multi-line strings are followed by a pragma comment (like `# type: ignore`) on a surrounding bracket, the `StringMerger` would merge them into a single long line. Because pragma comments prevent line splitting, this produced lines that violate the line length limit with no way to fix them.

**Before** (`black --unstable`):
```python
# Input:
(
    "A very very very very very very very very very very long string "
    "continued on the next line."
)  # type: ignore

# Output (one huge unsplittable line):
("A very very very very very very very very very very long string continued on the next line.")  # type: ignore
```

**After:** The multi-line string is left as-is, preserving the line length constraint.

## Root Cause

`_validate_msg()` in `StringMerger` only checked for pragma comments (`# type: ignore`, `# noqa`, `# pylint:`) on the string leaves themselves. It did not check surrounding tokens like closing brackets `)`, `]`, `}`. The pragma comment on `)` was invisible to the validation.

## Fix

Extended `_validate_msg()` to also scan tokens following the string group (walking through closing brackets) for pragma comments. If any are found, the merge is refused.

## Test plan

- Added regression test in `tests/data/cases/preview_long_strings__regression.py`
- All 209 existing formatting tests pass
- Verified both examples from #4510
- Verified normal string merging (without pragma comments) still works