### PR TITLE
Harden diff-shades comment workflow

### DIFF
--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -27,8 +27,56 @@ jobs:
         with:
           merge-multiple: true
           pattern: ".*.pr-comment.md"
+          path: ${{ runner.temp }}/diff-shades-artifacts
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate downloaded comment artifacts
+        id: comment-artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact_dir="${RUNNER_TEMP}/diff-shades-artifacts"
+          preview_artifact="${artifact_dir}/.preview.pr-comment.md"
+          stable_artifact="${artifact_dir}/.stable.pr-comment.md"
+
+          if [ ! -d "$artifact_dir" ]; then
+              echo "::error::Artifact directory does not exist: ${artifact_dir}"
+              exit 1
+          fi
+
+          while IFS= read -r -d '' entry; do
+              if [ "$(dirname "$entry")" != "$artifact_dir" ]; then
+                  echo "::error::Unexpected nested artifact path: ${entry}"
+                  exit 1
+              fi
+
+              case "$(basename "$entry")" in
+                  .preview.pr-comment.md|.stable.pr-comment.md) ;;
+                  *)
+                      echo "::error::Unexpected artifact path: ${entry}"
+                      exit 1
+                      ;;
+              esac
+
+              if [ ! -f "$entry" ] || [ -L "$entry" ]; then
+                  echo "::error::Artifact must be a regular file: ${entry}"
+                  exit 1
+              fi
+          done < <(find "$artifact_dir" -mindepth 1 -print0)
+
+          for artifact in "$preview_artifact" "$stable_artifact"; do
+              if [ ! -f "$artifact" ] || [ -L "$artifact" ]; then
+                  echo "::error::Missing expected artifact file: ${artifact}"
+                  exit 1
+              fi
+          done
+
+          {
+              echo "preview=${preview_artifact}"
+              echo "stable=${stable_artifact}"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -49,7 +97,9 @@ jobs:
         id: metadata
         run: |
           python scripts/diff_shades_gha_helper.py comment-details \
-          $pr $run_id $(echo .*.pr-comment.md)
+          "$pr" "$run_id" \
+          "${{ steps.comment-artifacts.outputs.preview }}" \
+          "${{ steps.comment-artifacts.outputs.stable }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
           pr: ${{ steps.pr.outputs.pr }}

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -97,13 +97,13 @@ jobs:
         id: metadata
         run: |
           python scripts/diff_shades_gha_helper.py comment-details \
-          "$pr" "$run_id" \
-          "${{ steps.comment-artifacts.outputs.preview }}" \
-          "${{ steps.comment-artifacts.outputs.stable }}"
+          "$pr" "$run_id" "$preview_artifact" "$stable_artifact"
         env:
           GITHUB_TOKEN: ${{ github.token }}
           pr: ${{ steps.pr.outputs.pr }}
           run_id: ${{ github.event.workflow_run.id }}
+          preview_artifact: ${{ steps.comment-artifacts.outputs.preview }}
+          stable_artifact: ${{ steps.comment-artifacts.outputs.stable }}
 
       - name: Try to find pre-existing PR comment
         id: find-comment

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,4 +22,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # The diff-shades comment workflow intentionally runs after the unprivileged
+      # diff-shades workflow so it can publish the generated PR comment. It must
+      # treat artifacts as untrusted and only read validated files from an isolated
+      # artifact directory.
+      - diff_shades_comment.yml


### PR DESCRIPTION
The way the diff-shades workflows work is that diff_shades.yml runs (untrusted) PR code to generate artifacts, then diff_shades_comment.yml runs (trusted) code from main to aggregate the artifacts and make a comment. But the old code did not validate that the artifacts produced by the first workflow were what we want them to be.