### PR TITLE
Fix normalize_string_prefix not lowercasing uppercase T t-string prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,13 +27,14 @@
   `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
-- Fix `normalize_string_prefix` not lowercasing the uppercase `T` prefix of t-strings
-  (e.g. `T"..."` was left unchanged instead of being normalized to `t"..."`) (#5185)
+
 
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
 
+- Normalize the uppercase `T` prefix of t-strings to lowercase in preview style
+  (e.g. `T"..."` is now normalized to `t"..."`) (#5185)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like
   `x[key] = expr` (#5095)
 - Parenthesize tuple expressions in `yield` statements for consistency with function

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,9 +27,8 @@
   `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
-- Fix `normalize_string_prefix` not lowercasing the uppercase `T` prefix of
-  t-strings (e.g. `T"..."` was left unchanged instead of being normalized to
-  `t"..."`) (#5185)
+- Fix `normalize_string_prefix` not lowercasing the uppercase `T` prefix of t-strings
+  (e.g. `T"..."` was left unchanged instead of being normalized to `t"..."`) (#5185)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@
   `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
+- Fix `normalize_string_prefix` not lowercasing the uppercase `T` prefix of
+  t-strings (e.g. `T"..."` was left unchanged instead of being normalized to
+  `t"..."`) (#XXXX)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@
   previously crashing) (#5161)
 - Fix `normalize_string_prefix` not lowercasing the uppercase `T` prefix of
   t-strings (e.g. `T"..."` was left unchanged instead of being normalized to
-  `t"..."`) (#XXXX)
+  `t"..."`) (#5185)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,13 +28,12 @@
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
 
-
 ### Preview style
 
 <!-- Changes that affect Black's preview style -->
 
-- Normalize the uppercase `T` prefix of t-strings to lowercase in preview style
-  (e.g. `T"..."` is now normalized to `t"..."`) (#5185)
+- Normalize the uppercase `T` prefix of t-strings to lowercase in preview style (e.g.
+  `T"..."` is now normalized to `t"..."`) (#5185)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like
   `x[key] = expr` (#5095)
 - Parenthesize tuple expressions in `yield` statements for consistency with function

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -43,6 +43,8 @@ Currently, the following features are included in the preview style:
   anyway; let the bracket explode instead. ([see below](labels/hug-comparator))
 - `parenthesize_tuple_in_yield`: Add parentheses around tuple expressions in `yield`
   statements.
+- `normalize_tstring_prefix`: Normalize the uppercase `T` prefix of t-strings to lowercase
+  (e.g. `T"..."` becomes `t"..."`).
 
 (labels/wrap-comprehension-in)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -43,8 +43,8 @@ Currently, the following features are included in the preview style:
   anyway; let the bracket explode instead. ([see below](labels/hug-comparator))
 - `parenthesize_tuple_in_yield`: Add parentheses around tuple expressions in `yield`
   statements.
-- `normalize_tstring_prefix`: Normalize the uppercase `T` prefix of t-strings to lowercase
-  (e.g. `T"..."` becomes `t"..."`).
+- `normalize_tstring_prefix`: Normalize the uppercase `T` prefix of t-strings to
+  lowercase (e.g. `T"..."` becomes `t"..."`).
 
 (labels/wrap-comprehension-in)=
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -473,7 +473,7 @@ class LineGenerator(Visitor[Line]):
             # We're ignoring docstrings with backslash newline escapes because changing
             # indentation of those changes the AST representation of the code.
             if self.mode.string_normalization:
-                docstring = normalize_string_prefix(leaf.value)
+                docstring = normalize_string_prefix(leaf.value, self.mode)
                 # We handle string normalization at the end of this method, but since
                 # what we do right now acts differently depending on quote style (ex.
                 # see padding logic below), there's a possibility for unstable
@@ -550,7 +550,7 @@ class LineGenerator(Visitor[Line]):
                 leaf.value = prefix + quote + docstring + quote
 
         if self.mode.string_normalization and leaf.type == token.STRING:
-            leaf.value = normalize_string_prefix(leaf.value)
+            leaf.value = normalize_string_prefix(leaf.value, self.mode)
             leaf.value = normalize_string_quotes(leaf.value)
         yield from self.visit_default(leaf)
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -263,6 +263,7 @@ class Preview(Enum):
     pyi_blank_line_after_function_docstring = auto()
     hug_comparator = auto()
     parenthesize_tuple_in_yield = auto()
+    normalize_tstring_prefix = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -6,10 +6,15 @@ import re
 import sys
 from functools import lru_cache
 from re import Match, Pattern
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
 
 from black._width_table import WIDTH_TABLE
 from blib2to3.pytree import Leaf
+
+if TYPE_CHECKING:
+    from black.mode import Mode
+
 
 STRING_PREFIX_CHARS: Final = "fturbFTURB"  # All possible string prefix characters.
 STRING_PREFIX_RE: Final = re.compile(
@@ -142,7 +147,7 @@ def assert_is_leaf_string(string: str) -> None:
     ), f"{set(string[:quote_idx])} is NOT a subset of {set(STRING_PREFIX_CHARS)}."
 
 
-def normalize_string_prefix(s: str) -> str:
+def normalize_string_prefix(s: str, mode: "Mode | None" = None) -> str:
     """Make all string prefixes lowercase."""
     match = STRING_PREFIX_RE.match(s)
     assert match is not None, f"failed to match string {s!r}"
@@ -150,15 +155,22 @@ def normalize_string_prefix(s: str) -> str:
     new_prefix = (
         orig_prefix.replace("F", "f")
         .replace("B", "b")
-        .replace("T", "t")
         .replace("U", "")
         .replace("u", "")
     )
+    if mode is None or _is_preview_tstring_normalization(mode):
+        new_prefix = new_prefix.replace("T", "t")
 
     # Python syntax guarantees max 2 prefixes and that one of them is "r"
     if len(new_prefix) == 2 and new_prefix[0].lower() != "r":
         new_prefix = new_prefix[::-1]
     return f"{new_prefix}{match.group(2)}"
+
+
+def _is_preview_tstring_normalization(mode: "Mode") -> bool:
+    from black.mode import Preview
+
+    return Preview.normalize_tstring_prefix in mode
 
 
 # Re(gex) does actually cache patterns internally but this still improves

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -150,6 +150,7 @@ def normalize_string_prefix(s: str) -> str:
     new_prefix = (
         orig_prefix.replace("F", "f")
         .replace("B", "b")
+        .replace("T", "t")
         .replace("U", "")
         .replace("u", "")
     )

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 from re import Match, Pattern
 from typing import TYPE_CHECKING, Final
 
-
 from black._width_table import WIDTH_TABLE
 from blib2to3.pytree import Leaf
 

--- a/tests/data/cases/pep_750.py
+++ b/tests/data/cases/pep_750.py
@@ -40,7 +40,6 @@ t'''
     {1}_cte AS ()'''}
 '''
 
-
 # output
 x = t"foo"
 x = t"foo {{ {2 + 2}bar {{ baz"
@@ -82,5 +81,3 @@ t"""
     WITH {f'''
     {1}_cte AS ()'''}
 """
-
-

--- a/tests/data/cases/pep_750.py
+++ b/tests/data/cases/pep_750.py
@@ -40,6 +40,11 @@ t'''
     {1}_cte AS ()'''}
 '''
 
+# Uppercase T prefix is normalized to lowercase t
+x = T"bar {1 + 1}"
+x = T'bar {1 + 1}'
+rT'\{{\}}'
+
 # output
 x = t"foo"
 x = t"foo {{ {2 + 2}bar {{ baz"
@@ -81,3 +86,8 @@ t"""
     WITH {f'''
     {1}_cte AS ()'''}
 """
+
+# Uppercase T prefix is normalized to lowercase t
+x = t"bar {1 + 1}"
+x = t"bar {1 + 1}"
+rt"\{{\}}"

--- a/tests/data/cases/pep_750.py
+++ b/tests/data/cases/pep_750.py
@@ -40,10 +40,6 @@ t'''
     {1}_cte AS ()'''}
 '''
 
-# Uppercase T prefix is normalized to lowercase t
-x = T"bar {1 + 1}"
-x = T'bar {1 + 1}'
-rT'\{{\}}'
 
 # output
 x = t"foo"
@@ -87,7 +83,4 @@ t"""
     {1}_cte AS ()'''}
 """
 
-# Uppercase T prefix is normalized to lowercase t
-x = t"bar {1 + 1}"
-x = t"bar {1 + 1}"
-rt"\{{\}}"
+

--- a/tests/data/cases/preview_pep_750_normalize_tstring_prefix.py
+++ b/tests/data/cases/preview_pep_750_normalize_tstring_prefix.py
@@ -1,0 +1,13 @@
+# flags: --preview --minimum-version=3.14
+
+# Uppercase T prefix is normalized to lowercase t in preview style
+x = T"bar {1 + 1}"
+x = T'bar {1 + 1}'
+rT'\{{\}}'
+
+# output
+
+# Uppercase T prefix is normalized to lowercase t in preview style
+x = t"bar {1 + 1}"
+x = t"bar {1 + 1}"
+rt"\{{\}}"


### PR DESCRIPTION
### Description

`normalize_string_prefix` is documented to "make all string prefixes lowercase", and it already normalises `F`→`f` and `B`→`b`. However, when t-string support was added in #4805 the `T`→`t` normalisation was accidentally omitted.

**Bug:** Black leaves `T"..."` unchanged instead of normalising it to `t"..."`:

```python
# Before (Black ≥ 26.5 with --target-version py314)
T"hello"   →   T"hello"   # wrong — should be t"hello"
RT"hello"  →   RT"hello"  # wrong — should be Rt"hello"
rT"hello"  →   rT"hello"  # wrong — should be rt"hello"
```

**Fix:** Add a single `.replace("T", "t")` step to the existing chain in `normalize_string_prefix`.

**Verification:**

```
$ pytest tests/test_format.py -k pep_750 -v
PASSED  tests/test_format.py::test_simple_format[pep_750]
```

> AI-assisted: this PR was prepared with the help of an AI coding tool.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?