### PR TITLE
docs: fix doctest formatting typo

### DIFF
--- a/docs/integrations/doctest_formatting.md
+++ b/docs/integrations/doctest_formatting.md
@@ -14,7 +14,7 @@ documentation files.
 
 ## blacken-docs
 
-[`blacken-docs`](https://pypi.org/project/blacken-docs/) is primarly used to apply
+[`blacken-docs`](https://pypi.org/project/blacken-docs/) is primarily used to apply
 _Black_ formatting to code in documentation files (e.g. `.rst`, `.md`, `.tex`).
 
 `blacken-docs` supports the following:


### PR DESCRIPTION
## Summary
- fix a typo in the doctest formatting integration docs

## Related issue
- N/A (trivial docs typo)

## Validation
- `git diff --check`
