### PR TITLE
Preserve multiline headers with fmt skip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Preserve multiline compound statement headers when `# fmt: skip` is placed on
-  the colon line (#5117)
+- Preserve multiline compound statement headers when `# fmt: skip` is placed on the
+  colon line (#5117)
 - Fix crash when an f-string follows a `# fmt: off` comment inside brackets (#5097)
 - Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
   both new syntactic features in Python 3.15 (#5048)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Preserve multiline compound statement headers when `# fmt: skip` is placed on
+  the colon line (#5117)
 - Fix crash when an f-string follows a `# fmt: off` comment inside brackets (#5097)
 - Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
   both new syntactic features in Python 3.15 (#5048)

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -646,7 +646,27 @@ def _generate_ignored_nodes_from_fmt_skip(
     if not prev_sibling and parent:
         prev_sibling = parent.prev_sibling
 
-    if prev_sibling is not None:
+    if parent is not None and parent.type == syms.suite and leaf.type == token.NEWLINE:
+        # The `# fmt: skip` is on the colon line of the if/while/def/class/...
+        # statements. The ignored nodes should be previous siblings of the
+        # parent suite node. Do this before the generic "same physical line"
+        # logic so multiline headers are preserved as a whole.
+        leaf.prefix = ""
+        parent_sibling = parent.prev_sibling
+        while parent_sibling is not None and parent_sibling.type != syms.suite:
+            ignored_nodes.insert(0, parent_sibling)
+            parent_sibling = parent_sibling.prev_sibling
+        # Special case for `async_stmt` where the ASYNC token is on the
+        # grandparent node.
+        grandparent = parent.parent
+        if (
+            grandparent is not None
+            and grandparent.prev_sibling is not None
+            and grandparent.prev_sibling.type == token.ASYNC
+        ):
+            ignored_nodes.insert(0, grandparent.prev_sibling)
+        yield from iter(ignored_nodes)
+    elif prev_sibling is not None:
         leaf.prefix = leaf.prefix[comment.consumed :]
 
         # Generates the nodes to be ignored by `fmt: skip`.
@@ -735,27 +755,6 @@ def _generate_ignored_nodes_from_fmt_skip(
                     ignored_nodes = header_nodes + ignored_nodes
 
         yield from ignored_nodes
-    elif (
-        parent is not None and parent.type == syms.suite and leaf.type == token.NEWLINE
-    ):
-        # The `# fmt: skip` is on the colon line of the if/while/def/class/...
-        # statements. The ignored nodes should be previous siblings of the
-        # parent suite node.
-        leaf.prefix = ""
-        parent_sibling = parent.prev_sibling
-        while parent_sibling is not None and parent_sibling.type != syms.suite:
-            ignored_nodes.insert(0, parent_sibling)
-            parent_sibling = parent_sibling.prev_sibling
-        # Special case for `async_stmt` where the ASYNC token is on the
-        # grandparent node.
-        grandparent = parent.parent
-        if (
-            grandparent is not None
-            and grandparent.prev_sibling is not None
-            and grandparent.prev_sibling.type == token.ASYNC
-        ):
-            ignored_nodes.insert(0, grandparent.prev_sibling)
-        yield from iter(ignored_nodes)
 
 
 def is_fmt_on(container: LN, mode: Mode) -> bool:

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -690,9 +690,6 @@ def _generate_ignored_nodes_from_fmt_skip(
             ignored_nodes.insert(0, grandparent.prev_sibling)
         yield from iter(ignored_nodes)
     elif prev_sibling is not None:
-        leaf.prefix = leaf.prefix[comment.consumed :]
-
-    if prev_sibling is not None:
         # Generates the nodes to be ignored by `fmt: skip`.
 
         # Nodes to ignore are the ones on the same line as the

--- a/tests/data/cases/fmtskip_class_header.py
+++ b/tests/data/cases/fmtskip_class_header.py
@@ -1,0 +1,5 @@
+class Body(model.BaseBody[
+    "Keyword", "For", "While", "Group", "If", "Try", "Var", "Return", "Continue",
+    "Break", "model.Message", "Error"
+]):  # fmt: skip
+    __slots__ = ()

--- a/tests/data/cases/fmtskip_class_header.py
+++ b/tests/data/cases/fmtskip_class_header.py
@@ -5,6 +5,13 @@ class Body(model.BaseBody[
     __slots__ = ()
 
 
+class Foo(Base[\
+    "A", "B"\
+]):  # fmt: skip
+
+    def a(self): ...
+
+
 def make_result(
     first  : int,
     second:   str,
@@ -25,3 +32,16 @@ if (
     and is_ready(  item  )
 ):  # fmt: skip
     process(item)
+
+match (method, *path.split("/")):
+    case ("GET", "parent", _, "resource", resource_id) \
+            | ("GET", "resource", resource_id):  # fmt: skip
+        pass
+    case _:
+        pass
+
+match x:
+    case a \
+        | b \
+        | c:  # fmt: skip
+        pass

--- a/tests/data/cases/fmtskip_class_header.py
+++ b/tests/data/cases/fmtskip_class_header.py
@@ -3,3 +3,25 @@ class Body(model.BaseBody[
     "Break", "model.Message", "Error"
 ]):  # fmt: skip
     __slots__ = ()
+
+
+def make_result(
+    first  : int,
+    second:   str,
+):  # fmt: skip
+    return first, second
+
+
+async def fetch_result(
+    client,
+    *,
+    timeout  =   1,
+):  # fmt: skip
+    return await client.fetch(timeout=timeout)
+
+
+if (
+    has_permission(  user  )
+    and is_ready(  item  )
+):  # fmt: skip
+    process(item)


### PR DESCRIPTION
Fixes #5112, closes #5114
fixes #5122, closes #5123

## Summary
- Handle `# fmt: skip` on compound statement colon lines before same-line backtracking.
- Preserve multiline class/function headers as a whole when the skip comment is on the colon line.
- Add regression coverage for multiline class, function, async function, and parenthesized `if` headers.

## Test Plan
- `python3 -m pytest tests/test_format.py -k fmtskip_class_header`
- Previously ran the full formatting suite on this branch before the extra edge-case fixture additions.