### PR TITLE
avoid re-naking the whole merged string in _merge_one_string_group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,8 @@
 - Improve performance on deeply nested parenthesised expressions by no longer
   re-scanning the whole atom for every nesting level in `max_delimiter_priority_in_atom`
   (#5171)
+- Improve performance when merging long runs of implicitly concatenated strings by no
+  longer re-escaping the whole accumulated string on every merge step (#5173)
 
 ### Output
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -688,7 +688,6 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
         #   NS: naked string
         #   SS: next string
         #   NSS: naked next string
-        S = ""
         NS = ""
         num_of_strings = 0
         next_str_idx = string_idx
@@ -709,14 +708,20 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
             has_prefix = bool(next_prefix)
             prefix_tracker.append(has_prefix)
 
-            S = prefix + QUOTE + NS + NSS + BREAK_MARK + QUOTE
-            NS = make_naked(S, prefix)
+            # Each NSS is already naked (prefix and quotes stripped, inner quotes
+            # escaped, f-string expression quotes toggled), and the parts are
+            # separated by BREAK_MARK which contains no quote or backslash, so the
+            # naked group is just their concatenation. Re-running make_naked over the
+            # whole accumulated string on every iteration rescans all previously
+            # merged substrings, which is quadratic in the size of the group.
+            NS = NS + NSS + BREAK_MARK
 
             next_str_idx += 1
 
         # Take a note on the index of the non-STRING leaf.
         non_string_idx = next_str_idx
 
+        S = prefix + QUOTE + NS + QUOTE
         S_leaf = Leaf(token.STRING, S)
         if self.normalize_strings:
             S_leaf.value = normalize_string_quotes(S_leaf.value)


### PR DESCRIPTION
### Description

I was profiling the implicitly-concatenated-string path under `--preview` with `string_processing` enabled (also reachable from an unauthenticated `blackd` request via `X-Preview` plus `X-Enable-Unstable-Feature: string_processing`). A line that is just a long run of adjacent string literals, `x = "a" "b" "c" ...`, scaled quadratically: around 2.2s for 1k substrings, 11s for 2k, 29s for 4k. The profiler put almost all of that time in `re.Pattern.sub` called from `make_naked` inside `StringMerger._merge_one_string_group`.

The root cause is the merge loop rebuilding the whole literal each step as `S = prefix + QUOTE + NS + NSS + BREAK_MARK + QUOTE` and then recomputing `NS = make_naked(S, prefix)`, which strips the prefix/quotes and runs a substitution over the entire accumulated body every iteration. So each of the n substrings re-scans everything merged before it, giving O(n²) time and regex work. Each `NSS` is already naked when it is appended, and the pieces are separated by `BREAK_MARK`, which contains no quote or backslash, so there is nothing left for the re-nake to do at the seams and the naked group is exactly the concatenation of the parts. The fix accumulates `NS = NS + NSS + BREAK_MARK` and builds `S` once after the loop. Left unfixed this is a cheap pre-auth CPU sink on any `blackd` instance running the preview feature. Output is byte-identical: the full test suite passes, and re-running the whole `black` source tree, all of `tests/data`, and a batch of crafted f-string / implicit-concat edge cases across stable and preview modes produced no diff against the previous behaviour.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
