### PR TITLE
fix: add conditional stripping for Linux executables

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -23,22 +23,27 @@ jobs:
             pathsep: ";"
             asset_name: black_windows.exe
             executable_mime: "application/vnd.microsoft.portable-executable"
+            strip: false
           - os: windows-11-arm
             pathsep: ";"
             asset_name: black_windows-arm.exe
             executable_mime: "application/vnd.microsoft.portable-executable"
+            strip: false
           - os: ubuntu-latest
             pathsep: ":"
             asset_name: black_linux
             executable_mime: "application/x-executable"
+            strip: true
           - os: ubuntu-24.04-arm
             pathsep: ":"
             asset_name: black_linux-arm
             executable_mime: "application/x-executable"
+            strip: true
           - os: macos-latest
             pathsep: ":"
             asset_name: black_macos
             executable_mime: "application/x-mach-binary"
+            strip: false
     permissions:
       contents: write # Needed to upload to release
 
@@ -56,8 +61,9 @@ jobs:
 
       - name: Build executable with PyInstaller
         run:
-          python -m PyInstaller -F --name ${{ matrix.asset_name }} --add-data
-          'src/blib2to3${{ matrix.pathsep }}blib2to3' src/black/__main__.py
+          python -m PyInstaller -F ${{ matrix.strip && '--strip' || '' }} --name ${{
+          matrix.asset_name }} --add-data 'src/blib2to3${{ matrix.pathsep }}blib2to3'
+          src/black/__main__.py
 
       - name: Quickly test executable
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,7 +69,7 @@
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
 - Reduce the size of Linux standalone binaries by stripping debug symbols during the
-  PyInstaller release build (#5233)
+  PyInstaller release build (#5223)
 
 ### Parser
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,8 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
+- Reduce the size of Linux standalone binaries by stripping debug symbols during the PyInstaller release build (#5233)
+
 ### Parser
 
 <!-- Changes to the parser or to version autodetection -->

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,8 @@
 
 <!-- Changes to how Black is packaged, such as dependency requirements -->
 
-- Reduce the size of Linux standalone binaries by stripping debug symbols during the PyInstaller release build (#5233)
+- Reduce the size of Linux standalone binaries by stripping debug symbols during the
+  PyInstaller release build (#5233)
 
 ### Parser
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->
This essentially fixes https://github.com/psf/black/issues/2291. 


I tried building the Linux executable on my machine ( Ubuntu 24.04 x86_64 desktop running Python 3.14 ) and found that executable generated was around ~12M, roughly the same size of PE and Mach-O generated by the Github Action workflow. 

On analysing the executable a bit, I found the main difference was the size of Python interpreter being bundled by PyInstaller. Following is the size comparison-

On my local-
```text
-rw-r--r-- 1 root root 8.7M Mar 24 00:34 /usr/lib/x86_64-linux-gnu/libpython3.14.so.1.0
```

On Github Action runner-
```text
-rwxrwxrwx 1 runner packer 31M Jun 28 21:54 /opt/hostedtoolcache/Python/3.14.6/x64/lib/libpython3.14.so.1.0
```

And this is what file command returned-

On my local-
```text
/usr/lib/x86_64-linux-gnu/libpython3.14.so.1.0: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=0d148f3b8bdf451ed0e7e416957307e9b691032b, stripped
```

On Github Action runner-
```text
/opt/hostedtoolcache/Python/3.14.6/x64/lib/libpython3.14.so.1.0: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=e6fdb4bf77689f4fbc54f28b6562a4c5121963df, with debug_info, not stripped
```

As we can see Github Action libpython is not stripped and carries DWARF data, as compared to what gets shipped on Ubuntu systems by default. It didn't make sense to me that release builds carried debug information anyway. I looked up a bit and found that PyInstaller offered [--strip](https://pyinstaller.org/en/stable/usage.html#cmdoption-s), which made sense over manually stripping the libpython provided by the runner's environment.

As it is not recommended to be used on Windows and the Mac executable seemed fine, I have added the appropriate matrix based check. 

I ran the workflow on my fork and these are the results-
<img width="2047" height="638" alt="image" src="https://github.com/user-attachments/assets/5ad0aaea-64b6-4d6c-bd39-87bc95b53f9f" />

I also did some sanity tests locally by trying to format some projects using the above x86_64 build just to be on safer side.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

