### PR TITLE
avoid quadratic opening-bracket scan in is_one_sequence_between

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@
   (#5171)
 - Improve performance when merging long runs of implicitly concatenated strings by no
   longer re-escaping the whole accumulated string on every merge step (#5173)
+- Improve performance on long calls and collections by no longer scanning the whole
+  line to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,8 +74,8 @@
   (#5171)
 - Improve performance when merging long runs of implicitly concatenated strings by no
   longer re-escaping the whole accumulated string on every merge step (#5173)
-- Improve performance on long calls and collections by no longer scanning the whole
-  line to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on long calls and collections by no longer scanning the whole line
+  to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
 
 ### Output
 

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -684,11 +684,24 @@ def is_one_sequence_between(
         return False
 
     depth = closing.bracket_depth + 1
-    for _opening_index, leaf in enumerate(leaves):
-        if leaf is opening:
+    # Locate `opening` by scanning inward from both ends at once. Callers pass the
+    # whole line's leaf list and this runs once per bracket, so a plain forward scan
+    # from the start costs O(index) and turns quadratic on a long line; meeting in
+    # the middle bounds each lookup to the nearer end.
+    _opening_index = -1
+    left = 0
+    right = len(leaves) - 1
+    while left <= right:
+        if leaves[left] is opening:
+            _opening_index = left
             break
+        if leaves[right] is opening:
+            _opening_index = right
+            break
+        left += 1
+        right -= 1
 
-    else:
+    if _opening_index == -1:
         return False
 
     commas = 0


### PR DESCRIPTION
Profiling format_str on a single long call such as result = g(f(a, b, c, d, e, f), ...) showed is_one_sequence_between dominating the run, with cProfile putting almost all of its time in the first loop. That loop finds the opening bracket by walking the line's whole leaf list from index 0, and both generate_trailers_to_omit and has_magic_trailing_comma call it once per closing bracket while the right-hand split runs. On a line with n brackets the per-call O(index) scan sums to O(n^2), so a 374 KB statement, reachable through unauthenticated blackd in the default style, takes around 8.5s here.

The leaf is a unique object, so the scan can meet in the middle: it checks both ends and steps inward, bounding each lookup to the nearer end and never costing more than the old forward scan. The same input now formats in 2.8s with a linear curve. I kept the change in the callee because both call sites only hold the bracket object and the full leaf list, so the cheaper lookup belongs where that list is searched; output stays byte-identical across the test suite and a 298-file corpus over five modes.