### PR TITLE
docs: update deprecated PEP URLs to peps.python.org

### DIFF
--- a/docs/guides/using_black_with_other_tools.md
+++ b/docs/guides/using_black_with_other_tools.md
@@ -138,8 +138,8 @@ profile = black
 
 [pycodestyle](https://pycodestyle.pycqa.org/) is a code linter. It warns you of syntax
 errors, possible bugs, stylistic errors, etc. For the most part, pycodestyle follows
-[PEP 8](https://www.python.org/dev/peps/pep-0008/) when warning about stylistic errors.
-There are a few deviations that cause incompatibilities with _Black_.
+[PEP 8](https://peps.python.org/pep-0008/) when warning about stylistic errors. There
+are a few deviations that cause incompatibilities with _Black_.
 
 #### Configuration
 

--- a/docs/the_black_code_style/current_style.md
+++ b/docs/the_black_code_style/current_style.md
@@ -205,7 +205,7 @@ standalone comments that immediately precede the given function/class.
 
 _Black_ will enforce single empty lines between a class-level docstring and the first
 following field or method. This conforms to
-[PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings).
+[PEP 257](https://peps.python.org/pep-0257/#multi-line-docstrings).
 
 _Black_ won't insert empty lines after function docstrings unless that empty line is
 required due to an inner function starting immediately after.
@@ -263,10 +263,10 @@ _Black_ to merge consecutive string literals that ended up on the same line (see
 
 Why settle on double quotes? They anticipate apostrophes in English text. They match the
 docstring standard described in
-[PEP 257](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring). An empty
-string in double quotes (`""`) is impossible to confuse with a one double-quote
-regardless of fonts and syntax highlighting used. On top of this, double quotes for
-strings are consistent with C which Python interacts a lot with.
+[PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring). An empty string in
+double quotes (`""`) is impossible to confuse with a one double-quote regardless of
+fonts and syntax highlighting used. On top of this, double quotes for strings are
+consistent with C which Python interacts a lot with.
 
 On certain keyboard layouts like US English, typing single quotes is a bit easier than
 double quotes. The latter requires use of the Shift key. My recommendation here is to
@@ -295,7 +295,7 @@ parts and uppercase letters for the digits themselves: `0xAB` instead of `0XAB` 
 
 _Black_ will break a line before a binary operator when splitting a block of code over
 multiple lines. This is so that _Black_ is compliant with the recent changes in the
-[PEP 8](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator)
+[PEP 8](https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator)
 style guide, which emphasizes that this approach improves readability.
 
 Almost all operators will be surrounded by single spaces, the only exceptions are unary
@@ -321,7 +321,7 @@ h = config['base'] ** 2
 ### Slices
 
 PEP 8
-[recommends](https://www.python.org/dev/peps/pep-0008/#whitespace-in-expressions-and-statements)
+[recommends](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements)
 to treat `:` in slices as a binary operator with the lowest priority, and to leave an
 equal amount of space on either side, except if a parameter is omitted (e.g.
 `ham[1 + 1 :]`). It recommends no spaces around `:` operators for "simple expressions"
@@ -395,7 +395,7 @@ be written in C, or they might be third-party, or their implementation may be ov
 dynamic, and so on).
 
 To solve this,
-[stub files with the `.pyi` file extension](https://www.python.org/dev/peps/pep-0484/#stub-files)
+[stub files with the `.pyi` file extension](https://peps.python.org/pep-0484/#stub-files)
 can be used to describe typing information for an external module. Those stub files omit
 the implementation of classes and functions they describe, instead they only contain the
 structure of the file (listing globals, functions, and classes with their members). The

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -475,10 +475,9 @@ code in compliance with many other _Black_ formatted projects.
 
 ### What on Earth is a `pyproject.toml` file?
 
-[PEP 518](https://www.python.org/dev/peps/pep-0518/) defines `pyproject.toml` as a
-configuration file to store build system requirements for Python projects. With the help
-of tools like [Poetry](https://python-poetry.org/),
-[Flit](https://flit.readthedocs.io/en/latest/), or
+[PEP 518](https://peps.python.org/pep-0518/) defines `pyproject.toml` as a configuration
+file to store build system requirements for Python projects. With the help of tools like
+[Poetry](https://python-poetry.org/), [Flit](https://flit.readthedocs.io/en/latest/), or
 [Hatch](https://hatch.pypa.io/latest/) it can fully replace the need for `setup.py` and
 `setup.cfg` files.
 

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -64,7 +64,7 @@ def lines_with_leading_tabs_expanded(s: str) -> list[str]:
 
 
 def fix_multiline_docstring(docstring: str, prefix: str) -> str:
-    # https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
+    # https://peps.python.org/pep-0257/#handling-docstring-indentation
     assert docstring, "INTERNAL ERROR: Multiline docstrings cannot be empty"
     lines = lines_with_leading_tabs_expanded(docstring)
     # Determine minimum indentation (first line doesn't count):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Supersedes #5110

The python.org/dev/peps/ URLs are legacy and redirect to peps.python.org. Use the canonical URLs to
match the convention already used elsewhere in the codebase (e.g. CHANGES.md, src/black/files.py,
src/black/linegen.py).

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [-] Implement any code style changes under the `--preview` style, following the stability policy?
- [-] Add an entry in `CHANGES.md` if necessary?
- [-] Add / update tests if necessary?
- [y] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
