### PR TITLE
avoid quadratic suite scan per fmt: skip in compound-statement check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,9 @@
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on functions and other blocks containing many `# fmt: skip`
+  comments by no longer scanning every leaf of the enclosing block for each directive
+  when checking for a semicolon-separated inline body (#5190)
 
 ### Output
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -623,22 +623,28 @@ def _should_keep_compound_statement_inline(
     Returns True only for compound statements with semicolon-separated bodies,
     like: if True: print("a"); print("b")  # fmt: skip
     """
-    # Check if there are semicolons in the body
-    for leaf in body_node.leaves():
-        if leaf.type == token.SEMI:
-            # Verify it's a single-line body (one simple_stmt)
-            if body_node.type == syms.suite:
-                # After formatting: check suite has one simple_stmt child
-                simple_stmts = [
-                    child
-                    for child in body_node.children
-                    if child.type == syms.simple_stmt
-                ]
-                return len(simple_stmts) == 1 and simple_stmts[0] is simple_stmt_parent
-            else:
-                # Original form: body_node IS the simple_stmt
-                return body_node is simple_stmt_parent
-    return False
+    # Narrow down to the single simple_stmt that may carry the semicolons before
+    # scanning any leaves. A compound statement's suite holds one child per body
+    # statement, so walking the whole suite here is O(n) and, called once per
+    # `# fmt: skip` line in the block, makes the pass O(n^2).
+    if body_node.type == syms.suite:
+        # After formatting: the suite must hold exactly one simple_stmt and it
+        # must be the one carrying the directive. Stop at the second simple_stmt.
+        target: LN | None = None
+        for child in body_node.children:
+            if child.type == syms.simple_stmt:
+                if target is not None:
+                    return False
+                target = child
+        if target is None or target is not simple_stmt_parent:
+            return False
+    else:
+        # Original form: body_node IS the simple_stmt
+        if body_node is not simple_stmt_parent:
+            return False
+        target = body_node
+
+    return any(leaf.type == token.SEMI for leaf in target.leaves())
 
 
 def _get_compound_statement_header(


### PR DESCRIPTION
### Description

Profiling a file with many `# fmt: skip` comments inside one function showed `_should_keep_compound_statement_inline` accounting for almost all the runtime, driving millions of `Leaf` generator calls. The function is meant to recognise a semicolon-separated one-line body such as `if True: print("a"); print("b")  # fmt: skip`, and it found the semicolon by walking every leaf of the body node. The catch is that when a skip directive sits on an ordinary statement inside any block, `_find_compound_statement_context` hands back the whole enclosing suite as the body node, so that scan visits every leaf of the entire block. `_generate_ignored_nodes_from_fmt_skip` runs the check once per directive, so a block of N skip comments becomes an O(N^2) pass. A 1600-statement function with one skip per line took around 24s here.

The semicolon search only matters for a body that is a single `simple_stmt`, so the check now narrows to that statement before touching any leaves: the suite has to contain exactly one `simple_stmt` and it has to be the one carrying the directive, bailing out at the second `simple_stmt`. Only then does it look for a `SEMI`, and only inside that one statement. Behaviour is unchanged, the full test suite and the black plus stdlib corpus format byte-for-byte identically in stable and preview, while the curve goes back to linear. Left unfixed this is reachable pre-auth through blackd, where a small crafted payload can tie a worker up for the full quadratic cost.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
