### PR TITLE
fix: no spurious target-version warning when runtime version is included

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
      Please include the PR number in the changelog entry, not the issue number -->
 
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
+- No spurious target-version warning when runtime version is included in
+  multiple --target-version flags (#5164)
 
 ### Highlights
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@
      Please include the PR number in the changelog entry, not the issue number -->
 
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
-- No spurious target-version warning when runtime version is included in multiple
-  --target-version flags (#5164)
+- No spurious target version warning when runtime version is included in a
+  --target-version flag (#5167)
 
 ### Highlights
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@
      Please include the PR number in the changelog entry, not the issue number -->
 
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
-- No spurious target-version warning when runtime version is included in
-  multiple --target-version flags (#5164)
+- No spurious target-version warning when runtime version is included in multiple
+  --target-version flags (#5164)
 
 ### Highlights
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -206,10 +206,16 @@ def target_version_option_callback(
 def _target_versions_exceed_runtime(
     target_versions: set[TargetVersion],
 ) -> bool:
+    """Check if ALL target versions exceed the runtime Python version.
+
+    If any target version is at or below the runtime version, the AST
+    safety check can succeed for that version's features, so the warning
+    would be spurious.
+    """
     if not target_versions:
         return False
-    max_target_minor = max(tv.value for tv in target_versions)
-    return max_target_minor > sys.version_info[1]
+    min_target_minor = min(tv.value for tv in target_versions)
+    return min_target_minor > sys.version_info[1]
 
 
 def _version_mismatch_message(target_versions: set[TargetVersion]) -> str:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -3283,6 +3283,22 @@ class TestASTSafety(BlackBaseTestCase):
         stderr = result.stderr_bytes.decode() if result.stderr_bytes else ""
         assert "Warning:" not in stderr
 
+    def test_mixed_target_versions_with_runtime_no_warning(self) -> None:
+        """Regression test for #5164: no spurious warning when target includes
+        the runtime version alongside higher versions."""
+        current_minor = sys.version_info[1]
+        higher_target = f"py3{current_minor + 1}"
+        runtime_target = f"py3{current_minor}"
+        code = "x = 1\n"
+        args = [
+            "--target-version", runtime_target,
+            "--target-version", higher_target,
+            "--code", code,
+        ]
+        result = BlackRunner().invoke(black.main, args)
+        stderr = result.stderr_bytes.decode() if result.stderr_bytes else ""
+        assert "Warning:" not in stderr
+
     @pytest.mark.incompatible_with_mypyc
     def test_target_version_exceeds_runtime_clear_error_message(self) -> None:
         max_target = max(TargetVersion, key=lambda tv: tv.value)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -3291,9 +3291,12 @@ class TestASTSafety(BlackBaseTestCase):
         runtime_target = f"py3{current_minor}"
         code = "x = 1\n"
         args = [
-            "--target-version", runtime_target,
-            "--target-version", higher_target,
-            "--code", code,
+            "--target-version",
+            runtime_target,
+            "--target-version",
+            higher_target,
+            "--code",
+            code,
         ]
         result = BlackRunner().invoke(black.main, args)
         stderr = result.stderr_bytes.decode() if result.stderr_bytes else ""


### PR DESCRIPTION
### Description

The `_target_versions_exceed_runtime` function was using `max()` to compare
target versions against the runtime version. This caused a spurious warning
when users specified the runtime version alongside higher target versions
(e.g., `--target-version py314 --target-version py315` on Python 3.14).

The fix uses `min()` instead: the warning now only fires when **all** target
versions exceed the runtime. If any target version is at or below the runtime,
the AST safety check can succeed for that version, making the warning
unnecessary.

Closes #5164.
Closes #5168.

### Approach

- Changed `max()` to `min()` in `_target_versions_exceed_runtime`
- Added regression test that verifies no warning when runtime version is
  included in the target set
- Updated the docstring to clarify the semantics

### AI assistance disclosure

This contribution was developed with the assistance of an AI coding agent
(Buck/OpenClaw). All code was reviewed and verified by a human contributor
before submission.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?