### PR TITLE
avoid quadratic multiline-string context scan in is_line_short_enough

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,12 +86,11 @@
   string processing) by maintaining the `blib2to3` sibling-node maps incrementally
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
-  to locate each bracket's opening pair in `is_one_sequence_between` (#5177) <<<<<<<
-  is-line-short-enough-quadratic
+  to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
 - Improve performance on lines holding a multiline string inside a large collection (for
   example a dict literal whose values are all triple-quoted strings) by locating the
   string's enclosing nodes via leaf membership instead of re-rendering each enclosing
-  node to a string in `is_line_short_enough` (#5188) =======
+  node to a string in `is_line_short_enough` (#5188)
 - Improve performance on files with many soft-keyword constructs (such as `match`/`case`
   blocks) by discarding spent token-lookahead ranges in the parser instead of
   re-scanning all of them for every token (#5186)
@@ -101,7 +100,6 @@
 - Improve performance on large dict literals and long semicolon-separated statements by
   wrapping a node's children in invisible parentheses in place instead of removing and
   re-inserting each one, which scanned the whole child list every time (#5184)
-  > > > > > > > main
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,10 @@
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on lines holding a multiline string inside a large collection (for
+  example a dict literal whose values are all triple-quoted strings) by locating the
+  string's enclosing nodes via leaf membership instead of re-rendering each enclosing
+  node to a string in `is_line_short_enough` (#5188)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,13 +86,12 @@
   string processing) by maintaining the `blib2to3` sibling-node maps incrementally
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
-  to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
-<<<<<<< is-line-short-enough-quadratic
+  to locate each bracket's opening pair in `is_one_sequence_between` (#5177) <<<<<<<
+  is-line-short-enough-quadratic
 - Improve performance on lines holding a multiline string inside a large collection (for
   example a dict literal whose values are all triple-quoted strings) by locating the
   string's enclosing nodes via leaf membership instead of re-rendering each enclosing
-  node to a string in `is_line_short_enough` (#5188)
-=======
+  node to a string in `is_line_short_enough` (#5188) =======
 - Improve performance on files with many soft-keyword constructs (such as `match`/`case`
   blocks) by discarding spent token-lookahead ranges in the parser instead of
   re-scanning all of them for every token (#5186)
@@ -102,7 +101,7 @@
 - Improve performance on large dict literals and long semicolon-separated statements by
   wrapping a node's children in invisible parentheses in place instead of removing and
   re-inserting each one, which scanned the whole child list every time (#5184)
->>>>>>> main
+  > > > > > > > main
 
 ### Output
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -13,6 +13,7 @@ from black.nodes import (
     STANDALONE_COMMENT,
     TEST_DESCENDANTS,
     child_towards,
+    first_leaf,
     is_docstring,
     is_import,
     is_multiline_string,
@@ -20,6 +21,7 @@ from black.nodes import (
     is_type_comment,
     is_type_ignore_comment,
     is_with_or_async_with_stmt,
+    last_leaf,
     make_simple_prefix,
     replace_child,
     syms,
@@ -1320,6 +1322,10 @@ def is_line_short_enough(line: Line, *, mode: Mode, line_str: str = "") -> bool:
     # store the leaves that contain parts of the MLS
     multiline_string_contexts: list[LN] = []
 
+    # `id()`s of the leaves on this line, used to find which ancestors of the
+    # multiline string are rendered in full on this line (see below).
+    line_leaf_ids = {id(leaf) for leaf in line.leaves}
+
     max_level_to_update: int | float = math.inf  # track the depth of the MLS
     for i, leaf in enumerate(line.leaves):
         if max_level_to_update == math.inf:
@@ -1363,8 +1369,18 @@ def is_line_short_enough(line: Line, *, mode: Mode, line_str: str = "") -> bool:
                 return False
             multiline_string = leaf
             ctx: LN = leaf
-            # fetch the leaf components of the MLS in the AST
-            while str(ctx) in line_str:
+            # fetch the leaf components of the MLS in the AST. An ancestor is
+            # part of the MLS context while it is rendered in full on this line,
+            # i.e. its first and last leaves both belong to the line (a line is
+            # a contiguous run of leaves). Walking the leaf ids instead of
+            # re-rendering `str(ctx)` and substring-searching `line_str` at every
+            # level keeps this linear; the old form was quadratic on lines with a
+            # large multiline-string-bearing collection (e.g. a dict literal with
+            # many triple-quoted values).
+            while (
+                id(first_leaf(ctx)) in line_leaf_ids
+                and id(last_leaf(ctx)) in line_leaf_ids
+            ):
                 multiline_string_contexts.append(ctx)
                 if ctx.parent is None:
                     break


### PR DESCRIPTION
### Description

While profiling Black on a generated config module I noticed formatting hung for several seconds on a single dict literal whose values were all triple-quoted strings. A flame graph put ~80% of the wall time in `is_line_short_enough`, specifically the `while str(ctx) in line_str` loop that walks the multiline string up through its enclosing AST nodes. Each step renders the whole ancestor subtree to a string and substring-searches the line, so when the topmost ancestor is the entire collection that render is O(N), and because `is_line_short_enough` runs once per candidate split line during line generation the whole pass is O(N²). A dict with 1600 triple-quoted values took ~2.2s; the cost grew quadratically with the number of members.

The walk only needs the ancestors that are wholly present on the current line, and since a line is a contiguous run of leaves an ancestor qualifies exactly when its first and last leaves both belong to the line. Checking two leaf ids against a set built once is O(depth) per step and bails out immediately for ancestors that aren't fully on the line, so the render-and-search disappears and the pass becomes linear (the 1600-value case drops to ~0.23s). Keeping the check here rather than at the call sites means every caller of `is_line_short_enough` benefits without having to special-case multiline strings. Output is unchanged: byte-identical across the test suite, the Black and stdlib sources in stable/preview, and several thousand fuzzed multiline-string structures.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
