### PR TITLE
Add validation for --line-ranges values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
   different working directories in the same process. The CWD fallback (used when no
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
   directory gets the correct `pyproject.toml` (#5152)
+- Add validation for --line-ranges values (#5107)
 
 ### Packaging
 

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -36,6 +36,16 @@ def parse_line_ranges(line_ranges: Sequence[str]) -> list[tuple[int, int]]:
                 f" {lines_str!r}"
             ) from None
         else:
+            if start < 1 or end < 1:
+                raise ValueError(
+                    "Incorrect --line-ranges value, "
+                    f"expect positive integers, found {lines_str!r}"
+                )
+            if start > end:
+                raise ValueError(
+                    "Incorrect --line-ranges value, expect START <= END, "
+                    f"found {lines_str!r}"
+                )
             lines.append((start, end))
     return lines
 

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -2,7 +2,33 @@
 
 import pytest
 
-from black.ranges import adjusted_lines, sanitized_lines
+from black.ranges import adjusted_lines, parse_line_ranges, sanitized_lines
+
+
+@pytest.mark.parametrize(
+    "lines_str, expected",
+    [
+        (["1-5"], [(1, 5)]),
+        (["1-1"], [(1, 1)]),
+        (["1-3", "5-7"], [(1, 3), (5, 7)]),
+    ],
+)
+def test_parse_line_ranges_valid(lines_str, expected):
+    assert parse_line_ranges(lines_str) == expected
+
+
+@pytest.mark.parametrize(
+    "lines_str",
+    [
+        ["5-3"],
+        ["0-5"],
+        ["-1-5"],
+        ["5-0"],
+    ],
+)
+def test_parse_line_ranges_invalid(lines_str):
+    with pytest.raises(ValueError, match="Incorrect --line-ranges"):
+        parse_line_ranges(lines_str)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -13,7 +13,9 @@ from black.ranges import adjusted_lines, parse_line_ranges, sanitized_lines
         (["1-3", "5-7"], [(1, 3), (5, 7)]),
     ],
 )
-def test_parse_line_ranges_valid(lines_str, expected):
+def test_parse_line_ranges_valid(
+    lines_str: list[str], expected: list[tuple[int, int]]
+) -> None:
     assert parse_line_ranges(lines_str) == expected
 
 
@@ -26,7 +28,7 @@ def test_parse_line_ranges_valid(lines_str, expected):
         ["5-0"],
     ],
 )
-def test_parse_line_ranges_invalid(lines_str):
+def test_parse_line_ranges_invalid(lines_str: list[str]) -> None:
     with pytest.raises(ValueError, match="Incorrect --line-ranges"):
         parse_line_ranges(lines_str)
 


### PR DESCRIPTION
## Summary

The `parse_line_ranges` function previously accepted invalid ranges without raising errors:
- `"5-3"` where START > END
- `"0-5"` or `"-1-5"` with non-positive line numbers

This adds validation to raise a clear `ValueError` with a descriptive message when invalid ranges are provided, instead of silently accepting them and producing unexpected formatting behavior.

## Test Plan

Added `test_parse_line_ranges_valid` and `test_parse_line_ranges_invalid` parametrized tests in `tests/test_ranges.py` covering:
- Valid ranges: single, same start/end, multiple ranges
- Invalid ranges: reversed (start > end), zero, negative