### PR TITLE
fix: resolve CWD before lru_cache key in find_project_root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,11 @@
 
 <!-- Changes to how Black can be configured -->
 
+- Fix `find_project_root` returning a stale cached result when `--code` is used from
+  different working directories in the same process. The CWD fallback (used when no
+  `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
+  directory gets the correct `pyproject.toml` (#5152)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -43,9 +43,8 @@ def _cached_resolve(path: Path) -> Path:
     return path.resolve()
 
 
-@lru_cache
 def find_project_root(
-    srcs: Sequence[str], stdin_filename: str | None = None
+    srcs: Sequence[str | Path], stdin_filename: str | None = None
 ) -> tuple[Path, str]:
     """Return a directory containing .git, .hg, or pyproject.toml.
 
@@ -64,10 +63,20 @@ def find_project_root(
     """
     if stdin_filename is not None:
         srcs = tuple(stdin_filename if s == "-" else s for s in srcs)
-    if not srcs:
-        srcs = [str(_cached_resolve(Path.cwd()))]
 
-    path_srcs = [_cached_resolve(Path(Path.cwd(), src)) for src in srcs]
+    if not srcs:
+        resolved_srcs: tuple[str, ...] = (str(_cached_resolve(Path.cwd())),)
+    else:
+        resolved_srcs = tuple(
+            str(_cached_resolve(Path(Path.cwd(), src))) for src in srcs
+        )
+
+    return _find_project_root_cached(resolved_srcs)
+
+
+@lru_cache
+def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
+    path_srcs = [Path(src) for src in srcs]
 
     # A list of lists of parents for each 'src'. 'src' is included as a
     # "parent" of itself if it is a directory


### PR DESCRIPTION
### Description

When `srcs` is empty (e.g. `black --code`), `find_project_root` fell back to `os.getcwd()` *inside* the `@lru_cache`-decorated function. The working directory was never part of the cache key — only `(srcs, stdin_filename)` was — so two calls from different directories with `srcs=()` would share the same cache entry and return the wrong project root and `pyproject.toml`.

This was observable in the test suite: `test_code_option_config` and `test_code_option_parent_config` both call `black --code` from different directories using `change_directory`. Whichever ran second would hit the stale cache entry from the first and load the wrong config.

**Fix:** split the function into two parts:
- `find_project_root` (public, no cache) resolves the CWD fallback upfront and normalises all `srcs` to absolute paths before handing off.
- `_find_project_root_cached` (private, `@lru_cache`) only ever receives fully-resolved paths, so its cache key is stable regardless of where the process is running from.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? — N/A, no formatting changes.
- [x] Add an entry in `CHANGES.md` if necessary? — Yes, added under Configuration.
- [x] Add / update tests if necessary? — The existing `test_code_option_config` and `test_code_option_parent_config` tests cover this exactly; they were failing before the fix.
- [x] Add new / update outdated documentation? — N/A, no user-visible API or formatting behaviour changed.