### PR TITLE
Preserve inline comments inside annotation subscripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix unstable formatting of annotated assignments whose subscript annotation contains
+  an inline comment (e.g. `x: list[  # pyright: ignore[...]\n    int\n] = []`). Black no
+  longer migrates the comment outside the subscript brackets, eliminating the
+  oscillation between formatter passes reported as #4733 (#5130)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -771,7 +771,9 @@ def transform_line(
                 # *current* transformation fits in the line length.  This is true only
                 # for simple cases.  All others require running more transforms via
                 # `transform_line()`.  This check doesn't know if those would succeed.
-                if is_line_short_enough(lines[0], mode=mode):
+                if is_line_short_enough(lines[0], mode=mode) or (
+                    omit and _over_length_only_due_to_subscript_comment(lines[0], mode)
+                ):
                     yield from lines
                     return
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -80,6 +80,7 @@ from black.strings import (
     normalize_string_prefix,
     normalize_string_quotes,
     normalize_unicode_escape_sequences,
+    str_width,
 )
 from black.trans import (
     CannotTransform,
@@ -2013,6 +2014,37 @@ def generate_trailers_to_omit(line: Line, line_length: int) -> Iterator[set[Leaf
                 closing_bracket = leaf
 
 
+def _over_length_only_due_to_subscript_comment(line: Line, mode: Mode) -> bool:
+    """Return True if `line` only exceeds `mode.line_length` because of an inline
+    comment attached to a subscript opening bracket (`[`).
+
+    This is the shape produced by the original of the issue #4733 reproducer:
+    a comment inside the annotation's subscript brackets renders at the end of
+    the head line after Black splits the statement, pushing it past the limit.
+    Taking the FORCE_OPTIONAL_PARENTHESES "second opinion" in that case wraps
+    the annotation in extra parens and migrates the comment outside the
+    subscript, which then oscillates on the next formatter pass.
+    """
+    if not line.leaves:
+        return False
+    # The over-length must be caused entirely by a trailing comment.
+    indent = "    " * line.depth
+    leaves_iter = iter(line.leaves)
+    first = next(leaves_iter)
+    text_without_comments = f"{first.prefix}{indent}{first.value}"
+    text_without_comments += "".join(str(leaf) for leaf in leaves_iter)
+    if str_width(text_without_comments) > mode.line_length:
+        return False
+    # And the comment must be attached to a subscript opening bracket.
+    for leaf_id, comments in line.comments.items():
+        if not comments:
+            continue
+        leaf = next((lf for lf in line.leaves if id(lf) == leaf_id), None)
+        if leaf is None or leaf.type != token.LSQB:
+            return False
+    return True
+
+
 def run_transformer(
     line: Line,
     transform: Transformer,
@@ -2040,6 +2072,12 @@ def run_transformer(
         or result[0].contains_uncollapsable_type_comments()
         or result[0].contains_unsplittable_type_ignore()
         or is_line_short_enough(result[0], mode=mode)
+        # result[0] only exceeds the length because of a comment attached to a
+        # subscript opening bracket.  Taking the FORCE_OPTIONAL_PARENTHESES
+        # "second opinion" wraps the annotation in extra invisible parens and
+        # migrates the comment outside the subscript, which then oscillates with
+        # a deeper-bracket split on the next formatter pass (issue #4733).
+        or _over_length_only_due_to_subscript_comment(result[0], mode)
         # If any leaves have no parents (which _can_ occur since
         # `transform(line)` potentially destroys the line's underlying node
         # structure), then we can't proceed. Doing so would cause the below

--- a/tests/data/cases/comment_in_subscript_annotation.py
+++ b/tests/data/cases/comment_in_subscript_annotation.py
@@ -1,0 +1,27 @@
+# Regression test for https://github.com/psf/black/issues/4733.
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  # bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    int
+] = []
+
+
+# Original (non-minimized) snippet from the issue report.
+def foo():
+    possibly_redundant_lowlevel_checkpoints: list[  # pyright: ignore[reportUnknownVariableType]
+        cst.BaseExpression
+    ] = field( default_factory=list)
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/4733.
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  # bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    int
+] = []
+
+
+# Original (non-minimized) snippet from the issue report.
+def foo():
+    possibly_redundant_lowlevel_checkpoints: list[  # pyright: ignore[reportUnknownVariableType]
+        cst.BaseExpression
+    ] = field(
+        default_factory=list
+    )

--- a/tests/data/cases/comment_in_subscript_annotation.py
+++ b/tests/data/cases/comment_in_subscript_annotation.py
@@ -22,6 +22,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  # bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 def foo():
     possibly_redundant_lowlevel_checkpoints: list[  # pyright: ignore[reportUnknownVariableType]
         cst.BaseExpression
-    ] = field(
-        default_factory=list
-    )
+    ] = field(default_factory=list)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -83,36 +83,6 @@ def test_empty() -> None:
     assert_format(source, expected)
 
 
-def test_issue_4733_stable_subscript_with_inline_comment() -> None:
-    # Regression test for https://github.com/psf/black/issues/4733
-    # A trailing comment on the opening line of a subscript annotation causes
-    # Black to produce different code on each pass.
-    source = (
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  #"
-        " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
-        "    int\n"
-        "] = []\n"
-    )
-    mode = black.Mode()
-    dst = black.format_str(source, mode=mode)
-    black.assert_stable(source, dst, mode=mode)
-
-
-def test_issue_4733_stable_annotated_assignment_with_inline_comment() -> None:
-    # Regression test for https://github.com/psf/black/issues/4733
-    # Original (non-minimized) snippet from the issue report.
-    source = (
-        "def foo():\n"
-        "    possibly_redundant_lowlevel_checkpoints: list[  #"
-        " pyright: ignore[reportUnknownVariableType]\n"
-        "        cst.BaseExpression\n"
-        "    ] = field( default_factory=list)\n"
-    )
-    mode = black.Mode()
-    dst = black.format_str(source, mode=mode)
-    black.assert_stable(source, dst, mode=mode)
-
-
 def test_patma_invalid() -> None:
     source, expected = read_data("miscellaneous", "pattern_matching_invalid")
     mode = black.Mode(target_versions={black.TargetVersion.PY310})

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -83,6 +83,36 @@ def test_empty() -> None:
     assert_format(source, expected)
 
 
+def test_issue_4733_stable_subscript_with_inline_comment() -> None:
+    # Regression test for https://github.com/psf/black/issues/4733
+    # A trailing comment on the opening line of a subscript annotation causes
+    # Black to produce different code on each pass.
+    source = (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  #"
+        " bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        "    int\n"
+        "] = []\n"
+    )
+    mode = black.Mode()
+    dst = black.format_str(source, mode=mode)
+    black.assert_stable(source, dst, mode=mode)
+
+
+def test_issue_4733_stable_annotated_assignment_with_inline_comment() -> None:
+    # Regression test for https://github.com/psf/black/issues/4733
+    # Original (non-minimized) snippet from the issue report.
+    source = (
+        "def foo():\n"
+        "    possibly_redundant_lowlevel_checkpoints: list[  #"
+        " pyright: ignore[reportUnknownVariableType]\n"
+        "        cst.BaseExpression\n"
+        "    ] = field( default_factory=list)\n"
+    )
+    mode = black.Mode()
+    dst = black.format_str(source, mode=mode)
+    black.assert_stable(source, dst, mode=mode)
+
+
 def test_patma_invalid() -> None:
     source, expected = read_data("miscellaneous", "pattern_matching_invalid")
     mode = black.Mode(target_versions={black.TargetVersion.PY310})


### PR DESCRIPTION
### Description

Fixes #4733.

Black crashes with `INTERNAL ERROR: produced different code on the second
pass of the formatter` on inputs like:

```python
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: list[  # pyright: ignore[...]
    int
] = []
```

## Root cause

The collapsed line is one char over the limit thanks to the inline comment
on the subscript's `[`. That's enough for `run_transformer` to try the
`FORCE_OPTIONAL_PARENTHESES` second opinion, which wraps the annotation in
invisible parens and pushes the comment out of the subscript. On the next
parse the comment lands on a different leaf, the splitter picks a different
shape, and the second-pass stability check blows up.

## Fix

Skip the second opinion in `run_transformer` when `result[0]` only goes over
because of comments attached to a subscript `[` (`LSQB`). The comment stops
migrating, formatting converges in one or two passes, and it stays where
the user wrote it.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?