### PR TITLE
fix(fmt: skip): respect skip directive on multi-line compound statements

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -643,7 +643,7 @@ def _generate_ignored_nodes_from_fmt_skip(
     if not comments or comment.value != comments[0].value:
         return
 
-    if not prev_sibling and parent:
+    if not prev_sibling and parent and parent.type != syms.suite:
         prev_sibling = parent.prev_sibling
 
     if prev_sibling is not None:


### PR DESCRIPTION
## Summary

Fixes #5112, closes #5117
fixes #5122, closes #5123

When `# fmt: skip` is placed on the colon line of a multi-line class (or def/if) statement, Black still reformatted it — collapsing multi-line type parameters onto a single line.

**Root cause:** In `_generate_ignored_nodes_from_fmt_skip()`, line 647 unconditionally sets `prev_sibling = parent.prev_sibling` when the leaf (NEWLINE) has no previous sibling. This causes the function to take the **per-sibling traversal path** (which stops at any leaf containing a newline in its prefix) instead of the **suite-sibling collection path** (the `elif` branch at line 738, which correctly collects ALL previous siblings of the suite node).

For a multi-line class like:
```python
class Foo(Base[\
    "A", "B"\
]):  # fmt: skip
```
The traversal starts at `:` and collects `]`, `)`, `:` — then hits `]` whose prefix contains `\n` (end of line), stopping early. The entire class header (`class Foo(Base[`, type params) is never marked as ignored, so Black reformats it.

**Fix:** Add `parent.type != syms.suite` condition on line 646 so that suite NEWLINEs fall through to the `elif` branch that properly collects all statement header nodes.

## Test plan

- [x] Reproduced issue #5112 with the exact example from the bug report — now left unchanged
- [x] Verified existing `# fmt: skip` cases still work (assignments, one-line compounds, etc.)
- [x] All 210 format tests pass
- [x] All 19 fmtskip format tests pass
- [x] All 3 skip-related unit tests pass