### PR TITLE
fix quadratic fmt: skip/off handling in normalize_fmt_off

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@
 - Improve performance on strings containing many consecutive backslashes (#5163)
 - Improve performance when merging implicitly concatenated f-strings whose expressions
   contain long string literals (#5165)
+- Improve performance on files with many `# fmt: skip`/`# fmt: off` comments by no
+  longer re-walking the whole tree from the root for every directive (#5169)
 
 ### Output
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -193,9 +193,14 @@ def normalize_fmt_off(
     node: Node, mode: Mode, lines: Collection[tuple[int, int]]
 ) -> None:
     """Convert content between `# fmt: off`/`# fmt: on` into standalone comments."""
-    try_again = True
-    while try_again:
-        try_again = convert_one_fmt_off_pair(node, mode, lines)
+    # Walk the leaves once and resume scanning from the last converted position
+    # instead of restarting from the root for every pair. Converting a pair only
+    # mutates the tree at or after the converted leaf, so earlier leaves never
+    # need to be revisited.
+    leaves = list(node.leaves())
+    i = 0
+    while i < len(leaves):
+        i = convert_one_fmt_off_pair(node, leaves, i, mode, lines)
 
 
 def _should_process_fmt_comment(
@@ -332,13 +337,25 @@ def _handle_comment_only_fmt_block(
 
 
 def convert_one_fmt_off_pair(
-    node: Node, mode: Mode, lines: Collection[tuple[int, int]]
-) -> bool:
+    node: Node,
+    leaves: list[Leaf],
+    start: int,
+    mode: Mode,
+    lines: Collection[tuple[int, int]],
+) -> int:
     """Convert content of a single `# fmt: off`/`# fmt: on` into a standalone comment.
 
-    Returns True if a pair was converted.
+    Scans `leaves` starting at `start`. Returns the index to resume scanning from:
+    the index of the leaf that was just converted (so further directives on the same
+    leaf are reconsidered), or ``len(leaves)`` when no further pair is found.
     """
-    for leaf in node.leaves():
+    for idx in range(start, len(leaves)):
+        leaf = leaves[idx]
+        # A previous conversion may have detached this leaf from the tree (e.g. it
+        # was absorbed into a fmt: off block); such leaves are already handled.
+        if not _is_attached(leaf, node):
+            continue
+
         # Skip STANDALONE_COMMENT nodes that were created by fmt:off/on/skip processing
         # to avoid reprocessing them in subsequent iterations
         if leaf.type == STANDALONE_COMMENT and hasattr(
@@ -368,7 +385,7 @@ def convert_one_fmt_off_pair(
                 if _handle_comment_only_fmt_block(
                     leaf, comment, previous_consumed, mode
                 ):
-                    return True
+                    return idx
                 continue
 
             # Need actual nodes to process
@@ -385,8 +402,18 @@ def convert_one_fmt_off_pair(
                 lines,
                 leaf,
             )
-            return True
+            return idx
 
+    return len(leaves)
+
+
+def _is_attached(leaf: Leaf, root: Node) -> bool:
+    """Return whether `leaf` is still reachable from `root` through its parents."""
+    current: LN | None = leaf
+    while current is not None:
+        if current is root:
+            return True
+        current = current.parent
     return False
 
 


### PR DESCRIPTION
**Quadratic `# fmt: skip`/`# fmt: off` handling**

While profiling formatting of a file with a few thousand `# fmt: skip` comments I noticed the runtime growing roughly fourfold each time the input doubled, with `convert_one_fmt_off_pair` and `blib2to3.pytree.leaves` dominating the trace. The root cause is in `normalize_fmt_off`: it converts one directive per call and restarts `node.leaves()` from the root every time, so a file with P directives walks the whole tree P+1 times, giving O(n*P) behaviour. Since `blackd` runs this on unauthenticated input, a fairly small file of skip comments is enough to tie a worker up for seconds.

Converting a pair only ever mutates the tree at or after the converted leaf, so there is no need to rescan from the start. This snapshots the leaves once and resumes scanning from the last converted position, skipping any leaf a previous conversion detached. Output stays the same across the existing fmt test cases and the formatting is still idempotent.