### PR TITLE
Standardize ReadTheDocs links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,4 +39,4 @@
      - PSF COC: https://www.python.org/psf/conduct/
      - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
      - Chat on Python Discord: https://discord.gg/RtVdv86PrH
-     - Stability policy: https://black.readthedocs.io/en/latest/the_black_code_style/index.html -->
+     - Stability policy: https://black.readthedocs.io/en/stable/the_black_code_style/index.html -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Welcome future contributor! We're happy to see you willing to make the project better.
 
 If you aren't familiar with _Black_, or are looking for documentation on something
-specific, the [user documentation](https://black.readthedocs.io/en/latest/) is the best
+specific, the [user documentation](https://black.readthedocs.io/en/stable/) is the best
 place to look.
 
 For getting started on contributing, please read the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ specific, the [user documentation](https://black.readthedocs.io/en/latest/) is t
 place to look.
 
 For getting started on contributing, please read the
-[contributing documentation](https://black.readthedocs.org/en/latest/contributing/) for
+[contributing documentation](https://black.readthedocs.io/en/latest/contributing/) for
 all you need to know.
 
 Thank you, and we look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Twisted and CPython:
 
 > At least the name is good.
 
-**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/) and
-[pipenv](https://pipenv.pypa.io/en/stable/):
+**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/)
+and [pipenv](https://pipenv.pypa.io/en/stable/):
 
 > This vastly improves the formatting of our code. Thanks a ton!
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://github.com/psf/black/actions"><img alt="Actions Status" src="https://github.com/psf/black/workflows/Test/badge.svg"></a>
 <a href="https://black.readthedocs.io/en/stable/?badge=stable"><img alt="Documentation Status" src="https://readthedocs.org/projects/black/badge/?version=stable"></a>
 <a href="https://coveralls.io/github/psf/black?branch=main"><img alt="Coverage Status" src="https://coveralls.io/repos/github/psf/black/badge.svg?branch=main"></a>
-<a href="https://github.com/psf/black/blob/main/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://github.com/psf/black/blob/main/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/latest/_static/license.svg"></a>
 <a href="https://pypi.org/project/black/"><img alt="PyPI" src="https://img.shields.io/pypi/v/black"></a>
 <a href="https://pypi.org/project/black"><img alt="Supported Python Versions" src="https://img.shields.io/pypi/pyversions/black?color=brightgreen"></a>
 <a href="https://pepy.tech/project/black"><img alt="Downloads" src="https://static.pepy.tech/badge/black"></a>
@@ -145,7 +145,7 @@ Are we missing anyone? Let us know.
 
 ## Testimonials
 
-**Mike Bayer**, [author of `SQLAlchemy`](https://www.sqlalchemy.org/):
+**Mike Bayer**, creator of [`SQLAlchemy`](https://www.sqlalchemy.org/):
 
 > I can't think of any single tool in my entire programming career that has given me a
 > bigger productivity increase by its introduction. I can now do refactorings in about
@@ -153,11 +153,11 @@ Are we missing anyone? Let us know.
 > code to format itself.
 
 **Dusty Phillips**,
-[writer](https://smile.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords=dusty+phillips):
+[writer](https://www.amazon.com/stores/Dusty-Phillips/author/B00HSYG5BO):
 
 > _Black_ is opinionated so you don't have to be.
 
-**Hynek Schlawack**, [creator of `attrs`](https://www.attrs.org/), core developer of
+**Hynek Schlawack**, creator of [`attrs`](https://www.attrs.org/), core developer of
 Twisted and CPython:
 
 > An auto-formatter that doesn't suck is all I want for Xmas!
@@ -166,8 +166,8 @@ Twisted and CPython:
 
 > At least the name is good.
 
-**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/latest/)
-and [`pipenv`](https://readthedocs.org/projects/pipenv/):
+**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/) and
+[pipenv](https://pipenv.pypa.io/en/stable/):
 
 > This vastly improves the formatting of our code. Thanks a ton!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/stable/config
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -124,7 +124,7 @@ If you are experiencing exceptionally weird issues or even segfaults, you can tr
 passing `--no-binary black` to your pip install invocation. This flag excludes all
 wheels (including the pure Python wheel), so this command will use the [sdist].
 
-[mypyc]: https://mypyc.readthedocs.io/en/latest/
+[mypyc]: https://mypyc.readthedocs.io/en/stable/
 [sdist]:
   https://packaging.python.org/en/latest/glossary/#term-Source-Distribution-or-sdist
 
@@ -136,4 +136,4 @@ fixable from _Black_'s end.
 Instead, run your chosen command line/shell through [Windows Terminal], which will
 properly handle rendering the emoji.
 
-[Windows Terminal]: https://github.com/microsoft/terminal
+[Windows Terminal]: https://aka.ms/terminal

--- a/docs/guides/using_black_with_other_tools.md
+++ b/docs/guides/using_black_with_other_tools.md
@@ -17,16 +17,17 @@ Compatible configuration files can be
 
 ### isort
 
-[isort](https://pypi.org/p/isort/) helps to sort and format imports in your Python code.
-_Black_ also formats imports, but in a different way from isort's defaults which leads
-to conflicting changes.
+[isort](https://isort.readthedocs.io/) helps to sort and format imports in your Python
+code. _Black_ also formats imports, but in a different way from isort's defaults which
+leads to conflicting changes.
 
 #### Profile
 
 Since version 5.0.0, isort supports
-[profiles](https://pycqa.github.io/isort/docs/configuration/profiles.html) to allow easy
-interoperability with common code styles. You can set the black profile in any of the
-[config files](https://pycqa.github.io/isort/docs/configuration/config_files.html)
+[profiles](https://isort.readthedocs.io/en/latest/configuration/profiles.html) to allow
+easy interoperability with common code styles. You can set the black profile in any of
+the
+[config files](https://isort.readthedocs.io/en/latest/configuration/config_files.html)
 supported by isort. Below, an example for `pyproject.toml`:
 
 ```toml
@@ -136,10 +137,10 @@ profile = black
 
 ### pycodestyle
 
-[pycodestyle](https://pycodestyle.pycqa.org/) is a code linter. It warns you of syntax
-errors, possible bugs, stylistic errors, etc. For the most part, pycodestyle follows
-[PEP 8](https://peps.python.org/pep-0008/) when warning about stylistic errors. There
-are a few deviations that cause incompatibilities with _Black_.
+[pycodestyle](https://pycodestyle.pycqa.org/en/stable/) is a code linter. It warns you
+of syntax errors, possible bugs, stylistic errors, etc. For the most part, pycodestyle
+follows [PEP 8](https://peps.python.org/pep-0008/) when warning about stylistic errors.
+There are a few deviations that cause incompatibilities with _Black_.
 
 #### Configuration
 
@@ -201,8 +202,8 @@ ignore = E203,E701
 
 ### Flake8
 
-[Flake8](https://pypi.org/p/flake8/) is a wrapper around multiple linters, including
-pycodestyle. As such, it has many of the same issues.
+[Flake8](https://flake8.pycqa.org/en/stable/) is a wrapper around multiple linters,
+including pycodestyle. As such, it has many of the same issues.
 
 #### Bugbear
 
@@ -251,9 +252,9 @@ extend-ignore = E203,E701
 
 ### Pylint
 
-[Pylint](https://pypi.org/p/pylint/) is also a code linter like Flake8. It has many of
-the same checks as Flake8 and more. It particularly has more formatting checks regarding
-style conventions like variable naming.
+[Pylint](https://pylint.readthedocs.io/) is also a code linter like Flake8. It has many
+of the same checks as Flake8 and more. It particularly has more formatting checks
+regarding style conventions like variable naming.
 
 #### Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ section for details). If you're feeling confident, use `--fast`.
 
 ## Testimonials
 
-**Mike Bayer**, author of [SQLAlchemy](https://www.sqlalchemy.org/):
+**Mike Bayer**, creator of [`SQLAlchemy`](https://www.sqlalchemy.org/):
 
 > _I can't think of any single tool in my entire programming career that has given me a
 > bigger productivity increase by its introduction. I can now do refactorings in about
@@ -43,11 +43,11 @@ section for details). If you're feeling confident, use `--fast`.
 > code to format itself._
 
 **Dusty Phillips**,
-[writer](https://smile.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords=dusty+phillips):
+[writer](https://www.amazon.com/stores/Dusty-Phillips/author/B00HSYG5BO):
 
 > _Black is opinionated so you don't have to be._
 
-**Hynek Schlawack**, creator of [attrs](https://www.attrs.org/), core developer of
+**Hynek Schlawack**, creator of [`attrs`](https://www.attrs.org/), core developer of
 Twisted and CPython:
 
 > _An auto-formatter that doesn't suck is all I want for Xmas!_
@@ -56,8 +56,8 @@ Twisted and CPython:
 
 > _At least the name is good._
 
-**Kenneth Reitz**, creator of [requests](https://python-requests.org/) and
-[pipenv](https://docs.pipenv.org/):
+**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/) and
+[pipenv](https://pipenv.pypa.io/en/stable/):
 
 > _This vastly improves the formatting of our code. Thanks a ton!_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ Twisted and CPython:
 
 > _At least the name is good._
 
-**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/) and
-[pipenv](https://pipenv.pypa.io/en/stable/):
+**Kenneth Reitz**, creator of [`requests`](https://requests.readthedocs.io/en/stable/)
+and [pipenv](https://pipenv.pypa.io/en/stable/):
 
 > _This vastly improves the formatting of our code. Thanks a ton!_
 

--- a/docs/integrations/doctest_formatting.md
+++ b/docs/integrations/doctest_formatting.md
@@ -14,7 +14,7 @@ documentation files.
 
 ## blacken-docs
 
-[`blacken-docs`](https://pypi.org/project/blacken-docs/) is primarily used to apply
+[`blacken-docs`](https://github.com/adamchainz/blacken-docs) is primarily used to apply
 _Black_ formatting to code in documentation files (e.g. `.rst`, `.md`, `.tex`).
 
 `blacken-docs` supports the following:
@@ -68,9 +68,9 @@ _Black_ formatting to code in documentation files (e.g. `.rst`, `.md`, `.tex`).
 
 ## blackdoc
 
-[`blackdoc`](https://pypi.org/project/blackdoc/) is primarily used to apply _Black_
-formatting to doctests in Python files. It will not format any file contents that are
-otherwise covered by _Black_.
+[`blackdoc`](https://blackdoc.readthedocs.io/en/stable) is primarily used to apply
+_Black_ formatting to doctests in Python files. It will not format any file contents
+that are otherwise covered by _Black_.
 
 `blackdoc` supports the following:
 

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -4,9 +4,9 @@
 
 Options include the following:
 
-- [wbolster/emacs-python-black](https://github.com/wbolster/emacs-python-black)
-- [proofit404/blacken](https://github.com/pythonic-emacs/blacken)
-- [Elpy](https://github.com/jorgenschaefer/elpy).
+- [emacs-python-black](https://github.com/wbolster/emacs-python-black)
+- [Blacken](https://github.com/pythonic-emacs/blacken)
+- [Elpy](https://elpy.readthedocs.io/en/stable/).
 
 ## PyCharm/IntelliJ IDEA
 
@@ -238,7 +238,7 @@ external command.
 
 ##### `vim-plug`
 
-To install with [vim-plug](https://github.com/junegunn/vim-plug):
+To install with [vim-plug](https://junegunn.github.io/vim-plug/):
 
 _Black_'s `stable` branch tracks official version updates, and can be used to simply
 follow the most recent stable version.
@@ -476,7 +476,7 @@ Sublime Text, Visual Studio Code and many more), you can use the
 
 ## Gradle (the build tool)
 
-Use the [Spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle) plugin.
+Use the [Spotless](https://plugins.gradle.org/plugin/com.diffplug.spotless) plugin.
 
 ## Kakoune
 
@@ -490,4 +490,4 @@ hook global WinSetOption filetype=python %{
 
 ## Thonny
 
-Use [Thonny-black-formatter](https://pypi.org/project/thonny-black-formatter/).
+Use [Thonny-black-formatter](https://github.com/ettore-galli/thonny-black-formatter).

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -477,8 +477,8 @@ code in compliance with many other _Black_ formatted projects.
 
 [PEP 518](https://peps.python.org/pep-0518/) defines `pyproject.toml` as a configuration
 file to store build system requirements for Python projects. With the help of tools like
-[Poetry](https://python-poetry.org/), [Flit](https://flit.readthedocs.io/en/latest/), or
-[Hatch](https://hatch.pypa.io/latest/) it can fully replace the need for `setup.py` and
+[Poetry](https://python-poetry.org/), [Flit](https://flit.pypa.io/), or
+[Hatch](https://hatch.pypa.io/) it can fully replace the need for `setup.py` and
 `setup.cfg` files.
 
 ### Where _Black_ looks for the file
@@ -517,10 +517,9 @@ Please note `blackd` will not use `pyproject.toml` configuration.
 
 ### Configuration format
 
-As the file extension suggests, `pyproject.toml` is a
-[TOML](https://github.com/toml-lang/toml) file. It contains separate sections for
-different tools. _Black_ is using the `[tool.black]` section. The option keys are the
-same as long names of options on the command line.
+As the file extension suggests, `pyproject.toml` is a [TOML](https://toml.io) file. It
+contains separate sections for different tools. _Black_ is using the `[tool.black]`
+section. The option keys are the same as long names of options on the command line.
 
 Most command-line options can be configured in `[tool.black]` by using their long name
 without the leading `--` (for example, `--line-length` becomes `line-length`). Options

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1174,7 +1174,7 @@ def validate_metadata(nb: MutableMapping[str, Any]) -> None:
     """If notebook is marked as non-Python, don't format it.
 
     All notebook metadata fields are optional, see
-    https://nbformat.readthedocs.io/en/latest/format_description.html. So
+    https://nbformat.readthedocs.io/en/stable/format_description.html. So
     if a notebook has empty metadata, we will try to parse it anyway.
     """
     language = nb.get("metadata", {}).get("language_info", {}).get("name", None)


### PR DESCRIPTION
## Summary

- update the contributing docs link in `CONTRIBUTING.md` from `black.readthedocs.org` to `black.readthedocs.io`
- keep existing `readthedocs.org` links that are platform badges or external project links unchanged

## Root cause

`CONTRIBUTING.md` was the only project documentation link in the repository using the `.org` domain for Black's rendered ReadTheDocs pages. Other Black documentation links already use `black.readthedocs.io`.

Fixes #5209.

## Validation

- `rg -n "black\.readthedocs\.org" CONTRIBUTING.md` returns no matches
- `rg -n "readthedocs\.org"` only shows the README documentation badge and the external pipenv docs link
- `npx --yes prettier@3.8.3 --check CONTRIBUTING.md`
- `git diff --check`
- `Invoke-WebRequest https://black.readthedocs.io/en/latest/contributing/` returned HTTP 200
