### PR TITLE
Write formatted files atomically to avoid corruption on write failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,8 @@
   --target-version flag (#5167)
 - Fix in-place formatting truncating or corrupting the source file if writing the
   reformatted contents fails partway through, e.g. because the disk is full. Black now
-  writes to a temporary file in the same directory and atomically replaces the
-  original once the write has fully succeeded (#5207)
+  writes to a temporary file in the same directory and atomically replaces the original
+  once the write has fully succeeded (#5207)
 
 ### Highlights
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
 - No spurious target version warning when runtime version is included in a
   --target-version flag (#5167)
+- Fix in-place formatting truncating or corrupting the source file if writing the
+  reformatted contents fails partway through, e.g. because the disk is full. Black now
+  writes to a temporary file in the same directory and atomically replaces the
+  original once the write has fully succeeded (#5207)
 
 ### Highlights
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1,8 +1,11 @@
 import io
 import json
+import os
 import platform
 import re
+import shutil
 import sys
+import tempfile
 import tokenize
 import traceback
 from collections.abc import (
@@ -998,8 +1001,27 @@ def format_file_in_place(
     dst_contents = header.decode(encoding) + dst_contents
 
     if write_back == WriteBack.YES:
-        with open(src, "w", encoding=encoding, newline=newline) as f:
-            f.write(dst_contents)
+        # Write to a temporary file in the same directory (so it's on the same
+        # filesystem) and atomically replace the target with it. This avoids
+        # leaving the file truncated or corrupted if writing fails partway
+        # through, e.g. because the disk is full (see issue #2479).
+        # If `src` is itself a symlink, write through to its resolved target
+        # instead of replacing the symlink with a regular file.
+        real_src = src.resolve() if src.is_symlink() else src
+        fd, tmp_file = tempfile.mkstemp(
+            dir=real_src.parent, prefix=f".{real_src.name}.", suffix=".tmp"
+        )
+        tmp_path = Path(tmp_file)
+        try:
+            with os.fdopen(fd, "w", encoding=encoding, newline=newline) as f:
+                f.write(dst_contents)
+                f.flush()
+                os.fsync(f.fileno())
+            shutil.copymode(real_src, tmp_path)
+            os.replace(tmp_path, real_src)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
     elif write_back in (WriteBack.DIFF, WriteBack.COLOR_DIFF):
         now = datetime.now(timezone.utc)
         src_name = f"{src}\t{then}"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -170,6 +170,54 @@ class BlackTestCase(BlackBaseTestCase):
                 os.unlink(tmp_file)
             self.assertFormatEqual(expected, actual)
 
+    def test_ff_preserves_file_on_write_failure(self) -> None:
+        # Regression test for #2479: if writing the reformatted contents fails
+        # partway through (e.g. because the disk is full), the original file
+        # must be left untouched instead of being truncated or corrupted.
+        source = "print('hello')\n"
+        with TemporaryDirectory() as workspace:
+            tmp_file = Path(workspace) / "source.py"
+            tmp_file.write_text(source, encoding="utf-8")
+            with patch(
+                "black.os.fsync", side_effect=OSError("No space left on device")
+            ):
+                with self.assertRaises(OSError):
+                    ff(tmp_file, write_back=black.WriteBack.YES)
+            self.assertEqual(tmp_file.read_text(encoding="utf-8"), source)
+            # No leftover temporary file should remain in the directory.
+            leftover = [p for p in Path(workspace).iterdir() if p != tmp_file]
+            self.assertEqual(leftover, [])
+
+    def test_ff_preserves_permissions(self) -> None:
+        if system() == "Windows":
+            return
+
+        with TemporaryDirectory() as workspace:
+            tmp_file = Path(workspace) / "source.py"
+            tmp_file.write_text("print('hello' )\n", encoding="utf-8")
+            tmp_file.chmod(0o640)
+            self.assertTrue(ff(tmp_file, write_back=black.WriteBack.YES))
+            self.assertEqual(tmp_file.stat().st_mode & 0o777, 0o640)
+
+    def test_ff_writes_through_symlink(self) -> None:
+        # Regression test: formatting a file via a symlinked path must write
+        # through to the real target, not replace the symlink with a regular
+        # file (which atomic replace-by-rename would otherwise do).
+        with TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            real_file = workspace_path / "real.py"
+            real_file.write_text("print('hello' )\n", encoding="utf-8")
+            symlink = workspace_path / "link.py"
+            try:
+                symlink.symlink_to(real_file)
+            except (OSError, NotImplementedError) as e:
+                self.skipTest(f"Can't create symlinks: {e}")
+
+            self.assertTrue(ff(symlink, write_back=black.WriteBack.YES))
+            self.assertTrue(symlink.is_symlink())
+            self.assertEqual(os.readlink(symlink), str(real_file))
+            self.assertEqual(real_file.read_text(encoding="utf-8"), 'print("hello")\n')
+
     def test_piping(self) -> None:
         _, source, expected = read_data_from_file(
             PROJECT_ROOT / "src/black/__init__.py"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -215,7 +215,9 @@ class BlackTestCase(BlackBaseTestCase):
 
             self.assertTrue(ff(symlink, write_back=black.WriteBack.YES))
             self.assertTrue(symlink.is_symlink())
-            self.assertEqual(os.readlink(symlink), str(real_file))
+            # Compare resolved paths rather than the raw readlink() target, since
+            # Windows may normalize it to an extended-length \\?\ path.
+            self.assertEqual(symlink.resolve(), real_file.resolve())
             self.assertEqual(real_file.read_text(encoding="utf-8"), 'print("hello")\n')
 
     def test_piping(self) -> None:


### PR DESCRIPTION
### Description

Fixes #2479.

Right now `format_file_in_place` opens the target file directly with `open(src, "w")` before writing the reformatted contents. That call truncates the file immediately, so if the write fails partway through for any reason (disk fills up, permissions get revoked mid-run, process gets killed, etc.) the original file is left wiped or half-written with no way to get it back. Since most people run Black on files that aren't always safely committed yet, that's a pretty rough way to lose code.

This was actually discussed in the issue back in 2021 - the suggestion from qlyoung (with JelleZijlstra agreeing) was to write to a temp file and swap it in, so that's what this PR does:

- Write the reformatted contents to a temp file created in the same directory as the target (so it's guaranteed to be on the same filesystem, which is what makes the swap atomic).
- `flush()` + `fsync()` the temp file before doing anything else, so we know the data actually made it to disk.
- Copy the original file's permission bits onto the temp file, then `os.replace()` it over the original. `os.replace` is atomic on both POSIX and Windows, so there's never a window where the file is half-written.
- If anything raises along the way, the temp file gets cleaned up and the original file is never touched.

One thing that took a bit of extra care: if the path being formatted is a symlink, `os.replace` operates on the symlink itself rather than what it points to, which would silently turn the symlink into a regular file. So there's a check for that - if `src` is a symlink, we resolve it first and write through to the real target, leaving the symlink itself alone.

Worth calling out (as was already flagged in the issue thread): this does mean Black now needs write permission on the containing directory, not just the file, since it has to create the temp file there. That seems like a reasonable trade-off for not losing people's work, but flagging it in case it's a concern for some setups.

Since JelleZijlstra asked in the thread whether other formatters handle this the same way, I went and checked a few:

- clang-format actually does exactly this - it writes to a temp file through LLVM's `TempFile` utility and renames it over the target (`llvm/lib/Support/Path.cpp`).
- gofmt doesn't rename a temp file over the target, but it does something in the same spirit: it copies the original file to a backup path before writing, and restores from that backup if the real write fails.
- rustfmt, Prettier, yapf, and autopep8 all just open the target file and write over it directly, as far as I could tell - I didn't find a fallback for this failure mode in any of them.

So it's a mixed bag rather than an industry standard - but there's real precedent for it in at least one widely-used formatter, and gofmt clearly cares about the same failure mode even though it solves it differently. Given Black is often run against files that aren't committed yet, I think it's worth fixing here regardless of what the others do.

On cooperlees' question about IO cost on large repos: I wasn't able to put together a reliable large-scale benchmark on my end, so take this as reasoning rather than a measured number. The extra work per file is one additional file creation, one `fsync`, and one `rename`, all constant-time metadata operations against the same directory regardless of the file's size. Parsing and re-rendering the file - which already happens today - should dominate the per-file cost by a good margin for anything but a near-empty file. Happy to help put together a proper before/after benchmark against a large real-world codebase if that would help move this along, or run whatever perf harness the project already uses if there is one.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (N/A - this doesn't change any formatting output, just how the result gets written to disk)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (N/A - no user-facing behavior or docs to update)