### PR TITLE
Keep parens around lambda iterables in comprehensions (preview)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@
   parenthesized expressions (#5135)
 - In `.pyi` stub files, enforce a blank line after a function or method that has a
   docstring-only body when another comment or statement follows it (#5158)
+- Keep the parentheses around a lambda used as the iterable of a comprehension (e.g.
+  `[x for x in (lambda: 0) if x]`). They were previously stripped by
+  `wrap_comprehension_in`, which produced invalid code and crashed Black (#5176)
 
 ### Configuration
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1647,7 +1647,7 @@ def normalize_invisible_parens(
                 and len(child.children) == 3
                 and is_lpar_token(child.children[0])
                 and is_rpar_token(child.children[-1])
-                and child.children[1].type == syms.test
+                and child.children[1].type in {syms.test, syms.lambdef}
             ):
                 if maybe_make_parens_invisible_in_atom(
                     child, parent=node, mode=mode, features=features

--- a/tests/data/cases/preview_wrap_comprehension_in.py
+++ b/tests/data/cases/preview_wrap_comprehension_in.py
@@ -33,6 +33,11 @@ lcomp3 = [
 # Don't remove parens around ternaries
 expected = [i for i in (a if b else c)]
 
+# Don't remove parens around lambdas; without them the trailing comprehension
+# clauses would be parsed as part of the lambda body, producing invalid code
+lambda_iter = [i for i in (lambda: 0) if i]
+lambda_iter_no_clause = [i for i in (lambda x: x)]
+
 # Nested arrays
 # First in will not be split because it would still be too long
 [[
@@ -113,6 +118,11 @@ lcomp3 = [
 
 # Don't remove parens around ternaries
 expected = [i for i in (a if b else c)]
+
+# Don't remove parens around lambdas; without them the trailing comprehension
+# clauses would be parsed as part of the lambda body, producing invalid code
+lambda_iter = [i for i in (lambda: 0) if i]
+lambda_iter_no_clause = [i for i in (lambda x: x)]
 
 # Nested arrays
 # First in will not be split because it would still be too long


### PR DESCRIPTION
### Description

On `--preview`, this code crashes Black with an `ASTSafetyError`:

```python
[x for x in (lambda: 0) if x]
```

`wrap_comprehension_in` makes the parens around a comprehension's iterable
invisible when the inner expression is low-precedence. There's already a guard
that keeps them for ternaries, but it only checks for `syms.test`, so a lambda
iterable slips through. Dropping the parens lets the trailing `if`/`for` clauses
get parsed as part of the lambda body (`lambda: 0 if x`), which isn't valid, so
Black emits unparsable output and bails out with an internal error. A bare
`[x for x in (lambda y: y)]` is broken the same way.

The fix extends the existing guard to also cover `syms.lambdef`. Long lambda
iterables still get wrapped, just with the parens kept. Hit a few comprehension
shapes (list/set/dict/genexpr, trailing `if` and `for`) while checking it.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
