### PR TITLE
Respect NO_COLOR by disabling ANSI output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 <!-- PR authors:
      Please include the PR number in the changelog entry, not the issue number -->
+
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
+
 ### Highlights
 
 <!-- Include any especially major or disruptive changes here -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 <!-- PR authors:
      Please include the PR number in the changelog entry, not the issue number -->
-
+- Add support for NO_COLOR environment variable to disable ANSI output (#5129)
 ### Highlights
 
 <!-- Include any especially major or disruptive changes here -->

--- a/src/black/output.py
+++ b/src/black/output.py
@@ -4,6 +4,7 @@ The double calls are for patching purposes in tests.
 """
 
 import json
+import os
 import re
 import tempfile
 from typing import Any
@@ -17,7 +18,7 @@ def _out(message: str | None = None, nl: bool = True, **styles: Any) -> None:
     if message is not None:
         if "bold" not in styles:
             styles["bold"] = True
-        message = style(message, **styles)
+        message = style_output(message, **styles)
     echo(message, nl=nl, err=True)
 
 
@@ -26,7 +27,7 @@ def _err(message: str | None = None, nl: bool = True, **styles: Any) -> None:
     if message is not None:
         if "fg" not in styles:
             styles["fg"] = "red"
-        message = style(message, **styles)
+        message = style_output(message, **styles)
     echo(message, nl=nl, err=True)
 
 
@@ -95,6 +96,8 @@ def diff(a: str, b: str, a_name: str, b_name: str) -> str:
 
 def color_diff(contents: str) -> str:
     """Inject the ANSI color codes to the diff."""
+    if not _color_enabled():
+        return contents
     lines = contents.split("\n")
     for i, line in enumerate(lines):
         if line.startswith("+++") or line.startswith("---"):
@@ -107,6 +110,16 @@ def color_diff(contents: str) -> str:
             line = "\033[31m" + line + "\033[0m"  # red, reset
         lines[i] = line
     return "\n".join(lines)
+
+
+def style_output(message: str, **styles: Any) -> str:
+    if not _color_enabled():
+        return message
+    return style(message, **styles)
+
+
+def _color_enabled() -> bool:
+    return "NO_COLOR" not in os.environ
 
 
 @mypyc_attr(patchable=True)

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -6,9 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-from click import style
-
-from black.output import err, out
+from black.output import err, out, style_output
 
 
 class Changed(Enum):
@@ -94,14 +92,20 @@ class Report:
         if self.change_count:
             s = "s" if self.change_count > 1 else ""
             report.append(
-                style(f"{self.change_count} file{s} ", bold=True, fg="blue")
-                + style(f"{reformatted}", bold=True)
+                style_output(
+                    f"{self.change_count} file{s} ", bold=True, fg="blue"
+                )
+                + style_output(f"{reformatted}", bold=True)
             )
 
         if self.same_count:
             s = "s" if self.same_count > 1 else ""
-            report.append(style(f"{self.same_count} file{s} ", fg="blue") + unchanged)
+            report.append(
+                style_output(f"{self.same_count} file{s} ", fg="blue") + unchanged
+            )
         if self.failure_count:
             s = "s" if self.failure_count > 1 else ""
-            report.append(style(f"{self.failure_count} file{s} {failed}", fg="red"))
+            report.append(
+                style_output(f"{self.failure_count} file{s} {failed}", fg="red")
+            )
         return ", ".join(report) + "."

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -92,9 +92,7 @@ class Report:
         if self.change_count:
             s = "s" if self.change_count > 1 else ""
             report.append(
-                style_output(
-                    f"{self.change_count} file{s} ", bold=True, fg="blue"
-                )
+                style_output(f"{self.change_count} file{s} ", bold=True, fg="blue")
                 + style_output(f"{reformatted}", bold=True)
             )
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -240,6 +240,23 @@ class BlackTestCase(BlackBaseTestCase):
         self.assertIn("\033[31m", actual)
         self.assertIn("\033[0m", actual)
 
+    def test_piping_diff_with_color_respects_no_color(self) -> None:
+        source, _ = read_data("cases", "expression.py")
+        args = [
+            "-",
+            "--fast",
+            f"--line-length={black.DEFAULT_LINE_LENGTH}",
+            "--diff",
+            "--color",
+            f"--config={EMPTY_CONFIG}",
+        ]
+        with patch.dict(os.environ, {"NO_COLOR": "1"}):
+            result = BlackRunner().invoke(
+                black.main, args, input=BytesIO(source.encode("utf-8"))
+            )
+        actual = result.output
+        self.assertNotIn("\033[", actual)
+
     def test_pep_572_version_detection(self) -> None:
         source, _ = read_data("cases", "pep_572")
         root = black.lib2to3_parse(source)
@@ -794,6 +811,13 @@ class BlackTestCase(BlackBaseTestCase):
                 "2 files would be reformatted, 3 files would be left unchanged, 2"
                 " files would fail to reformat.",
             )
+
+    def test_report_respects_no_color(self) -> None:
+        report = Report()
+        report.done(Path("f1"), black.Changed.YES)
+        with patch.dict(os.environ, {"NO_COLOR": "1"}):
+            output = str(report)
+        self.assertEqual(output, unstyle(output))
 
     def test_lib2to3_parse(self) -> None:
         with self.assertRaises(black.InvalidInput):


### PR DESCRIPTION
Summary

Disable ANSI color output when NO_COLOR is set.
Applies to colored diffs ([--diff --color](vscode-file://vscode-app/c:/Users/32825/AppData/Local/Programs/Microsoft%20VS%20Code/974500e64f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) and report styling.
Keeps behavior unchanged when NO_COLOR is not set.
Details

Add a shared helper to guard styling and diff coloring based on NO_COLOR.
Ensure report styling uses the same guard so summary lines are plain text.
Tests

python -m pytest test_black.py -k "no_color"

<img width="1056" height="144" alt="屏幕截图 2026-05-13 105133" src="https://github.com/user-attachments/assets/7
<img width="1048" height="648" alt="屏幕截图 2026-05-13 105127" src="https://github.com/user-attachments/assets/b0ae4e94-e035-4792-bbf2-41c81c29b420" />
230d8c6-ca59-4ab7-85ce-ca1fde4b2c37" />
<img width="1058" height="696" alt="屏幕截图 2026-05-13 105119" src="https://github.com/user-attachments/assets/e0541a26-bdf1-41b2-9ec8-968315595d21" />
