### PR TITLE
Fix crash when f-string follows # fmt: off inside brackets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash when an f-string follows a `# fmt: off` comment inside brackets (#5097)
 - Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
   both new syntactic features in Python 3.15 (#5048)
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -575,6 +575,12 @@ class LineGenerator(Visitor[Line]):
         yield from self.visit_default(node)
 
     def visit_fstring(self, node: Node) -> Iterator[Line]:
+        # If the fstring was converted to a STANDALONE_COMMENT by
+        # normalize_fmt_off (e.g. it was inside a # fmt: off block),
+        # skip the fstring-to-string conversion and just visit normally.
+        if any(child.type == STANDALONE_COMMENT for child in node.children):
+            yield from self.visit_default(node)
+            return
         # currently we don't want to format and split f-strings at all.
         string_leaf = fstring_tstring_to_string(node)
         node.replace(string_leaf)
@@ -590,6 +596,11 @@ class LineGenerator(Visitor[Line]):
         yield from self.visit_STRING(string_leaf)
 
     def visit_tstring(self, node: Node) -> Iterator[Line]:
+        # If the tstring was converted to a STANDALONE_COMMENT by
+        # normalize_fmt_off, skip the conversion and just visit normally.
+        if any(child.type == STANDALONE_COMMENT for child in node.children):
+            yield from self.visit_default(node)
+            return
         # currently we don't want to format and split t-strings at all.
         string_leaf = fstring_tstring_to_string(node)
         node.replace(string_leaf)

--- a/tests/data/cases/fmtonoff6.py
+++ b/tests/data/cases/fmtonoff6.py
@@ -27,3 +27,63 @@ dependencies = {
     f"{x}"
     # fmt: on
 ]
+
+# Same as above but unindented inside brackets.
+(
+# fmt: off
+f"""
+"""
+# fmt: on
+)
+
+[
+# fmt: off
+f"{x}"
+# fmt: on
+]
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/2478.
+def foo():
+    arr = (
+        (3833567325051000, 5, 1, 2, 4229.25, 6, 0),
+        # fmt: off
+    )
+
+
+# Regression test for https://github.com/psf/black/issues/3458.
+dependencies = {
+    a: b,
+    # fmt: off
+}
+
+
+# Regression test for https://github.com/psf/black/issues/4511.
+# fmt: off inside brackets with an f-string should not crash.
+(
+    # fmt: off
+    f"""
+"""
+    # fmt: on
+)
+
+[
+    # fmt: off
+    f"{x}"
+    # fmt: on
+]
+
+# Same as above but unindented inside brackets.
+(
+    # fmt: off
+f"""
+"""
+    # fmt: on
+)
+
+[
+    # fmt: off
+f"{x}"
+    # fmt: on
+]

--- a/tests/data/cases/fmtonoff6.py
+++ b/tests/data/cases/fmtonoff6.py
@@ -11,3 +11,19 @@ dependencies = {
     a: b,
     # fmt: off
 }
+
+
+# Regression test for https://github.com/psf/black/issues/4511.
+# fmt: off inside brackets with an f-string should not crash.
+(
+    # fmt: off
+    f"""
+"""
+    # fmt: on
+)
+
+[
+    # fmt: off
+    f"{x}"
+    # fmt: on
+]


### PR DESCRIPTION
## Summary

Fixes #4511.

Black crashes with an `AssertionError` when formatting code that contains an f-string after a `# fmt: off` comment inside brackets:

```python
(
# fmt: off
f"""
"""
# fmt: on
)
```

Error:
```
error: cannot format: {' ', 'r', 'f', 'o', ':', 'm', 't', '#', '\n'} is NOT a subset of {'U', 'r', 'f', 'u', 'F', 'R', 'b', 'B'}.
```

## Root Cause

`normalize_fmt_off` runs before line generation and converts content between `# fmt: off`/`# fmt: on` into `STANDALONE_COMMENT` nodes. When this content is inside an f-string node, the f-string's children (FSTRING_START, FSTRING_MIDDLE, FSTRING_END) get replaced with a single STANDALONE_COMMENT leaf.

When `visit_fstring` is later called for this modified node, it calls `fstring_tstring_to_string()` which does `str(node)[len(node.prefix):]`. This produces a value like `# fmt: off\nf"""\n"""` — the comment text becomes part of the "string value", which fails the string prefix assertion.

## Fix

Added a guard in `visit_fstring` (and `visit_tstring`) to detect when the node contains a STANDALONE_COMMENT child (indicating it was modified by `normalize_fmt_off`). In that case, fall back to `visit_default` instead of attempting the f-string-to-string conversion.

## Test plan

- Added regression tests in `tests/data/cases/fmtonoff6.py` for both triple-quoted and single-line f-strings with `# fmt: off` inside brackets
- All 209 existing formatting tests pass
- Verified the fix produces idempotent output