### PR TITLE
avoid full children-list and sibling-map rebuild in Node.replace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,9 @@
   rather than rebuilding them from scratch after every tree mutation (#5178)
 - Improve performance on long calls and collections by no longer scanning the whole line
   to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance when merging large groups of implicitly concatenated strings by no
+  longer rebuilding a node's children list and sibling maps from scratch on every
+  `replace` call (#5194)
 
 ### Output
 

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -130,22 +130,21 @@ class Base:
         assert new is not None
         if not isinstance(new, list):
             new = [new]
-        l_children = []
-        found = False
-        for ch in self.parent.children:
+        parent = self.parent
+        for i, ch in enumerate(parent.children):
             if ch is self:
-                assert not found, (self.parent.children, self, new)
-                if new is not None:
-                    l_children.extend(new)
-                found = True
-            else:
-                l_children.append(ch)
-        assert found, (self.children, self, new)
-        self.parent.children = l_children
-        self.parent.changed()
-        self.parent.invalidate_sibling_maps()
+                break
+        else:
+            raise AssertionError((parent.children, self, new))
+        # Splice the new children in place of `self` and keep the cached sibling
+        # maps valid without rebuilding them, which would be O(len(children)) per
+        # call and quadratic when many children are replaced while siblings are
+        # read in between (e.g. merging implicitly concatenated strings).
+        parent._replace_child_in_sibling_maps(self, new)
+        parent.children[i : i + 1] = new
+        parent.changed()
         for x in new:
-            x.parent = self.parent
+            x.parent = parent
         self.parent = None
 
     def get_lineno(self) -> int | None:
@@ -405,6 +404,26 @@ class Node(Base):
         next_map[id(before)] = child
         if after is not None:
             prev_map[id(after)] = child
+
+    def _replace_child_in_sibling_maps(self, old: NL, new_children: list[NL]) -> None:
+        """Swap ``old`` for ``new_children`` at the same position in the maps."""
+        prev_map = self.prev_sibling_map
+        next_map = self.next_sibling_map
+        if prev_map is None or next_map is None:
+            return
+        if id(old) not in prev_map:
+            self.invalidate_sibling_maps()
+            return
+        before = prev_map.pop(id(old))
+        after = next_map.pop(id(old))
+        previous = before
+        for child in new_children:
+            prev_map[id(child)] = previous
+            next_map[id(previous)] = child
+            previous = child
+        next_map[id(previous)] = after
+        if after is not None:
+            prev_map[id(after)] = previous
 
     def update_sibling_maps(self) -> None:
         _prev: dict[int, NL | None] = {}


### PR DESCRIPTION
### Description

Profiling `--preview` formatting of a module with a long run of implicitly concatenated f-strings (`x = f"{a0}" f"{a1}" ...`) showed `update_sibling_maps` taking most of the runtime, with `Node.replace` close behind. The cause is that `replace` rebuilds the parent's whole `children` list and then calls `invalidate_sibling_maps`, so the next read of a sibling rebuilds the prev/next maps in full. `visit_fstring`/`visit_tstring` call `node.replace(string_leaf)` once per concatenated piece, so on a node with many children every replacement costs O(children) for the list rebuild and another O(children) for the map rebuild, and the whole pass becomes quadratic. A 4000-piece concatenation takes about 5.9s and the growth is plainly quadratic; this is reachable from untrusted source and from unauthenticated `blackd` with `X-Preview`.

#5178 made the other mutators (`remove`/`set_child`/`insert_child`/`append_child`) update the sibling maps incrementally, but `replace` was left invalidating them wholesale, and it is also the only mutator that rebuilt the entire children list. The fix locates the replaced child once, splices the new children in with a list slice, and adds `_replace_child_in_sibling_maps` to patch the cached maps in place (handling the one-to-many case) with the same fallback-to-invalidate the neighbouring helpers already use. Keeping the splice next to the list edit means a sibling read after a `replace` no longer pays for the whole node. Output is byte-identical across the test suite (465 passed) and the Black source tree in stable and preview, and a randomised map-equivalence check confirms the spliced maps match a fresh rebuild; the 4000-piece input drops from ~5.9s to ~1.1s and the curve flattens.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (no style change; output is identical)
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary? (no behaviour change to assert; exercised by the existing suite, same as #5178)
- [ ] Add new / update outdated documentation?