### PR TITLE
Do not use pip-install; add dependency cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 2
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -18,4 +18,4 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, reopened]
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 permissions:
   contents: read
 

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group diff-shades --group diff-shades-comment
@@ -80,7 +79,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group diff-shades
@@ -139,7 +137,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group diff-shades
@@ -211,7 +208,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group diff-shades --group diff-shades-comment

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -24,6 +24,7 @@ concurrency:
 
 env:
   HATCH_BUILD_HOOKS_ENABLE: "1"
+  PIP_UPLOADED_PRIOR_TO: P2D
   # Clang is less picky with the C code it's given than gcc (and may generate faster
   # binaries too).
   CC: clang-18
@@ -47,7 +48,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group diff-shades --group diff-shades-comment
+
+      - name: Install dependencies
+        run: python -m pip install --group diff-shades --group diff-shades-comment
 
       - name: Calculate run configuration & metadata
         id: set-config
@@ -78,7 +81,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group diff-shades
+
+      - name: Install dependencies
+        run: python -m pip install --group diff-shades
 
       - name: Configure git
         run: |
@@ -135,7 +140,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group diff-shades
+
+      - name: Install dependencies
+        run: python -m pip install --group diff-shades
 
       - name: Configure git
         run: |
@@ -205,7 +212,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group diff-shades --group diff-shades-comment
+
+      - name: Install dependencies
+        run: python -m pip install --group diff-shades --group diff-shades-comment
 
       - name: Generate HTML diff report
         run: |

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -24,6 +24,7 @@ concurrency:
 
 env:
   HATCH_BUILD_HOOKS_ENABLE: "1"
+  PIP_UPLOADED_PRIOR_TO: P2D
   # Clang is less picky with the C code it's given than gcc (and may generate faster
   # binaries too).
   CC: clang-18

--- a/.github/workflows/diff_shades.yml
+++ b/.github/workflows/diff_shades.yml
@@ -24,7 +24,6 @@ concurrency:
 
 env:
   HATCH_BUILD_HOOKS_ENABLE: "1"
-  PIP_UPLOADED_PRIOR_TO: P2D
   # Clang is less picky with the C code it's given than gcc (and may generate faster
   # binaries too).
   CC: clang-18

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -7,9 +7,6 @@ on:
 
 permissions: {}
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group diff-shades-comment

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/diff_shades_comment.yml
+++ b/.github/workflows/diff_shades_comment.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   comment:
     runs-on: ubuntu-latest
@@ -84,7 +87,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group diff-shades-comment
+
+      - name: Install dependencies
+        run: python -m pip install --group diff-shades-comment
 
       - name: Get PR number
         id: pr

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
 
 env:
+  PIP_UPLOADED_PRIOR_TO: P2D
   REGISTRY: pyfound/black
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   docs:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   docs:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -36,7 +39,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: -e .[d] --group docs
+
+      - name: Install dependencies
+        run: python -m pip install -e ".[d]" --group docs
 
       - name: Build documentation
         run: sphinx-build -a -b html -W --keep-going docs/ docs/_build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   docs:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install -e ".[d]" --group docs

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,9 +18,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
@@ -37,7 +40,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group tox
+
+      - name: Install dependencies
+        run: python -m pip install --group tox
 
       - name: Run fuzz tests
         id: fuzz

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   lint:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -33,7 +36,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: -e . --group tox
+
+      - name: Install dependencies
+        run: python -m pip install -e . --group tox
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install -e . --group tox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   lint:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,6 @@ on: [push, pull_request]
 
 permissions: {}
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   lint:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   update-stable:
     runs-on: ubuntu-latest

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - run: python scripts/release.py -a
 

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   publish:
     name: publish (${{ matrix.os }})
@@ -58,7 +61,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: .[colorama] --group pyinstaller
+
+      - name: Install dependencies
+        run: python -m pip install ".[colorama]" --group pyinstaller
 
       - name: Build executable with PyInstaller
         run:

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install ".[colorama]" --group pyinstaller

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -11,9 +11,6 @@ on:
 
 permissions: {}
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   publish:
     name: publish (${{ matrix.os }})

