### PR TITLE
Keep nested parens around lambda/ternary comprehension iterables (preview)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,9 +48,10 @@
 - Keep the parentheses around a lambda used as the iterable of a comprehension (e.g.
   `[x for x in (lambda: 0) if x]`). They were previously stripped by
   `wrap_comprehension_in`, which produced invalid code and crashed Black (#5176)
-- Keep redundant nested parentheses around a lambda or conditional expression used as a
-  comprehension's iterable (e.g. `[x for x in ((lambda: 0))]`). The inner pair was still
-  being stripped, leaving the bare expression and crashing Black (#5200)
+- Collapse redundant nested parentheses around a lambda or conditional expression used
+  as a comprehension's iterable down to a single pair (e.g. `[x for x in ((lambda: 0))]`
+  becomes `[x for x in (lambda: 0)]`). Previously the inner pair was stripped too,
+  leaving the bare expression and crashing Black (#5200)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@
 - Keep the parentheses around a lambda used as the iterable of a comprehension (e.g.
   `[x for x in (lambda: 0) if x]`). They were previously stripped by
   `wrap_comprehension_in`, which produced invalid code and crashed Black (#5176)
+- Keep redundant nested parentheses around a lambda or conditional expression used as a
+  comprehension's iterable (e.g. `[x for x in ((lambda: 0))]`). The inner pair was still
+  being stripped, leaving the bare expression and crashing Black (#5200)
 
 ### Configuration
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1567,6 +1567,27 @@ def _force_standalone_comment_split(line: Line) -> Iterator[Line]:
         yield current_line
 
 
+def _is_parenthesized_lambda_or_ternary(node: LN) -> bool:
+    """Whether `node` is an atom wrapping a lambda or conditional expression,
+    looking through any redundant nested parentheses.
+
+    As a comprehension's iterable, such an expression must keep at least one pair
+    of parentheses: without them the trailing `for`/`if` clauses would be parsed
+    as part of the lambda body (or break the ternary), producing invalid code.
+    """
+    while (
+        node.type == syms.atom
+        and len(node.children) == 3
+        and is_lpar_token(node.children[0])
+        and is_rpar_token(node.children[-1])
+    ):
+        middle = node.children[1]
+        if middle.type in {syms.test, syms.lambdef}:
+            return True
+        node = middle
+    return False
+
+
 def normalize_invisible_parens(
     node: Node, parens_after: set[str], *, mode: Mode, features: Collection[Feature]
 ) -> None:
@@ -1668,11 +1689,7 @@ def normalize_invisible_parens(
                 ):
                     wrap_in_parentheses(node, child, visible=True)
             elif child.type == syms.atom and not (
-                "in" in parens_after
-                and len(child.children) == 3
-                and is_lpar_token(child.children[0])
-                and is_rpar_token(child.children[-1])
-                and child.children[1].type in {syms.test, syms.lambdef}
+                "in" in parens_after and _is_parenthesized_lambda_or_ternary(child)
             ):
                 if maybe_make_parens_invisible_in_atom(
                     child, parent=node, mode=mode, features=features

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1688,10 +1688,22 @@ def normalize_invisible_parens(
                     and is_one_tuple(child.children[0])
                 ):
                     wrap_in_parentheses(node, child, visible=True)
-            elif child.type == syms.atom and not (
-                "in" in parens_after and _is_parenthesized_lambda_or_ternary(child)
-            ):
-                if maybe_make_parens_invisible_in_atom(
+            elif child.type == syms.atom:
+                if "in" in parens_after and _is_parenthesized_lambda_or_ternary(child):
+                    # A lambda or conditional expression used as a comprehension's
+                    # iterable must keep at least one pair of parentheses, otherwise
+                    # the trailing `for`/`if` clauses get absorbed into it and the
+                    # code becomes invalid. Any extra nested pairs are redundant, so
+                    # collapse them while keeping exactly one visible pair.
+                    maybe_make_parens_invisible_in_atom(
+                        child, parent=node, mode=mode, features=features
+                    )
+                    opening = child.children[0]
+                    closing = child.children[-1]
+                    if is_lpar_token(opening) and is_rpar_token(closing):
+                        opening.value = "("
+                        closing.value = ")"
+                elif maybe_make_parens_invisible_in_atom(
                     child, parent=node, mode=mode, features=features
                 ):
                     wrap_in_parentheses(node, child, visible=False)

--- a/tests/data/cases/preview_wrap_comprehension_in.py
+++ b/tests/data/cases/preview_wrap_comprehension_in.py
@@ -38,6 +38,12 @@ expected = [i for i in (a if b else c)]
 lambda_iter = [i for i in (lambda: 0) if i]
 lambda_iter_no_clause = [i for i in (lambda x: x)]
 
+# Redundant nested parens around a lambda or ternary must be preserved too;
+# stripping the inner pair as well would expose the bare expression and crash
+double_lambda_iter = [i for i in ((lambda: 0)) if i]
+double_lambda_no_clause = [i for i in ((lambda x: x))]
+double_ternary = [i for i in ((a if b else c))]
+
 # Nested arrays
 # First in will not be split because it would still be too long
 [[
@@ -123,6 +129,12 @@ expected = [i for i in (a if b else c)]
 # clauses would be parsed as part of the lambda body, producing invalid code
 lambda_iter = [i for i in (lambda: 0) if i]
 lambda_iter_no_clause = [i for i in (lambda x: x)]
+
+# Redundant nested parens around a lambda or ternary must be preserved too;
+# stripping the inner pair as well would expose the bare expression and crash
+double_lambda_iter = [i for i in ((lambda: 0)) if i]
+double_lambda_no_clause = [i for i in ((lambda x: x))]
+double_ternary = [i for i in ((a if b else c))]
 
 # Nested arrays
 # First in will not be split because it would still be too long

--- a/tests/data/cases/preview_wrap_comprehension_in.py
+++ b/tests/data/cases/preview_wrap_comprehension_in.py
@@ -38,11 +38,12 @@ expected = [i for i in (a if b else c)]
 lambda_iter = [i for i in (lambda: 0) if i]
 lambda_iter_no_clause = [i for i in (lambda x: x)]
 
-# Redundant nested parens around a lambda or ternary must be preserved too;
-# stripping the inner pair as well would expose the bare expression and crash
+# A lambda or ternary iterable must keep at least one pair of parens, but any
+# redundant nested pairs are collapsed down to a single pair
 double_lambda_iter = [i for i in ((lambda: 0)) if i]
 double_lambda_no_clause = [i for i in ((lambda x: x))]
 double_ternary = [i for i in ((a if b else c))]
+triple_lambda = [i for i in (((lambda: 0))) if i]
 
 # Nested arrays
 # First in will not be split because it would still be too long
@@ -130,11 +131,12 @@ expected = [i for i in (a if b else c)]
 lambda_iter = [i for i in (lambda: 0) if i]
 lambda_iter_no_clause = [i for i in (lambda x: x)]
 
-# Redundant nested parens around a lambda or ternary must be preserved too;
-# stripping the inner pair as well would expose the bare expression and crash
-double_lambda_iter = [i for i in ((lambda: 0)) if i]
-double_lambda_no_clause = [i for i in ((lambda x: x))]
-double_ternary = [i for i in ((a if b else c))]
+# A lambda or ternary iterable must keep at least one pair of parens, but any
+# redundant nested pairs are collapsed down to a single pair
+double_lambda_iter = [i for i in (lambda: 0) if i]
+double_lambda_no_clause = [i for i in (lambda x: x)]
+double_ternary = [i for i in (a if b else c)]
+triple_lambda = [i for i in (lambda: 0) if i]
 
 # Nested arrays
 # First in will not be split because it would still be too long


### PR DESCRIPTION
While poking at `wrap_comprehension_in` after #5176, I hit a case it doesn't cover. #5176 keeps the parens around a lambda or ternary used as a comprehension's iterable so the trailing `for`/`if` clauses aren't absorbed into it. But when those parens are redundantly nested, e.g.

```python
[x for x in ((lambda: 0))]
```

`maybe_make_parens_invisible_in_atom` recurses and strips *both* pairs, leaving `[x for x in lambda: 0]` — invalid code, which crashes with an `ASTSafetyError` at the default line length. Same for a nested ternary and for generator/dict/set comprehensions, and at deeper nesting.

The guard only inspected the atom's direct child, so a paren-wrapped atom slipped past it. I made it look through the redundant nested parens before deciding whether the iterable is a lambda/ternary, so at least one pair is kept (matching what the stable style does with such input).

Added the nested lambda/ternary cases to the existing `preview_wrap_comprehension_in` fixture — they crashed before and pass now. The full test suite, mypy, flake8 and the self-format check are green.