### PR TITLE
avoid quadratic token-lookahead scan in the parser's TokenProxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,9 @@
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on files with many soft-keyword constructs (such as `match`/`case`
+  blocks) by discarding spent token-lookahead ranges in the parser instead of
+  re-scanning all of them for every token (#5186)
 
 ### Output
 

--- a/src/blib2to3/pgen2/driver.py
+++ b/src/blib2to3/pgen2/driver.py
@@ -82,7 +82,16 @@ class TokenProxy:
         # If the current position is already compromised (looked up)
         # return the eaten token, if not just go further on the given
         # token producer.
-        for release_range in self._release_ranges:
+        # Ranges are appended in counter order and the counter only moves
+        # forward, so any range we've already advanced past can never match
+        # again. Drop that exhausted prefix; otherwise the scan below grows
+        # with the number of soft-keyword lookaheads and parsing a file full
+        # of them (e.g. many `match`/`case` blocks) becomes quadratic.
+        ranges = self._release_ranges
+        while ranges and ranges[0].end is not None and ranges[0].end <= self._counter:
+            ranges.pop(0)
+
+        for release_range in ranges:
             assert release_range.end is not None
 
             start, end = release_range.start, release_range.end


### PR DESCRIPTION
Profiling `format_str` on a file built from many `match`/`case` blocks showed `TokenProxy.__next__` in the blib2to3 driver dominating the run, with almost all of its time spent in the loop that walks `self._release_ranges`. Every soft keyword (`match`, `case`, `type`) makes the parser open a lookahead range through `TokenProxy.release()` to disambiguate it, and that context manager appends a `ReleaseRange` but never drops it, so the list grows to one entry per construct and is never pruned. `__next__` runs once per token and rescans the whole list each time, so a file with n such blocks parses in O(n^2): a 4000-case `match`, reachable through unauthenticated blackd in the default style, takes around 3.8s here with the scan iterating roughly n/2 stale ranges on every token.

The ranges are appended in counter order, never overlap, and the counter only moves forward, so any range whose end the counter has already passed can never match again. Dropping that exhausted prefix before the scan collapses the list back to the single live range and restores linear parsing (the same input now formats in about 1.0s); output stays byte-identical across the test suite and a 1685-entry corpus over five modes. The prune sits in `__next__` because that is where the range list is read and where the stale entries would otherwise pile up.
