### PR TITLE
fix: initialize Leaf.bracket_depth in __init__

### DIFF
--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -482,6 +482,7 @@ class Leaf(Base):
             self._prefix = prefix
         self.fixers_applied: list[Any] | None = fixers_applied[:]
         self.children = []
+        self.bracket_depth = 0
         self.opening_bracket = opening_bracket
         self.fmt_pass_converted_first_leaf = fmt_pass_converted_first_leaf
 


### PR DESCRIPTION
Fixes #5214, closes #5215, closes #5227, closes #5267

racket_depth was declared as int in the Leaf class but never initialized in Leaf.__init__, which could cause AttributeError when accessing it before rackets.py sets it.