### PR TITLE
Validate include and force-exclude config types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
   directory gets the correct `pyproject.toml` (#5152)
 - Add validation for --line-ranges values (#5107)
+- Reject non-string `include` and `force-exclude` values in `pyproject.toml`
+  (#5193)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,8 +56,7 @@
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
   directory gets the correct `pyproject.toml` (#5152)
 - Add validation for --line-ranges values (#5107)
-- Reject non-string `include` and `force-exclude` values in `pyproject.toml`
-  (#5193)
+- Reject non-string `include` and `force-exclude` values in `pyproject.toml` (#5193)
 
 ### Packaging
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -157,10 +157,20 @@ def read_pyproject_toml(
     if exclude is not None and not isinstance(exclude, str):
         raise click.BadOptionUsage("exclude", "Config key exclude must be a string")
 
+    include = config.get("include")
+    if include is not None and not isinstance(include, str):
+        raise click.BadOptionUsage("include", "Config key include must be a string")
+
     extend_exclude = config.get("extend_exclude")
     if extend_exclude is not None and not isinstance(extend_exclude, str):
         raise click.BadOptionUsage(
             "extend-exclude", "Config key extend-exclude must be a string"
+        )
+
+    force_exclude = config.get("force_exclude")
+    if force_exclude is not None and not isinstance(force_exclude, str):
+        raise click.BadOptionUsage(
+            "force-exclude", "Config key force-exclude must be a string"
         )
 
     line_ranges = config.get("line_ranges")

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1675,6 +1675,26 @@ class BlackTestCase(BlackBaseTestCase):
         self.assertEqual(config["exclude"], r"\.pyi?$")
         self.assertEqual(config["include"], r"\.py?$")
 
+    def test_read_pyproject_toml_rejects_non_string_regex_configs(self) -> None:
+        for config_key, option_name in [
+            ("include", "include"),
+            ("force-exclude", "force-exclude"),
+        ]:
+            with self.subTest(config_key=config_key):
+                with TemporaryDirectory() as workspace:
+                    config = Path(workspace) / "pyproject.toml"
+                    config.write_text(
+                        f'[tool.black]\n{config_key} = ["not", "a", "regex"]\n',
+                        encoding="utf-8",
+                    )
+
+                    fake_ctx = FakeContext()
+                    with pytest.raises(click.BadOptionUsage) as exc_info:
+                        black.read_pyproject_toml(fake_ctx, None, str(config))
+
+                    assert exc_info.value.option_name == option_name
+                    assert "must be a string" in exc_info.value.message
+
     def test_read_pyproject_toml_from_stdin(self) -> None:
         with TemporaryDirectory() as workspace:
             root = Path(workspace)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1695,6 +1695,23 @@ class BlackTestCase(BlackBaseTestCase):
                     assert exc_info.value.option_name == option_name
                     assert "must be a string" in exc_info.value.message
 
+    def test_cli_rejects_non_string_pyproject_regex_configs(self) -> None:
+        for config_key in ["include", "force-exclude"]:
+            with self.subTest(config_key=config_key):
+                with TemporaryDirectory() as workspace:
+                    config = Path(workspace) / "pyproject.toml"
+                    config.write_text(
+                        f'[tool.black]\n{config_key} = ["not", "a", "regex"]\n',
+                        encoding="utf-8",
+                    )
+
+                    result = BlackRunner().invoke(
+                        black.main, ["--config", str(config), "--code", "print(1)"]
+                    )
+
+                    assert result.exit_code == 2
+                    assert f"Config key {config_key} must be a string" in result.stderr
+
     def test_read_pyproject_toml_from_stdin(self) -> None:
         with TemporaryDirectory() as workspace:
             root = Path(workspace)


### PR DESCRIPTION
### Summary

Reject non-string `include` and `force-exclude` values in `pyproject.toml`.

### Details

Black already validates that `exclude` and `extend-exclude` config values are strings before passing them through regex validation. The same regex-backed options `include` and `force-exclude` did not have that type check, so list values could be silently stringified and accepted with surprising regex semantics.

This adds matching `BadOptionUsage` checks for `include` and `force_exclude`, plus a regression test for both config keys.

### Test

- `python -m pytest tests/test_black.py::BlackTestCase::test_read_pyproject_toml_rejects_non_string_regex_configs tests/test_black.py::BlackTestCase::test_read_pyproject_toml -q`