### PR TITLE
Handle empty cache files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,9 +56,6 @@
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
   directory gets the correct `pyproject.toml` (#5152)
 - Add validation for --line-ranges values (#5107)
-
-### Caching
-
 - Ignore empty cache files like other malformed cache files instead of raising an
   `EOFError` (#5192)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,11 @@
   directory gets the correct `pyproject.toml` (#5152)
 - Add validation for --line-ranges values (#5107)
 
+### Caching
+
+- Ignore empty cache files like other malformed cache files instead of raising an
+  `EOFError` (#5192)
+
 ### Packaging
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->

--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -79,7 +79,7 @@ class Cache:
             try:
                 data: dict[str, tuple[float, int, str]] = pickle.load(fobj)
                 file_data = {k: FileData(*v) for k, v in data.items()}
-            except (pickle.UnpicklingError, ValueError, IndexError):
+            except (pickle.UnpicklingError, EOFError, ValueError, IndexError):
                 return cls(mode, cache_file)
 
         return cls(mode, cache_file, file_data)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2256,6 +2256,13 @@ class TestCaching:
             cache = black.Cache.read(mode)
             assert not cache.is_changed(src)
 
+    def test_cache_empty_file(self) -> None:
+        mode = DEFAULT_MODE
+        with cache_dir():
+            cache_file = get_cache_file(mode)
+            cache_file.touch()
+            assert black.Cache.read(mode).file_data == {}
+
     def test_cache_single_file_already_cached(self) -> None:
         mode = DEFAULT_MODE
         with cache_dir() as workspace:


### PR DESCRIPTION
### Summary

Treat empty or truncated cache files the same way as other malformed cache files.

### Details

`Cache.read()` already ignores malformed pickle data so a later cache write can repair the file, but an empty cache file raises `EOFError`, which was not caught. This can happen if cache creation is interrupted or an external process truncates the file.

This change catches `EOFError` while reading the cache and adds a regression test for an empty cache file.

### Test

- `python -m pytest tests/test_black.py::TestCaching::test_cache_empty_file tests/test_black.py::TestCaching::test_cache_broken_file -q`