### PR TITLE
Fix fmt off block before with statement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
+- Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a
+  `with` statement after another standalone comment (#5189)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
 - Fix multiline docstring indentation when leading tabs are used inside indented

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,8 @@
 
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
-- Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a
-  `with` statement after another standalone comment (#5189)
+- Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`
+  statement after another standalone comment (#5189)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
 - Fix multiline docstring indentation when leading tabs are used inside indented

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -300,9 +300,11 @@ def _handle_comment_only_fmt_block(
         # This preserves all comments and content before the fmt:off directive
         pre_fmt_off_consumed = all_comments[fmt_off_idx - 1].consumed
 
-    standalone_comment_prefix = (
-        original_prefix[:pre_fmt_off_consumed] + "\n" * comment.newlines
-    )
+    preceding_prefix = original_prefix[:pre_fmt_off_consumed]
+    if fmt_off_idx > 0:
+        preceding_prefix = preceding_prefix.lstrip("\r\n")
+
+    standalone_comment_prefix = preceding_prefix + "\n" * comment.newlines
 
     fmt_off_prefix = original_prefix.split(comment.value)[0]
     if "\n" in fmt_off_prefix:

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -407,6 +407,12 @@ class LineGenerator(Visitor[Line]):
             and contains_fmt_directive(lines[-1], FMT_ON)
         )
         if is_fmt_off_block:
+            is_after_invisible_lpar = (
+                leaf.fmt_pass_converted_first_leaf is None
+                and len(self.current_line.leaves) == 1
+                and self.current_line.leaves[0].type == token.LPAR
+                and not self.current_line.leaves[0].value
+            )
             # This is a fmt:off/on block from normalize_fmt_off - we still need
             # to process any prefix comments (like markdown comments) but append
             # the fmt block itself directly to preserve its formatting
@@ -425,7 +431,7 @@ class LineGenerator(Visitor[Line]):
                 leaf.prefix = ""
 
             self.current_line.append(leaf)
-            if not any_open_brackets:
+            if not any_open_brackets or is_after_invisible_lpar:
                 yield from self.line()
         else:
             # Normal standalone comment - process through visit_default

--- a/tests/data/cases/fmtonoff_comment_only_with.py
+++ b/tests/data/cases/fmtonoff_comment_only_with.py
@@ -1,0 +1,34 @@
+# flags: --minimum-version=3.10
+
+with open("bug.txt", "r", encoding="utf-8") as fh1:
+    pass
+# fmt: off
+# fmt: on
+# xxx
+# fmt: off
+# fmt: on
+with open("bug.txt", "r", encoding="utf-8") as fh2:
+    pass
+def fn(str: str) -> float:
+    match str:
+        case _:
+            pass
+
+# output
+
+with open("bug.txt", "r", encoding="utf-8") as fh1:
+    pass
+# fmt: off
+# fmt: on
+
+# xxx
+# fmt: off
+# fmt: on
+with open("bug.txt", "r", encoding="utf-8") as fh2:
+    pass
+
+
+def fn(str: str) -> float:
+    match str:
+        case _:
+            pass


### PR DESCRIPTION
### Description

Fixes #5187.

Comment-only `# fmt: off` / `# fmt: on` blocks before a `with` statement could be emitted on the same logical line as the following `with` statement after a preceding standalone comment. When the line was split, the separator before `with` became a line prefix, so Black produced invalid code with a leading space at top level.

This normalizes the prefix copied onto comment-only fmt blocks and flushes those blocks when they follow Black's invisible context-manager parenthesis, while leaving fmt blocks inside real bracketed expressions on the existing path.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (N/A: this fixes invalid output, not a style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (N/A.)

### Testing

- `/tmp/black-pr-5187-venv/bin/python -m pytest tests/test_format.py -k 'fmtonoff_comment_only_with or fmtonoff6 or fmtonoff3 or fmtonoff2 or fmtskip11'`
- `/tmp/black-pr-5187-venv/bin/python -m pytest tests/test_format.py`
- `/tmp/black-pr-5187-venv/bin/python -m black --check src/black/linegen.py src/black/comments.py`
- `env -u NO_COLOR TERM=xterm-256color /tmp/black-pr-5187-venv/bin/python -m pytest tests --run-optional no_jupyter`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.