### PR TITLE
avoid quadratic child rescan in append_leaves

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,6 +106,10 @@
 - Improve performance on large dict literals and long semicolon-separated statements by
   wrapping a node's children in invisible parentheses in place instead of removing and
   re-inserting each one, which scanned the whole child list every time (#5184)
+- Improve performance when copying a long line's leaves into a new line (for example
+  `--preview` string processing of `"%s ..." % (a, b, c, ...)` or a string with a
+  backslash continuation) by resuming the child lookup in `append_leaves` instead of
+  rescanning each leaf's parent from the start (#5199)
 
 ### Output
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1283,9 +1283,32 @@ def append_leaves(
     Pre-conditions:
         set(@leaves) is a subset of set(@old_line.leaves).
     """
+    # @leaves is a slice of @old_line.leaves, so the leaves are in tree (DFS)
+    # order and the children replaced within any one parent are reached at
+    # strictly increasing positions. Remembering where the last child of each
+    # parent was found lets the lookup resume from there instead of rescanning the
+    # whole child list through Base.remove on every leaf, which is otherwise
+    # O(n^2) when a node has many children replaced (e.g. wrapping the operand
+    # tuple of "%s" % (a, b, c, ...) or copying a very long line for a second
+    # formatting pass).
+    search_start: dict[int, int] = {}
     for old_leaf in leaves:
         new_leaf = Leaf(old_leaf.type, old_leaf.value)
-        replace_child(old_leaf, new_leaf)
+        parent = old_leaf.parent
+        if parent is not None:
+            children = parent.children
+            index = search_start.get(id(parent), 0)
+            while index < len(children) and children[index] is not old_leaf:
+                index += 1
+            if index < len(children):
+                # set_child swaps the child in place (the old one keeps the same
+                # position), so the next sibling to replace is always further on.
+                parent.set_child(index, new_leaf)
+                search_start[id(parent)] = index + 1
+            else:
+                # The resume hint missed (unexpected ordering); fall back to the
+                # full scan so behaviour is unchanged.
+                replace_child(old_leaf, new_leaf)
         new_line.append(new_leaf, preformatted=preformatted)
 
         for comment_leaf in old_line.comments_after(old_leaf):


### PR DESCRIPTION
### Description

While profiling `--preview` string processing I traced a quadratic into `Base.remove`. `append_leaves` copies a line's leaves into a new line and, for each one, calls `replace_child`, which goes through `Base.remove` to scan the parent's whole children list for the leaf's position. The leaves arrive in tree order, so within a single parent every replaced child sits at a strictly increasing index, yet each `remove` restarts the scan from the front. Copying a line whose n leaves share one parent is therefore O(n²). Both `"%s ..." % (a, b, c, ...)` and a string carrying a backslash line continuation hit it, as does the `FORCE_OPTIONAL_PARENTHESES` second pass that copies a whole line. An 8000-term concatenation spent roughly 2.35s almost entirely in that scan.

The fix keeps a per-parent record of where the previous child was found and resumes the lookup from there, swapping the child in place with `set_child` rather than the remove-and-reinsert pair. A missed hint falls back to the original full scan so nothing changes for the odd case. Keeping this inside `append_leaves` puts the resume state exactly where the ordering guarantee holds, without touching `Base.remove` itself. The same input now runs in roughly 0.59s with a linear curve, and output is byte-identical across the test suite and the black + tests source tree in stable, preview and unstable modes.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
