### PR TITLE
Prepare release 26.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,85 +1,57 @@
 # Change Log
 
-## Unreleased
-
-<!-- PR authors:
-     Please include the PR number in the changelog entry, not the issue number -->
+## Version 26.5.0
 
 ### Highlights
 
-<!-- Include any especially major or disruptive changes here -->
+- Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
+  both new syntactic features in Python 3.15 (#5048)
+- Python 3.15 is now supported. Compiled wheels are not yet provided for Python 3.15, so
+  performance may be slower than on existing Python versions. Wheels will be provided
+  once Python 3.15 is later in its release cycle. (#5127)
 
 ### Stable style
 
-<!-- Changes that affect Black's stable style -->
-
-- Preserve multiline compound statement headers when `# fmt: skip` is placed on the
-  colon line (#5117)
 - Fix `# fmt: skip` being ignored in nested `if` expressions with parenthesized `in`
   clauses (#4903)
+- Add syntactic support for Python 3.15 (#5048)
 - Fix crash when an f-string follows a `# fmt: off` comment inside brackets (#5097)
-- Add support for unpacking in comprehensions (PEP 798) and for lazy imports (PEP 810),
-  both new syntactic features in Python 3.15 (#5048)
+- Preserve multiline compound statement headers when `# fmt: skip` is placed on the
+  colon line (#5117)
 
 ### Preview style
 
-<!-- Changes that affect Black's preview style -->
-
-- Prevent string merger from creating unsplittable long lines when a pragma comment
-  (e.g. `# type: ignore`) follows the closing bracket (#5096)
 - Improve heuristics around whether blank lines should appear before, within and after
   groups of same-name decorated functions (such as `@overload` groups) in `.pyi` stub
   files (#5021)
 - Fix blank lines being removed between a function and a decorated class in `.pyi` stub
   files (#5092)
-
-### Configuration
-
-<!-- Changes to how Black can be configured -->
+- Prevent string merger from creating unsplittable long lines when a pragma comment
+  (e.g. `# type: ignore`) follows the closing bracket (#5096)
 
 ### Packaging
 
-<!-- Changes to how Black is packaged, such as dependency requirements -->
-
-- Python 3.15 is now supported. Compiled wheels are not yet provided for Python 3.15, so
-  performance may be slower than on existing Python versions. Wheels will be provided
-  once Python 3.15 is later in its release cycle. (#5127)
-
-### Parser
-
-<!-- Changes to the parser or to version autodetection -->
-
-### Performance
-
-<!-- Changes that improve Black's performance. -->
+- Run CI on 3.15 (#5127)
 
 ### Output
 
 - Improve parse error readability by showing multi-line output with an error pointer.
   (#5068)
-
 - Add `SourceASTParseError` to distinguish source parse failures from internal safety
   errors, improving error reporting when Black's lenient parser accepts input that
   `ast.parse()` rejects (#5080)
 
 ### _Blackd_
 
-<!-- Changes to blackd -->
-
 - Return HTTP 400 (Bad Request) for source parse failures instead of HTTP 500, keeping
   HTTP 500 only for genuine internal safety errors (#5080)
 
 ### Integrations
 
-<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-
 - Added documentation for doctest formatting tools and updated the integrations index to
   match (#4916)
 
 ### Documentation
-
-<!-- Major changes to documentation and policies. Small docs changes
-     don't need a changelog entry. -->
 
 - Use "Version X.Y.Z" headings in changelog for stable permalink anchors on ReadTheDocs
   (#5063)

--- a/docs/contributing/release_process.md
+++ b/docs/contributing/release_process.md
@@ -42,7 +42,7 @@ To cut a release:
 1. Determine the release's version number
    - **_Black_ follows the [CalVer] versioning standard using the `YY.M.N` format**
      - So unless there already has been a release during this month, `N` should be `0`
-   - Example: the first release in January, 2022 → `22.1.0`
+   - Example: the first release in January, 2026 → `26.1.0`
    - `release.py` will calculate this and log it to stdout for your copy-paste pleasure
 1. Double-check that no changelog entries since the last release were put in the wrong
    section (e.g., run `git diff origin/stable CHANGES.md`)

--- a/docs/guides/using_black_with_jupyter_notebooks.md
+++ b/docs/guides/using_black_with_jupyter_notebooks.md
@@ -111,7 +111,7 @@ Simply replace the `black` hook with `black-jupyter`.
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.0
     hooks:
       - id: black-jupyter
         language_version: python3.11

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -259,11 +259,11 @@ version scheme used by Black):
 Plug 'psf/black', { 'tag': '*.*.*' }
 ```
 
-and the following demonstrates pinning to a specific year's stable style (2022 in this
+and the following demonstrates pinning to a specific year's stable style (2026 in this
 case):
 
 ```vim
-Plug 'psf/black', { 'tag': '22.*.*' }
+Plug 'psf/black', { 'tag': '26.*.*' }
 ```
 
 ##### Vundle

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -50,7 +50,7 @@ If you want to match versions covered by Black's
   with:
     options: "--check --verbose"
     src: "./src"
-    version: "~= 22.0"
+    version: "~= 26.0"
 ```
 
 To read the version from the `pyproject.toml` file instead, set `use_pyproject` to

--- a/docs/integrations/source_version_control.md
+++ b/docs/integrations/source_version_control.md
@@ -8,7 +8,7 @@ Use [pre-commit](https://pre-commit.com/). Once you
 repos:
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -34,7 +34,7 @@ include Jupyter Notebooks. To use this hook, simply replace the hook's `id: blac
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.0
     hooks:
       - id: black-jupyter
         language_version: python3.11
@@ -64,7 +64,7 @@ Configure exclusions directly in `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: 26.5.0
     hooks:
       - id: black
         exclude: ^migrations/|^generated/

--- a/docs/the_black_code_style/index.md
+++ b/docs/the_black_code_style/index.md
@@ -29,8 +29,8 @@ _Black_:
 - If code has been formatted with _Black_, it will remain unchanged when formatted with
   the same options using any other release in the same calendar year.
 
-  This means projects can safely use `black ~= 22.0` without worrying about formatting
-  changes disrupting their project in 2022. We may still fix bugs where _Black_ crashes
+  This means projects can safely use `black ~= 26.0` without worrying about formatting
+  changes disrupting their project in 2026. We may still fix bugs where _Black_ crashes
   on some code, and make other improvements that do not affect formatting.
 
   In rare cases, we may make changes affecting code that has not been previously

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -280,8 +280,8 @@ configuration file for consistent results across environments.
 
 ```console
 $ black --version
-black, 26.3.1 (compiled: yes)
-$ black --required-version 26.3.1 -c "format = 'this'"
+black, 26.5.0 (compiled: yes)
+$ black --required-version 26.5.0 -c "format = 'this'"
 format = "this"
 $ black --required-version 31.5b2 -c "still = 'beta?!'"
 Oh no! 💥 💔 💥 The required version does not match the running version!
@@ -388,7 +388,7 @@ You can check the version of _Black_ you have installed using the `--version` fl
 
 ```console
 $ black --version
-black, 26.3.1
+black, 26.5.0
 ```
 
 #### `--config`

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -152,10 +152,10 @@ class SourceFiles:
         )
 
         # Remove all comments
-        changes_string = re.sub(r"(?m)^<!--(?>(?:.|\n)*?-->)\n\n", "", changes_string)
+        changes_string = re.sub(r"(?m)^<!--(?>(?:.|\n)*?-->)\n+", "", changes_string)
 
         # Remove empty subheadings
-        changes_string = re.sub(r"(?m)^###.+\n\n(?=#)", "", changes_string)
+        changes_string = re.sub(r"(?m)^###.+\n+(?=#)", "", changes_string)
 
         with self.changes_path.open("w", encoding="utf-8") as cfp:
             cfp.write(changes_string)


### PR DESCRIPTION
I also took the liberty to update a few version examples that aren't updated by release.py. These ones aren't as big a deal because they're more obviously only examples. They're also only the major version, so it should be possible to just remember to change them every January