### PR TITLE
avoid quadratic child-list rescan when wrapping nodes in parens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,9 @@
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on large dict literals and long semicolon-separated statements by
+  wrapping a node's children in invisible parentheses in place instead of removing and
+  re-inserting each one, which scanned the whole child list every time (#5184)
 
 ### Output
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -263,7 +263,7 @@ class LineGenerator(Visitor[Line]):
                             remove_brackets_around_comma=False,
                         )
                     else:
-                        wrap_in_parentheses(node, child, visible=False)
+                        wrap_in_parentheses(node, child, visible=False, index=i)
         yield from self.visit_default(node)
 
     def visit_funcdef(self, node: Node) -> Iterator[Line]:
@@ -312,9 +312,9 @@ class LineGenerator(Visitor[Line]):
     def visit_simple_stmt(self, node: Node) -> Iterator[Line]:
         """Visit a statement without nested statements."""
         prev_type: int | None = None
-        for child in node.children:
+        for i, child in enumerate(node.children):
             if (prev_type is None or prev_type == token.SEMI) and is_arith_like(child):
-                wrap_in_parentheses(node, child, visible=False)
+                wrap_in_parentheses(node, child, visible=False, index=i)
             prev_type = child.type
 
         if node.parent and node.parent.type in STATEMENT:

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -1000,22 +1000,40 @@ def is_type_ignore_comment_string(value: str, mode: Mode) -> bool:
     ].lstrip().startswith("ignore")
 
 
-def wrap_in_parentheses(parent: Node, child: LN, *, visible: bool = True) -> None:
+def wrap_in_parentheses(
+    parent: Node, child: LN, *, visible: bool = True, index: int | None = None
+) -> None:
     """Wrap `child` in parentheses.
 
     This replaces `child` with an atom holding the parentheses and the old
     child.  That requires moving the prefix.
 
     If `visible` is False, the leaves will be valueless (and thus invisible).
+
+    When the caller already knows `child`'s position in `parent.children` it
+    can pass `index` so the child is swapped in place. The default path locates
+    `child` with `Base.remove`, which scans and rewrites the whole child list;
+    that is O(len(parent.children)) per call and turns quadratic when a caller
+    wraps every child of a large node (e.g. each value of a big dict literal).
     """
     lpar = Leaf(token.LPAR, "(" if visible else "")
     rpar = Leaf(token.RPAR, ")" if visible else "")
     prefix = child.prefix
     child.prefix = ""
-    index = child.remove() or 0
-    new_child = Node(syms.atom, [lpar, child, rpar])
-    new_child.prefix = prefix
-    parent.insert_child(index, new_child)
+    if index is None:
+        index = child.remove() or 0
+        new_child = Node(syms.atom, [lpar, child, rpar])
+        new_child.prefix = prefix
+        parent.insert_child(index, new_child)
+    else:
+        # Detach the child pointer first so the atom can adopt it, then swap it
+        # in place. set_child resets the old child's parent, so reattach it to
+        # the new atom afterwards.
+        child.parent = None
+        new_child = Node(syms.atom, [lpar, child, rpar])
+        new_child.prefix = prefix
+        parent.set_child(index, new_child)
+        child.parent = new_child
 
 
 def unwrap_singleton_parenthesis(node: LN) -> LN | None:


### PR DESCRIPTION
### Description

Profiling Black on a large dict literal (a single `{0: 0, 1: 1, ...}` with
thousands of entries under `--preview`) showed almost all the time inside
`blib2to3`'s `Base.remove`: a 16000-entry dict took ~85s, and `remove` alone
accounted for ~34s of a 59s run. The cause is `wrap_in_parentheses`, which
swaps a child for an invisible-parens atom by calling `child.remove()` (a
linear scan of `parent.children` plus a list delete) and then `insert_child`
(another linear shift). `visit_dictsetmaker` wraps every value of a dict, and
`visit_simple_stmt` wraps every arith-like statement on a semicolon-separated
line, so each wrap re-scanned the whole sibling list and the pass went
quadratic in the number of children. The `simple_stmt` path is stable style,
so `a + b; c + d; ...` triggers it without any preview flag; left unfixed it is
a pre-auth amplification vector through `blackd`.

Both callers already hold the child's index from their `enumerate` loop, so
`wrap_in_parentheses` takes an optional `index` and, when given, swaps the
child in place via `set_child` (an O(1) list write plus the incremental
sibling-map update added in #5178) instead of remove + re-insert. The default
`remove()` path is unchanged for callers that don't know the position. Output
is byte-identical across the test suite and crafted dict/set/comprehension/
semicolon inputs in stable, preview and unstable modes; the 16000-entry dict
drops from ~85s to ~15s and the curve flattens to linear.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
