### PR TITLE
fix quadratic backtracking in unicode escape normalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@
 
 <!-- Changes that improve Black's performance. -->
 
+- Improve performance on strings containing many consecutive backslashes (#5163)
+
 ### Output
 
 <!-- Changes to Black's terminal output and error messages -->

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -21,7 +21,7 @@ UNICODE_ESCAPE_RE: Final = re.compile(
     r"|(U(?P<U>[a-fA-F0-9]{8}))"  # Character with 32-bit hex value xxxxxxxx
     r"|(x(?P<x>[a-fA-F0-9]{2}))"  # Character with hex value hh
     r"|(N\{(?P<N>[a-zA-Z0-9 \-]{2,})\})"  # Character named name in the Unicode database
-    r")",
+    r")?",
     re.VERBOSE,
 )
 
@@ -319,8 +319,8 @@ def normalize_unicode_escape_sequences(leaf: Leaf) -> None:
         groups = m.groupdict()
         back_slashes = groups["backslashes"]
 
-        if len(back_slashes) % 2 == 0:
-            return back_slashes + groups["body"]
+        if groups["body"] is None or len(back_slashes) % 2 == 0:
+            return m.group(0)
 
         if groups["u"]:
             # \u


### PR DESCRIPTION
normalize_unicode_escape_sequences runs UNICODE_ESCAPE_RE over every string leaf, and the pattern matched a backslash run with (\\+) immediately followed by a required escape body. A long run of backslashes with no trailing u/U/x/N escape makes the engine retry the run from each restart position, so formatting a string of backslashes is quadratic: a 64KB literal already takes minutes, and blackd accepts far larger bodies over the wire. Making the escape body optional lets the whole run be consumed in a single match, which restores linear time and leaves the output identical.