### PR TITLE
Fix case guard splitting at small line lengths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix a crash when splitting `case case if ...` match patterns at very small line
+  lengths (#5147)
+
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1107,6 +1107,11 @@ def _maybe_split_omitting_optional_parens(
                     and rhs.opening_bracket.parent.parent
                     and rhs.opening_bracket.parent.parent.type == syms.dictsetmaker
                 )
+                and not (
+                    rhs.opening_bracket.parent
+                    and rhs.opening_bracket.parent.parent
+                    and rhs.opening_bracket.parent.parent.type == syms.case_block
+                )
             ):
                 raise CannotSplit(
                     "Splitting failed, body is still too long and can't be split."
@@ -1648,6 +1653,11 @@ def normalize_invisible_parens(
                 # A special patch for "case case:" scenario, the second occurrence
                 # of case will be not parsed as a Python keyword.
                 break
+
+            elif isinstance(child, Node) and child.type == syms.guard:
+                # Guard nodes handle their own inner wrapping. Wrapping the guard
+                # itself can produce invalid output when the case pattern splits.
+                pass
 
             elif not is_multiline_string(child):
                 if (

--- a/tests/data/cases/pattern_matching_case_case_small_line_length.py
+++ b/tests/data/cases/pattern_matching_case_case_small_line_length.py
@@ -1,0 +1,13 @@
+# flags: --minimum-version=3.10 --line-length=10
+
+match test:
+    case case if True:
+        pass
+
+# output
+
+match test:
+    case (
+        case
+    ) if True:
+        pass


### PR DESCRIPTION
Fixes #4280

### Description

When `case case if True` is formatted at a small line length, Black can make the pattern parentheses visible but also wrap the guard itself. That produces invalid output shaped like `case case ( if True ):`, and the second formatting pass fails to parse it.

This keeps guard nodes from being wrapped as a whole and allows the case-pattern split to keep the visible pattern parentheses instead. The guard remains outside the pattern parentheses, matching the expected output from the issue.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

Tests run:

- `.\.venv\Scripts\python -m pytest tests/test_format.py -k pattern_matching_case_case_small_line_length -q`
- `.\.venv\Scripts\python -m pytest tests/test_format.py -k pattern_matching -q`
- `.\.venv\Scripts\python -m pytest tests/test_format.py -q`
- `.\.venv\Scripts\python -m black --check src\black\linegen.py`
- `.\.venv\Scripts\python -m pytest tests -q --run-optional no_jupyter -k "not symlink"`

I also ran `.\.venv\Scripts\python -m pytest tests -q --run-optional no_jupyter`; only three existing symlink tests failed because this Windows environment cannot create symlinks.