### PR TITLE
avoid quadratic per-leaf copy in StringMerger.do_transform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@
   splicing the unchanged blocks into each parent's child list in a single pass rather
   than removing and re-inserting each one, which rescanned and shifted the whole child
   list on every conversion (#5213)
+- Improve performance of `--preview` string merging on lines such as
+  `"%s ..." % (a, b, c, ...)` by copying the leaves that surround the merged string in
+  one `append_leaves` call instead of one call per leaf, which rescanned the shared
+  parent's child list from the start every time (#5220)
 
 ### Output
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -579,8 +579,18 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
         new_line = line.clone()
         previous_merged_string_idx = -1
         previous_merged_num_of_strings = -1
+        # Leaves outside any merged string group are copied in runs rather than
+        # one at a time. append_leaves resumes the search for each leaf's
+        # position from where the previous sibling of the same parent was found,
+        # so copying a run of leaves that share a parent (the operand tuple of
+        # "%s ..." % (a, b, c, ...)) stays linear; a fresh call per leaf restarts
+        # that search from the front every time and is quadratic in the operands.
+        pending: list[Leaf] = []
         for i, leaf in enumerate(LL):
             if i in merged_string_idx_dict:
+                if pending:
+                    append_leaves(new_line, line, pending)
+                    pending = []
                 previous_merged_string_idx = i
                 previous_merged_num_of_strings, string_leaf = merged_string_idx_dict[i]
                 new_line.append(string_leaf)
@@ -594,7 +604,10 @@ class StringMerger(StringTransformer, CustomSplitMapMixin):
                     new_line.append(comment_leaf, preformatted=True)
                 continue
 
-            append_leaves(new_line, line, [leaf])
+            pending.append(leaf)
+
+        if pending:
+            append_leaves(new_line, line, pending)
 
         return Ok(new_line)
 


### PR DESCRIPTION
### Description

Profiling `--preview` string merging on `"%s ..." % (a, b, c, ...)` still showed a quadratic after #5199 linearised `append_leaves`: the run sat around 4s for 8000 operands with `len` called about 32 million times. `StringMerger.do_transform` rebuilds the merged line by walking every leaf of the old line and copying each leaf that is not part of a merged string with its own `append_leaves(new_line, line, [leaf])` call. The resume hint added in #5199 only persists inside a single `append_leaves` call, so a one-leaf call always restarts the search for the leaf's position from the front. A `%` expression's operand tuple is a single parent holding every operand, so copying its n leaves one at a time rescans that child list from index 0 each time and is O(n²). It is reachable pre-auth from `blackd` with `X-Preview` and `X-Enable-Unstable-Feature: string_processing`.

I gather the consecutive leaves that fall outside any merged string group and hand each contiguous run to `append_leaves` in one call, which is the shape the resume hint was built for, so the copy stays linear. The per-leaf calls were doing nothing the batched call does not, comments included, so the new line is built identically. Output is byte-identical across the test suite and the black source tree in stable, preview and unstable modes plus crafted `%`-format and implicit-concat inputs; the 8000-operand case drops from roughly 4.1s to 0.8s and the curve flattens from quadratic to linear.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