--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   publish:
     name: publish (${{ matrix.os }})

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group cibw
@@ -85,7 +84,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group cibw
@@ -113,7 +111,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install --group hatch

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -10,6 +10,7 @@ on:
 permissions: {}
 
 env:
+  PIP_UPLOADED_PRIOR_TO: P2D
   PROJECT: https://pypi.org/p/black
 
 jobs:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -10,6 +10,7 @@ on:
 permissions: {}
 
 env:
+  PIP_UPLOADED_PRIOR_TO: P2D
   PROJECT: https://pypi.org/p/black
 
 jobs:
@@ -29,7 +30,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group cibw
+
+      - name: Install dependencies
+        run: python -m pip install --group cibw
 
       - name: generate matrix
         if: |
@@ -83,7 +86,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group cibw
+
+      - name: Install dependencies
+        run: python -m pip install --group cibw
 
       - name: Run cibuildwheel
         run: cibuildwheel . --only ${{ matrix.only }}
@@ -109,7 +114,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group hatch
+
+      - name: Install dependencies
+        run: python -m pip install --group hatch
 
       - name: Build wheel and source distributions
         run: python -m hatch build

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -10,7 +10,6 @@ on:
 permissions: {}
 
 env:
-  PIP_UPLOADED_PRIOR_TO: P2D
   PROJECT: https://pypi.org/p/black
 
 jobs:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -115,8 +115,16 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --group hatch
 
+      - name: Calculate PIP_UPLOADED_PRIOR_TO
+        # virtualenv 20.39 uses pip 26.0 - manually calculate this until we bump virtualenv/hatch
+        id: uploaded_prior_to
+        run:
+          echo "date=$(date -u -d "2 days ago" +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build wheel and source distributions
         run: python -m hatch build
+        env:
+          PIP_UPLOADED_PRIOR_TO: ${{ steps.uploaded_prior_to.outputs.date }}
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -14,9 +14,6 @@ on:
 
 permissions: {}
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 jobs:
   test-release-tool:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -14,6 +14,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   test-release-tool:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -14,6 +14,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   test-release-tool:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -42,7 +45,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group coverage
+
+      - name: Install dependencies
+        run: python -m pip install --group coverage
 
       - name: Print Python Version
         run: python --version --version && which python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -58,7 +61,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: --group tox
+
+      - name: Install dependencies
+        run: python -m pip install --group tox
 
       - name: Unit tests
         if: "!startsWith(matrix.python-version, 'pypy')"
@@ -119,7 +124,9 @@ jobs:
           python-version: "3.15"
           allow-prereleases: true
           pip-version: "26.1"
-          pip-install: -e .[uvloop]
+
+      - name: Install dependencies
+        run: python -m pip install -e ".[uvloop]"
 
       - name: Format ourselves
         run: python -m black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,6 @@ jobs:
         with:
           python-version: "3.15"
           allow-prereleases: true
-          pip-version: "26.1"
 
       - name: Install dependencies
         run: python -m pip install -e ".[uvloop]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PIP_UPLOADED_PRIOR_TO: P2D
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,9 @@ on:
 
 permissions: {}
 
+env:
+  PIP_UPLOADED_PRIOR_TO: P2D
+
 jobs:
   zizmor:
     name: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,3 +6,6 @@ rules:
       # treat artifacts as untrusted and only read validated files from an isolated
       # artifact directory.
       - diff_shades_comment.yml
+  dependabot-cooldown:
+    config:
+      days: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir /src
 COPY . /src/
 ENV VIRTUAL_ENV=/opt/venv
 ENV HATCH_BUILD_HOOKS_ENABLE=1
+ENV PIP_UPLOADED_PRIOR_TO=P2D
 # Install build tools to compile black + dependencies
 RUN apt update && apt install -y build-essential git python3-dev
 


### PR DESCRIPTION
Zizmor recommends against pip-install (https://docs.zizmor.sh/audits/#misfeature).

Also add dependency cooldowns to prevent supply-chain compromises.