### PR TITLE
fix quadratic backtracking in debug f-string quote detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@
 <!-- Changes that improve Black's performance. -->
 
 - Improve performance on strings containing many consecutive backslashes (#5163)
+- Improve performance when merging implicitly concatenated f-strings whose expressions
+  contain long string literals (#5165)
 
 ### Output
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -641,7 +641,7 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
                     for span in iter_fexpr_spans(string)
                 ]
                 debug_expressions_contain_visible_quotes = any(
-                    re.search(r".*[\'\"].*(?<![!:=])={1}(?!=)(?![^\s:])", expression)
+                    re.search(r"[\'\"].*(?<![!:=])={1}(?!=)(?![^\s:])", expression)
                     for expression in f_expressions
                 )
                 if not debug_expressions_contain_visible_quotes:


### PR DESCRIPTION
the debug f-string check in make_naked runs re.search with a leading .*, so it rescans for a quote from every start position. while merging implicitly concatenated strings (string_processing / --unstable, and blackd) an expression with a quote but no = goes quadratic, e.g. a long literal like f"{'aaa...'}":

    n= 8000   0.80s
    n=16000   3.17s
    n=32000  11.77s

the leading .* is redundant under re.search, so dropping it restores linear time. i checked the truthiness is unchanged against the old pattern over 300k random expressions.