### PR TITLE
Preserve comments before fmt: skip lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Preserve inline comments (including `# type: ignore`) immediately before a
+  `# fmt: skip` line, avoiding AST equivalence failures (#5139)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -754,7 +754,10 @@ def _generate_ignored_nodes_from_fmt_skip(
                 current_node = current_node.parent
 
             if current_node.type in (token.NEWLINE, token.INDENT):
-                current_node.prefix = ""
+                if not list_comments(
+                    current_node.prefix, is_endmarker=False, mode=mode
+                ):
+                    current_node.prefix = ""
                 break
 
             if current_node.type == token.DEDENT:

--- a/tests/data/cases/fmtskip_type_ignore.py
+++ b/tests/data/cases/fmtskip_type_ignore.py
@@ -1,0 +1,2 @@
+a = 1  # type: ignore
+b = 1  # fmt: skip


### PR DESCRIPTION
### Description

Fixes #5138.

When `# fmt: skip` converts a line into a standalone comment leaf, the backwards scan to find the start of that physical line could clear the prefix on the preceding `NEWLINE`/`INDENT` boundary. If the previous line had an inline comment such as `# type: ignore`, that comment was lost in the formatted output, causing Black's AST equivalence check to fail because the `TypeIgnore` node disappeared.

This preserves prefixes on the boundary leaf when they contain comments, while still clearing comment-free whitespace prefixes. A regression case covers the two-line reproducer from the issue.

### Tests

- `black --check repro_5138.py` (local reproducer)
- `python -m pytest tests/test_format.py -k fmtskip_type_ignore -q`
- `python -m pytest tests/test_format.py -k 'fmtskip or type_ignore' -q`
- `python -m pytest tests/test_format.py -q`
- `black --check src/black/comments.py tests/data/cases/fmtskip_type_ignore.py`

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
