### PR TITLE
Validate BLACK_NUM_WORKERS values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,8 @@
 - Ignore empty cache files like other malformed cache files instead of raising an
   `EOFError` (#5192)
 - Reject non-string `include` and `force-exclude` values in `pyproject.toml` (#5193)
+- Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors
+  instead of crashing (#5211)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,8 +61,8 @@
 - Ignore empty cache files like other malformed cache files instead of raising an
   `EOFError` (#5192)
 - Reject non-string `include` and `force-exclude` values in `pyproject.toml` (#5193)
-- Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors
-  instead of crashing (#5211)
+- Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors instead
+  of crashing (#5211)
 
 ### Packaging
 

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -18,6 +18,7 @@ from multiprocessing import Manager
 from pathlib import Path
 from typing import Any
 
+import click
 from mypy_extensions import mypyc_attr
 
 from black import WriteBack, format_file_in_place
@@ -89,8 +90,22 @@ def reformat_many(
     """Reformat multiple files using a ProcessPoolExecutor."""
 
     if workers is None:
-        workers = int(os.environ.get("BLACK_NUM_WORKERS", 0))
-        workers = workers or os.cpu_count() or 1
+        workers_value = os.environ.get("BLACK_NUM_WORKERS")
+        if workers_value is not None:
+            try:
+                workers = int(workers_value)
+            except ValueError:
+                raise click.BadParameter(
+                    f"{workers_value!r} is not a valid integer",
+                    param_hint="BLACK_NUM_WORKERS",
+                ) from None
+            if workers < 1:
+                raise click.BadParameter(
+                    f"{workers_value!r} is not in the range x>=1",
+                    param_hint="BLACK_NUM_WORKERS",
+                )
+        else:
+            workers = os.cpu_count() or 1
     if sys.platform == "win32":
         # Work around https://bugs.python.org/issue26903
         workers = min(workers, 60)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1122,6 +1122,26 @@ class BlackTestCase(BlackBaseTestCase):
             self.invokeBlack([str(workspace)])
 
     @event_loop()
+    def test_invalid_black_num_workers(self) -> None:
+        for workers in ["abc", "0", "-1"]:
+            with (
+                cache_dir() as workspace,
+                patch.dict(os.environ, {"BLACK_NUM_WORKERS": workers}),
+            ):
+                for f in [
+                    (workspace / "one.py").resolve(),
+                    (workspace / "two.py").resolve(),
+                ]:
+                    f.write_text('print("hello")\n', encoding="utf-8")
+
+                result = BlackRunner().invoke(black.main, [str(workspace)])
+
+            assert result.exit_code == 2
+            assert result.exception is not None
+            assert "BLACK_NUM_WORKERS" in result.stderr
+            assert "Traceback" not in result.stderr
+
+    @event_loop()
     def test_check_diff_use_together(self) -> None:
         with cache_dir():
             # Files which will be reformatted.


### PR DESCRIPTION
## Summary

- validate `BLACK_NUM_WORKERS` before using it to size the worker pool
- report malformed, zero, or negative values as Click parameter errors that name the environment variable
- add regression coverage for invalid `BLACK_NUM_WORKERS` values

## Test Plan

- `python -m pytest tests/test_black.py::BlackTestCase::test_invalid_black_num_workers tests/test_black.py::BlackTestCase::test_works_in_mono_process_only_environment -q`
- `python -m black src/black/concurrency.py tests/test_black.py --check`

Fixes #5210
