### PR TITLE
avoid rebuilding sibling maps on every node mutation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,9 @@
   (#5171)
 - Improve performance when merging long runs of implicitly concatenated strings by no
   longer re-escaping the whole accumulated string on every merge step (#5173)
+- Improve performance on code whose formatting rewrites large nodes (such as `--preview`
+  string processing) by maintaining the `blib2to3` sibling-node maps incrementally rather
+  than rebuilding them from scratch after every tree mutation (#5178)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,8 +75,8 @@
 - Improve performance when merging long runs of implicitly concatenated strings by no
   longer re-escaping the whole accumulated string on every merge step (#5173)
 - Improve performance on code whose formatting rewrites large nodes (such as `--preview`
-  string processing) by maintaining the `blib2to3` sibling-node maps incrementally rather
-  than rebuilding them from scratch after every tree mutation (#5178)
+  string processing) by maintaining the `blib2to3` sibling-node maps incrementally
+  rather than rebuilding them from scratch after every tree mutation (#5178)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,15 +73,14 @@
   re-scanning the whole atom for every nesting level in `max_delimiter_priority_in_atom`
   (#5171)
 - Improve performance when merging long runs of implicitly concatenated strings by no
-  longer re-escaping the whole accumulated string on every merge step (#5173)
-<<<<<<< sibling-maps-incremental
+  longer re-escaping the whole accumulated string on every merge step (#5173) <<<<<<<
+  sibling-maps-incremental
 - Improve performance on code whose formatting rewrites large nodes (such as `--preview`
   string processing) by maintaining the `blib2to3` sibling-node maps incrementally
-  rather than rebuilding them from scratch after every tree mutation (#5178)
-=======
+  rather than rebuilding them from scratch after every tree mutation (#5178) =======
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
->>>>>>> main
+  > > > > > > > main
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,14 +73,13 @@
   re-scanning the whole atom for every nesting level in `max_delimiter_priority_in_atom`
   (#5171)
 - Improve performance when merging long runs of implicitly concatenated strings by no
-  longer re-escaping the whole accumulated string on every merge step (#5173) <<<<<<<
+  longer re-escaping the whole accumulated string on every merge step (#5173)
   sibling-maps-incremental
 - Improve performance on code whose formatting rewrites large nodes (such as `--preview`
   string processing) by maintaining the `blib2to3` sibling-node maps incrementally
-  rather than rebuilding them from scratch after every tree mutation (#5178) =======
+  rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
-  > > > > > > > main
 
 ### Output
 

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -174,7 +174,7 @@ class Base:
                 if node is self:
                     del self.parent.children[i]
                     self.parent.changed()
-                    self.parent.invalidate_sibling_maps()
+                    self.parent._remove_from_sibling_maps(self)
                     self.parent = None
                     return i
         return None
@@ -322,10 +322,11 @@ class Node(Base):
         child's parent attribute appropriately.
         """
         child.parent = self
-        self.children[i].parent = None
+        old = self.children[i]
+        old.parent = None
         self.children[i] = child
         self.changed()
-        self.invalidate_sibling_maps()
+        self._replace_in_sibling_maps(old, child)
 
     def insert_child(self, i: int, child: NL) -> None:
         """
@@ -335,7 +336,10 @@ class Node(Base):
         child.parent = self
         self.children.insert(i, child)
         self.changed()
-        self.invalidate_sibling_maps()
+        if 0 <= i < len(self.children) and self.children[i] is child:
+            self._insert_into_sibling_maps(i, child)
+        else:
+            self.invalidate_sibling_maps()
 
     def append_child(self, child: NL) -> None:
         """
@@ -345,11 +349,62 @@ class Node(Base):
         child.parent = self
         self.children.append(child)
         self.changed()
-        self.invalidate_sibling_maps()
+        self._insert_into_sibling_maps(len(self.children) - 1, child)
 
     def invalidate_sibling_maps(self) -> None:
         self.prev_sibling_map: dict[int, NL | None] | None = None
         self.next_sibling_map: dict[int, NL | None] | None = None
+
+    def _insert_into_sibling_maps(self, i: int, child: NL) -> None:
+        """Splice a newly inserted child into the cached sibling maps.
+
+        Keeps the maps valid without rebuilding them from scratch, which would
+        be O(len(children)) per call and quadratic when many children are
+        inserted while siblings are read in between (e.g. ``append_leaves``).
+        """
+        prev_map = self.prev_sibling_map
+        next_map = self.next_sibling_map
+        if prev_map is None or next_map is None:
+            return
+        before = self.children[i - 1] if i > 0 else None
+        after = self.children[i + 1] if i + 1 < len(self.children) else None
+        prev_map[id(child)] = before
+        next_map[id(child)] = after
+        next_map[id(before)] = child
+        if after is not None:
+            prev_map[id(after)] = child
+
+    def _remove_from_sibling_maps(self, child: NL) -> None:
+        """Splice a removed child out of the cached sibling maps."""
+        prev_map = self.prev_sibling_map
+        next_map = self.next_sibling_map
+        if prev_map is None or next_map is None:
+            return
+        if id(child) not in prev_map:
+            self.invalidate_sibling_maps()
+            return
+        before = prev_map.pop(id(child))
+        after = next_map.pop(id(child))
+        next_map[id(before)] = after
+        if after is not None:
+            prev_map[id(after)] = before
+
+    def _replace_in_sibling_maps(self, old: NL, child: NL) -> None:
+        """Swap ``old`` for ``child`` at the same position in the sibling maps."""
+        prev_map = self.prev_sibling_map
+        next_map = self.next_sibling_map
+        if prev_map is None or next_map is None:
+            return
+        if id(old) not in prev_map:
+            self.invalidate_sibling_maps()
+            return
+        before = prev_map.pop(id(old))
+        after = next_map.pop(id(old))
+        prev_map[id(child)] = before
+        next_map[id(child)] = after
+        next_map[id(before)] = child
+        if after is not None:
+            prev_map[id(after)] = child
 
     def update_sibling_maps(self) -> None:
         _prev: dict[int, NL | None] = {}


### PR DESCRIPTION
### Description

While profiling `--preview` runs over string-heavy modules I traced a quadratic in `format_str` to the sibling-map cache in `blib2to3/pytree.py`. On an input shaped like `"%s " * n` formatted against `% (a,) * n`, `update_sibling_maps` accounted for 54% of the runtime: every `replace_child`/`append_leaves` mutation dropped the parent's `prev`/`next` maps, and the following `whitespace()` lookup rebuilt them in full, so a node with N children was rescanned on each of its own mutations.

1. `remove`, `set_child`, `insert_child` and `append_child` discarded both sibling maps on every call, forcing the next `prev_sibling`/`next_sibling` read to rebuild the entire O(N) map from scratch.
2. Each of those mutators now splices only the affected node into or out of the existing maps in O(1), and falls back to a full invalidation when the maps are absent or the node is unexpectedly missing.

Output is unchanged. The incremental maps are byte-for-byte identical to a from-scratch rebuild, which I verified against a rebuild over 16k randomised mutation sequences, the full test suite, and the black plus stdlib trees in both stable and preview. On the `%`-format case `update_sibling_maps` disappears from the profile and wall-clock drops roughly 4x at n=1200. Left as is this is an amplification vector through blackd, where the preview path is reachable without authentication.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (n/a, no style change; output is byte-identical)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary? (behaviour is unchanged and stays covered by the existing suite)
- [ ] Add new / update outdated documentation? (internal change, none needed)