### PR TITLE
docs: fix line-splitting comment wording

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@
 <!-- Major changes to documentation and policies. Small docs changes
      don't need a changelog entry. -->
 
+- Fix wording in line-splitting comments (#5106)
 - Use "Version X.Y.Z" headings in changelog for stable permalink anchors on ReadTheDocs
   (#5063)
 - Note in the editor integrations that the SublimeText `sublack` plugin is archived and

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1331,7 +1331,7 @@ def can_be_split(line: Line) -> bool:
     """Return False if the line cannot be split *for sure*.
 
     This is not an exhaustive search but a cheap heuristic that we can use to
-    avoid some unfortunate formattings (mostly around wrapping unsplittable code
+    avoid some unfortunate formatting (mostly around wrapping unsplittable code
     in unnecessary parentheses).
     """
     leaves = line.leaves
@@ -1369,7 +1369,7 @@ def can_omit_invisible_parens(
 ) -> bool:
     """Does `rhs.body` have a shape safe to reformat without optional parens around it?
 
-    Returns True for only a subset of potentially nice looking formattings but
+    Returns True for only a subset of potentially nice-looking formatting but
     the point is to not return false positives that end up producing lines that
     are too long.
     """


### PR DESCRIPTION
## Summary
- fix wording in line-splitting comments

## Related issue
- N/A (trivial docs/comment fix)

## Guideline alignment
- reviewed `CONTRIBUTING.md`
- kept the change to one source file comment block with no behavior impact

## Validation
- `git diff --check`
