### PR TITLE
Fix preview split for commented method chains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Split method chains consistently when a standalone comment appears between chained
+  calls (#5218)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like
   `x[key] = expr` (#5095)
 - Parenthesize tuple expressions in `yield` statements for consistency with function

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -43,6 +43,8 @@ Currently, the following features are included in the preview style:
   anyway; let the bracket explode instead. ([see below](labels/hug-comparator))
 - `parenthesize_tuple_in_yield`: Add parentheses around tuple expressions in `yield`
   statements.
+- `split_method_chain_on_standalone_comment`: Split method chains consistently when a
+  standalone comment appears between chained calls.
 
 (labels/wrap-comprehension-in)=
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1438,6 +1438,10 @@ def delimiter_split(
     if (
         delimiter_priority == DOT_PRIORITY
         and bt.delimiter_count_with_priority(delimiter_priority) == 1
+        and not (
+            Preview.split_method_chain_on_standalone_comment in mode
+            and line.contains_standalone_comments()
+        )
     ):
         raise CannotSplit("Splitting a single attribute from its owner looks wrong")
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -263,6 +263,7 @@ class Preview(Enum):
     pyi_blank_line_after_function_docstring = auto()
     hug_comparator = auto()
     parenthesize_tuple_in_yield = auto()
+    split_method_chain_on_standalone_comment = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -92,7 +92,8 @@
           "pyi_blank_line_before_decorated_class",
           "pyi_blank_line_after_function_docstring",
           "hug_comparator",
-          "parenthesize_tuple_in_yield"
+          "parenthesize_tuple_in_yield",
+          "split_method_chain_on_standalone_comment"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/preview_method_chain_comment.py
+++ b/tests/data/cases/preview_method_chain_comment.py
@@ -1,0 +1,30 @@
+# flags: --preview
+x = (
+    very_long_function_name_with_many_arguments(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000).f()
+    # Comment
+    .g()
+)
+y = (
+    very_long_function_name_with_many_arguments(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000).f()
+    # Comment
+    .g()
+    .h()
+)
+# output
+x = (
+    very_long_function_name_with_many_arguments(
+        100, 200, 300, 400, 500, 600, 700, 800, 900, 1000
+    )
+    .f()
+    # Comment
+    .g()
+)
+y = (
+    very_long_function_name_with_many_arguments(
+        100, 200, 300, 400, 500, 600, 700, 800, 900, 1000
+    )
+    .f()
+    # Comment
+    .g()
+    .h()
+)


### PR DESCRIPTION
### Description

Fixes psf/black#3998.

When a standalone comment appears between chained method calls, Black could split the
same leading call differently depending on whether another chained call followed the
comment. This adds a preview-gated formatter feature so commented method chains split
the first trailer consistently.

The change is intentionally limited to dotted delimiter splitting when the line contains
a standalone comment. Stable style remains unchanged.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

Validation:

- `PYTHONPYCACHEPREFIX=.pycache-tmp /Volumes/STOREJET/2/Dependencies/black-3998-venv/bin/python -m pytest tests/test_format.py -k preview_method_chain_comment -q`
- `PYTHONPYCACHEPREFIX=.pycache-tmp /Volumes/STOREJET/2/Dependencies/black-3998-venv/bin/python -m pytest tests/test_docs.py tests/test_schema.py -q`
- `PYTHONPYCACHEPREFIX=.pycache-tmp /Volumes/STOREJET/2/Dependencies/black-3998-venv/bin/python -m pytest tests/test_format.py -q`
- `git diff --check`
