### PR TITLE
Fix crash on standalone comments in comprehensions and lambdas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash when a standalone comment sits between tokens of a comprehension or lambda
+  (#5144)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,12 +16,12 @@
 <!-- Changes that affect Black's stable style -->
 
 <<<<<<< fix/4296-standalone-comments-comprehensions
+
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
-  (#5144)
-=======
+  (#5144) =======
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
->>>>>>> main
+  > > > > > > > main
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,13 +15,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
-<<<<<<< fix/4296-standalone-comments-comprehensions
-
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
-  (#5144) =======
+  (#5144)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
-  > > > > > > > main
 
 ### Preview style
 

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -225,6 +225,17 @@ def is_split_after_delimiter(leaf: Leaf) -> Priority:
     Higher numbers are higher priority.
     """
     if leaf.type == token.COMMA:
+        # For-target commas are tuple-packing, not list delimiters; splitting
+        # on them produces invalid Python if `for` lands on another line (#4296).
+        parent = leaf.parent
+        if parent is not None and parent.type == syms.exprlist:
+            grandparent = parent.parent
+            if grandparent is not None and grandparent.type in {
+                syms.comp_for,
+                syms.old_comp_for,
+                syms.for_stmt,
+            }:
+                return 0
         return COMMA_PRIORITY
 
     return 0

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -833,7 +833,13 @@ def transform_line(
             break
 
     else:
-        yield line
+        # A leftover standalone comment would render inline and break the
+        # second pass with a parse error (#4296). Force a split so the
+        # output is at least valid Python.
+        if line.contains_standalone_comments():
+            yield from _force_standalone_comment_split(line)
+        else:
+            yield line
 
 
 def should_split_funcdef_with_rhs(line: Line, mode: Mode) -> bool:
@@ -1521,6 +1527,24 @@ def standalone_comment_split(
         for comment_after in line.comments_after(leaf):
             yield from append_to_line(comment_after)
 
+    if current_line:
+        yield current_line
+
+
+def _force_standalone_comment_split(line: Line) -> Iterator[Line]:
+    """Last-resort split at every standalone-comment boundary."""
+    current_line = Line(
+        mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+    )
+    for leaf in line.leaves:
+        if current_line.leaves and (
+            leaf.type == STANDALONE_COMMENT or current_line.is_comment
+        ):
+            yield current_line
+            current_line = Line(
+                mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+            )
+        current_line.append(leaf, preformatted=True)
     if current_line:
         yield current_line
 

--- a/tests/data/cases/comments_in_comprehensions.py
+++ b/tests/data/cases/comments_in_comprehensions.py
@@ -1,0 +1,91 @@
+# Regression tests for https://github.com/psf/black/issues/4296.
+
+[
+    x
+    for
+    # comment
+    x, y in ["AB",]
+]
+
+[
+    [
+        x
+        for x
+        # comment
+        in [
+            # comment
+            "ABC"
+        ]
+    ]
+]
+
+{
+    (
+        lambda
+        # comment
+        x: [
+            # comment
+        ]
+    )
+}
+
+async def f():
+    return [
+        x
+        async for
+        # comment
+        x, y in ["AB",]
+    ]
+
+for (a, b), c in [
+    # comment
+    z,
+]:
+    pass
+
+# output
+
+# Regression tests for https://github.com/psf/black/issues/4296.
+
+[
+    x
+    for
+    # comment
+    x, y in [
+        "AB",
+    ]
+]
+
+[
+    [x for x
+    # comment
+    in [
+    # comment
+    "ABC"]]
+]
+
+{
+    lambda
+    # comment
+    x: [
+        # comment
+    ]
+}
+
+
+async def f():
+    return [
+        x
+        async for
+        # comment
+        x, y in [
+            "AB",
+        ]
+    ]
+
+
+for (a, b), c in [
+    # comment
+    z,
+]:
+    pass


### PR DESCRIPTION
### Description

Fixes #4296.

Three inputs from the issue crash on the first formatting pass:

```py
[
    x for
    # comment
    x, y in ["AB",]
]

[
    [
        x for x
        # comment
        in [
            # comment
            "ABC"
        ]
    ]
]

{(lambda
    # comment
    x: [
        # comment
    ]
)}
```

All of them blow up with `Cannot parse: ... bad input` because Black dumps a string where a standalone comment sits inline next to the following token, and Python's tokenizer swallows everything to the next newline.

## Root cause

Two distinct things.

For cases B and C, `transform_line` runs through its splitters and, when nothing succeeds, falls through to `yield line`. `Line.__str__` concatenates leaves without inserting newlines, so a `STANDALONE_COMMENT` mid-stream renders glued to whatever follows. `Line.append_safe` enforces "comment on its own line" only at bracket depth 0 or inside an open `for` / `lambda`. For comments living inside arbitrary nested brackets, there's no guard.

For case A, `standalone_comment_split` does pull the comment between `for` and the tuple target onto its own line, but the resulting sub-line `x, y in ["AB",]` no longer carries the `for` keyword. Its bracket tracker walks fresh, the comma between `x` and `y` lands at depth 0, gets `COMMA_PRIORITY`, and `delimiter_split` breaks the tuple apart. Black also tacks a stray trailing comma onto the iterable.

## Fix

- `linegen.py`: when no transformer succeeds and the line still carries standalone comments, fall back to `_force_standalone_comment_split`, which yields each comment on its own line. The alternative is invalid Python, so the unconditional split is safe.
- `brackets.py`: `is_split_after_delimiter` returns 0 for commas whose parent is `exprlist` and whose grandparent is `comp_for` / `old_comp_for` / `for_stmt`. Those commas are tuple-packing, not list delimiters.

The fixture covers the three issue cases plus async-for and a nested tuple target (`for (a, b), c in ...`) to lock both fixes in.

Flagging that case B comes out with loose indentation:

```py
[
    [x for x
    # comment
    in [
    # comment
    "ABC"]]
]
```

The inner `[...]` doesn't re-explode, so the comment and `"ABC"]]` sit at the wrong depth. Let me know if there's a target shape you'd want, or if this is fine for the crash fix.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
