### PR TITLE
fix: rename unused loop variable to _i

### DIFF
--- a/src/blib2to3/pgen2/conv.py
+++ b/src/blib2to3/pgen2/conv.py
@@ -200,7 +200,7 @@ class Converter(grammar.Grammar):
         mo = re.match(r"static label labels\[(\d+)\] = {$", line)
         assert mo, (lineno, line)
         nlabels = int(mo.group(1))
-        for i in range(nlabels):
+        for _i in range(nlabels):
             lineno, line = lineno + 1, next(f)
             mo = re.match(r'\s+{(\d+), (0|"\w+")},$', line)
             assert mo, (lineno, line)


### PR DESCRIPTION
B007: loop control variable `i` in conv.py was assigned but never used.
✅ 226 tests pass.