### PR TITLE
Document standalone release executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ _Black_ can be installed by running `pip install black`. It requires Python 3.10
 run. If you want to format Jupyter Notebooks, install with
 `pip install "black[jupyter]"`.
 
+If you want to run _Black_ without installing Python, download one of the
+PyInstaller-built standalone executables from the
+[latest GitHub release](https://github.com/psf/black/releases/latest).
+
 ### Usage
 
 To get started right away with sensible defaults:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,10 @@ If you want to format Jupyter Notebooks, install with `pip install "black[jupyte
 See the [Jupyter Notebooks guide](./guides/using_black_with_jupyter_notebooks.md) for
 more details.
 
+If you want to run _Black_ without installing Python, download one of the
+PyInstaller-built standalone executables from the
+[latest GitHub release](https://github.com/psf/black/releases/latest).
+
 If you can't wait for the latest _hotness_ and want to install from GitHub, use:
 
 `pip install git+https://github.com/psf/black`


### PR DESCRIPTION
### Description

Closes #2492.

This adds short installation notes to the README and Getting Started page pointing users to the standalone executables published on GitHub releases. The wording focuses on Black users who want to run Black without installing Python, rather than explaining PyInstaller itself.

This follows the review feedback from #4545 that the binaries should be surfaced in the installation docs.

Docs-only change; I did not add a CHANGES.md entry because the changelog notes that small docs changes do not need one. Please add `ci: skip news` if appropriate.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (Not applicable.)
- [x] Add an entry in `CHANGES.md` if necessary? (Not necessary for this small docs change.)
- [x] Add / update tests if necessary? (Not necessary for docs-only wording.)
- [x] Add new / update outdated documentation?

### Test Plan

- `git diff --check`