### PR TITLE
docs: add Neovim integration guide and fix http link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
 <!-- Major changes to documentation and policies. Small docs changes
      don't need a changelog entry. -->
 
+- Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches
+  (#5124)
+
 ## Version 26.5.0
 
 ### Highlights
@@ -107,8 +110,6 @@
   (#5063)
 - Note in the editor integrations that the SublimeText `sublack` plugin is archived and
   unmaintained (#5082)
-- Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches
-  (#5124)
 
 ## Version 26.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,7 +107,8 @@
   (#5063)
 - Note in the editor integrations that the SublimeText `sublack` plugin is archived and
   unmaintained (#5082)
-- Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches (#5061)
+- Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches
+  (#5061)
 
 ## Version 26.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,7 @@
   (#5063)
 - Note in the editor integrations that the SublimeText `sublack` plugin is archived and
   unmaintained (#5082)
+- Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches (#5061)
 
 ## Version 26.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,7 +108,7 @@
 - Note in the editor integrations that the SublimeText `sublack` plugin is archived and
   unmaintained (#5082)
 - Add Neovim integration guide covering conform.nvim, ALE, and simple command approaches
-  (#5061)
+  (#5124)
 
 ## Version 26.3.1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Twisted and CPython:
 
 > _At least the name is good._
 
-**Kenneth Reitz**, creator of [requests](http://python-requests.org/) and
+**Kenneth Reitz**, creator of [requests](https://python-requests.org/) and
 [pipenv](https://docs.pipenv.org/):
 
 > _This vastly improves the formatting of our code. Thanks a ton!_

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -353,6 +353,67 @@ nnoremap <F9> :Black<CR>
    let g:ale_fixers.python = ['black']
    ```
 
+## Neovim
+
+### Via conform.nvim
+
+[conform.nvim](https://github.com/stevearc/conform.nvim) is a lightweight formatter
+plugin for Neovim. It supports _Black_ out of the box as long as `black` is available
+in your `PATH`.
+
+1. Install `black` (e.g. `pip install black` or `pipx install black`)
+
+1. Install `conform.nvim` using your plugin manager and add the following to your Neovim
+   configuration:
+
+   ```lua
+   require("conform").setup({
+     formatters_by_ft = {
+       python = { "black" },
+     },
+   })
+   ```
+
+1. To format on save, add:
+
+   ```lua
+   require("conform").setup({
+     formatters_by_ft = {
+       python = { "black" },
+     },
+     format_on_save = {
+       timeout_ms = 500,
+       lsp_format = "fallback",
+     },
+   })
+   ```
+
+### With ALE
+
+[ALE](https://github.com/dense-analysis/ale) supports both Vim and Neovim. See the
+[Vim section](#with-ale) above for setup instructions — the same configuration works
+for Neovim.
+
+### Simple command
+
+You can invoke _Black_ on the current file directly from Neovim without any plugins:
+
+```vim
+:!black %
+```
+
+To create a convenient `:Black` command, add this to your `init.lua`:
+
+```lua
+vim.api.nvim_create_user_command(
+  "Black",
+  function()
+    vim.cmd("!black " .. vim.fn.expand("%"))
+  end,
+  { nargs = 0 }
+)
+```
+
 ## Gedit
 
 gedit is the default text editor of the GNOME, Unix like Operating Systems. Open gedit

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -358,8 +358,8 @@ nnoremap <F9> :Black<CR>
 ### Via conform.nvim
 
 [conform.nvim](https://github.com/stevearc/conform.nvim) is a lightweight formatter
-plugin for Neovim. It supports _Black_ out of the box as long as `black` is available
-in your `PATH`.
+plugin for Neovim. It supports _Black_ out of the box as long as `black` is available in
+your `PATH`.
 
 1. Install `black` (e.g. `pip install black` or `pipx install black`)
 
@@ -391,8 +391,8 @@ in your `PATH`.
 ### With ALE
 
 [ALE](https://github.com/dense-analysis/ale) supports both Vim and Neovim. See the
-[Vim section](#with-ale) above for setup instructions — the same configuration works
-for Neovim.
+[Vim section](#with-ale) above for setup instructions — the same configuration works for
+Neovim.
 
 ### Simple command
 


### PR DESCRIPTION
### Description

This PR addresses two documentation improvements:

**1. Add Neovim integration guide (fixes #3960)**

Neovim has grown significantly in popularity but was completely missing from the [editor integrations docs](https://black.readthedocs.io/en/stable/integrations/editors.html). The Vim section only covers Vim-specific plugins.

The new Neovim section covers three common approaches:
- **conform.nvim** — the most popular modern formatter plugin for Neovim, with a format-on-save example
- **ALE** — cross-references the existing Vim section since ALE works with both
- **Simple command** — no-plugin approach using `:!black %` with a Lua `nvim_create_user_command` example

**2. Fix `http://` link in docs/index.md**

The testimonials section linked to `http://python-requests.org/` which redirects to `https://`. Updated to use `https://` directly.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy? — N/A (docs only)
- [x] Add an entry in `CHANGES.md` if necessary? — Yes, added changelog entry for the Neovim guide
- [ ] Add / update tests if necessary? — N/A (docs only)
- [x] Add new / update outdated documentation? — Yes, added Neovim section and fixed http link