### PR TITLE
Fix typo in current_style.md

### DIFF
--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -489,8 +489,8 @@ AST of the target. There are three limited cases in which the AST does differ:
    whitespace anyway.
 
 1. _Black_ manages optional parentheses for some statements. In the case of the `del`
-   statement, presence of wrapping parentheses or lack thereof changes the resulting
-   AST but is semantically equivalent in the interpreter.
+   statement, presence of wrapping parentheses or lack thereof changes the resulting AST
+   but is semantically equivalent in the interpreter.
 
 1. _Black_ might move comments around, which includes type comments. Those are part of
    the AST as of Python 3.8. While the tool implements a number of special cases for

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -489,7 +489,7 @@ AST of the target. There are three limited cases in which the AST does differ:
    whitespace anyway.
 
 1. _Black_ manages optional parentheses for some statements. In the case of the `del`
-   statement, presence of wrapping parentheses or lack of thereof changes the resulting
+   statement, presence of wrapping parentheses or lack thereof changes the resulting
    AST but is semantically equivalent in the interpreter.
 
 1. _Black_ might move comments around, which includes type comments. Those are part of


### PR DESCRIPTION
### Description

Small docs typo fix in the Black code style docs

### Checklist

- [X] Implement any code style changes under the `--preview` style, following the stability policy?
- [X] Add an entry in `CHANGES.md` if necessary?
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation?

Docs typo only; I believe this should not need a changelog entry.