### PR TITLE
Add regression tests for #4513

### DIFF
--- a/tests/data/cases/fmtskip_in_parens.py
+++ b/tests/data/cases/fmtskip_in_parens.py
@@ -1,0 +1,49 @@
+# Regression tests for https://github.com/psf/black/issues/4513.
+# Fixed by #4903 ("Improve fmt:skip handling in nested expressions with checks").
+# Each of the three inputs below used to crash with a "Cannot parse" error.
+
+# Case A: triple-quoted string inside parens with a leading `# fmt: skip` line.
+(
+# fmt: skip
+"""
+"""
+)
+
+# Case B: line-continued string inside parens with a leading `# fmt: skip` line.
+(
+# fmt: skip
+"\
+"
+)
+
+# Case C: `# fmt: skip` on the opening paren of a comparator expression.
+foo = (  # fmt: skip
+    some_long_expression
+    > some_other_long_expression
+)
+
+# output
+
+# Regression tests for https://github.com/psf/black/issues/4513.
+# Fixed by #4903 ("Improve fmt:skip handling in nested expressions with checks").
+# Each of the three inputs below used to crash with a "Cannot parse" error.
+
+# Case A: triple-quoted string inside parens with a leading `# fmt: skip` line.
+(
+# fmt: skip
+"""
+"""
+)
+
+# Case B: line-continued string inside parens with a leading `# fmt: skip` line.
+(
+# fmt: skip
+"\
+"
+)
+
+# Case C: `# fmt: skip` on the opening paren of a comparator expression.
+foo = (  # fmt: skip
+    some_long_expression
+    > some_other_long_expression
+)


### PR DESCRIPTION
### Description

Regression tests for #4513, fixed in #4903. Each of these three inputs used to blow up with `Cannot parse: ...`; on current `main` Black leaves them alone.

```py
# Case A: triple-quoted string in parens with a leading `# fmt: skip`
(
# fmt: skip
"""
"""
)

# Case B: line-continued string in parens with a leading `# fmt: skip`
(
# fmt: skip
"\
"
)

# Case C (from @jenstroeger): `# fmt: skip` on the opening paren of a comparator
foo = (  # fmt: skip
    some_long_expression
    > some_other_long_expression
)
```

Bisected to aef52e0: all three crash on `aef52e0~1` and round-trip unchanged on `aef52e0` and after. See discussion in #4513.

No `CHANGES.md` entry since this is test-only and not user-facing. Please apply the skip-news label.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
