### PR TITLE
avoid re-walking nested brackets in max_delimiter_priority_in_atom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,8 +64,8 @@
 - Improve performance on files with many `# fmt: skip`/`# fmt: off` comments by no
   longer re-walking the whole tree from the root for every directive (#5169)
 - Improve performance on deeply nested parenthesised expressions by no longer
-  re-scanning the whole atom for every nesting level in
-  `max_delimiter_priority_in_atom` (#5171)
+  re-scanning the whole atom for every nesting level in `max_delimiter_priority_in_atom`
+  (#5171)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,9 @@
   contain long string literals (#5165)
 - Improve performance on files with many `# fmt: skip`/`# fmt: off` comments by no
   longer re-walking the whole tree from the root for every directive (#5169)
+- Improve performance on deeply nested parenthesised expressions by no longer
+  re-scanning the whole atom for every nesting level in
+  `max_delimiter_priority_in_atom` (#5171)
 
 ### Output
 

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -1,6 +1,6 @@
 """Builds on top of nodes.py to track brackets."""
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from typing import Final, Union
 
@@ -352,17 +352,43 @@ def max_delimiter_priority_in_atom(node: LN) -> Priority:
         return 0
 
     bt = BracketTracker()
-    for c in node.children[1:-1]:
-        if isinstance(c, Leaf):
-            bt.mark(c)
-        else:
-            for leaf in c.leaves():
-                bt.mark(leaf)
+    for leaf in _top_level_leaves(node.children[1:-1]):
+        bt.mark(leaf)
     try:
         return bt.max_delimiter_priority()
 
     except ValueError:
         return 0
+
+
+def _top_level_leaves(children: Iterable[LN]) -> Iterator[Leaf]:
+    """Yield the leaves that can be top-level (depth 0) delimiters of an atom.
+
+    Anything inside a nested bracket pair is at depth >= 1 and therefore cannot
+    be a top-level delimiter, so only the pair's brackets are kept (to balance
+    the depth tracker) and its interior is skipped. This keeps the scan
+    proportional to the atom's own length instead of re-walking every descendant
+    on every call, which matters for deeply nested expressions like
+    ``((((...))))``.
+    """
+    for child in children:
+        if isinstance(child, Leaf):
+            yield child
+            continue
+        if not child.children:
+            continue
+        first = child.children[0]
+        last = child.children[-1]
+        if (
+            isinstance(first, Leaf)
+            and isinstance(last, Leaf)
+            and first.type in OPENING_BRACKETS
+            and last.type in CLOSING_BRACKETS
+        ):
+            yield first
+            yield last
+        else:
+            yield from _top_level_leaves(child.children)
 
 
 def get_leaves_inside_matching_brackets(leaves: Sequence[Leaf]) -> set[LeafID]:


### PR DESCRIPTION
**Quadratic paren normalisation on deeply nested atoms**

Profiling the formatting of an over-parenthesised assignment showed `maybe_make_parens_invisible_in_atom` recursing once per paren layer, and at every layer it calls `max_delimiter_priority_in_atom`, which walks every descendant leaf of the atom through the recursive `Node.leaves()` generator. For input shaped like `x = (((...)))` that means a full re-scan at each depth, so the work grows cubically once the per-leaf generator delegation is counted in. A 1.6 kB file with 800 nested parens took about 7s here, and the profile was almost entirely `Node.leaves()` and `BracketTracker.mark`.

Only depth-0 leaves can be a top-level delimiter, yet the old scan descended into every nested bracket pair whose contents sit at depth >= 1 and can never contribute. The fix keeps just the brackets of a nested pair to balance the depth tracker and skips the interior, so each call is proportional to the atom's own top level rather than its whole subtree; that same file now formats in about 170ms. Output is unchanged across the test suite, a multi-file corpus and fuzzed bracket-heavy inputs. Worth fixing because the scan runs during ordinary formatting and is reachable pre-auth through blackd, where a tiny request body can pin a worker for seconds.