### PR TITLE
avoid quadratic node removal when converting fmt: off/on blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@
   splicing the unchanged blocks into each parent's child list in a single pass rather
   than removing and re-inserting each one, which rescanned and shifted the whole child
   list on every conversion (#5213)
+- Improve performance on files with many `# fmt: off`/`# fmt: on` blocks by resuming the
+  search for each converted block within its parent's child list from the previous
+  conversion's position instead of rescanning the whole list from the start on every
+  node removal (#5232)
 
 ### Output
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -198,9 +198,14 @@ def normalize_fmt_off(
     # mutates the tree at or after the converted leaf, so earlier leaves never
     # need to be revisited.
     leaves = list(node.leaves())
+    # Per-parent hint of where the previous conversion removed a child, so the
+    # left-to-right removals below don't rescan each parent's children list from
+    # index 0 every time (quadratic when a file has many `# fmt: off` blocks
+    # sharing one parent).
+    search_hints: dict[int, int] = {}
     i = 0
     while i < len(leaves):
-        i = convert_one_fmt_off_pair(node, leaves, i, mode, lines)
+        i = convert_one_fmt_off_pair(node, leaves, i, mode, lines, search_hints)
 
 
 def _should_process_fmt_comment(
@@ -344,6 +349,7 @@ def convert_one_fmt_off_pair(
     start: int,
     mode: Mode,
     lines: Collection[tuple[int, int]],
+    search_hints: dict[int, int] | None = None,
 ) -> int:
     """Convert content of a single `# fmt: off`/`# fmt: on` into a standalone comment.
 
@@ -403,6 +409,7 @@ def convert_one_fmt_off_pair(
                 is_fmt_skip,
                 lines,
                 leaf,
+                search_hints,
             )
             return idx
 
@@ -426,6 +433,7 @@ def _handle_regular_fmt_block(
     is_fmt_skip: bool,
     lines: Collection[tuple[int, int]],
     leaf: Leaf,
+    search_hints: dict[int, int] | None = None,
 ) -> None:
     """Handle fmt blocks with actual AST nodes."""
     first = ignored_nodes[0]  # Can be a container node with the `leaf`.
@@ -509,7 +517,19 @@ def _handle_regular_fmt_block(
 
     first_idx: int | None = None
     for ignored in ignored_nodes:
-        index = ignored.remove()
+        ignored_parent = ignored.parent
+        hint = (
+            search_hints.get(id(ignored_parent), 0)
+            if search_hints is not None and ignored_parent is not None
+            else 0
+        )
+        index = ignored.remove(hint)
+        if (
+            index is not None
+            and search_hints is not None
+            and ignored_parent is not None
+        ):
+            search_hints[id(ignored_parent)] = index
         if first_idx is None:
             first_idx = index
 

--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -163,15 +163,25 @@ class Base:
             self.parent.changed()
         self.was_changed = True
 
-    def remove(self) -> int | None:
+    def remove(self, search_start: int = 0) -> int | None:
         """
         Remove the node from the tree. Returns the position of the node in its
         parent's children before it was removed.
+
+        ``search_start`` hints where to begin looking in the parent's children.
+        A caller that removes many siblings of the same parent in left-to-right
+        order can pass the last returned position to avoid rescanning the whole
+        list from index 0 every time, which is quadratic over the parent. The
+        entire list is still searched (starting at the hint and wrapping around),
+        so an inaccurate hint only costs a little extra scanning.
         """
         if self.parent:
-            for i, node in enumerate(self.parent.children):
-                if node is self:
-                    del self.parent.children[i]
+            children = self.parent.children
+            count = len(children)
+            for offset in range(count):
+                i = (search_start + offset) % count
+                if children[i] is self:
+                    del children[i]
                     self.parent.changed()
                     self.parent._remove_from_sibling_maps(self)
                     self.parent = None


### PR DESCRIPTION
### Description

Profiling a file with many `# fmt: off`/`# fmt: on` regions interspersed with ordinary code showed `Base.remove` in `blib2to3/pytree.py` dominating and growing quadratically: the number of children scanned across all removals was 502k at 500 blocks, 2.0M at 1000 and 8.0M at 2000, quadrupling every time the block count doubled. The cause is that `normalize_fmt_off` converts each block to a `STANDALONE_COMMENT` through `_handle_regular_fmt_block`, which calls `ignored.remove()` on every node of the block, and `remove` locates the node by scanning its parent's children from index 0. Every top-level block shares one parent (`file_input`), which grows to O(N) children, so converting N blocks is O(N^2) work dominated by that scan.

Because the blocks are converted left to right, the position of each removal within a given parent only moves forward. I added an optional `search_start` hint to `remove` and thread a small per-parent position map through `normalize_fmt_off`/`convert_one_fmt_off_pair`/`_handle_regular_fmt_block`, so each removal resumes the scan from the previous conversion's index instead of restarting. The full children list is still searched (the scan wraps around modulo its length), so a stale hint only costs a little extra work and never changes which node is removed; children scanned drops to linear (3k/6k/12k for the same inputs). This is the inner counterpart to #5169, which removed the outer re-traversal of this same pass but left the per-node removal alone, and to #5213, which fixed the equivalent `remove` behaviour on the separate `--line-ranges` path. Output is byte-identical across the test suite (226 format cases), the `fmtonoff` data and the Black source tree in both stable and preview; left unfixed a small `# fmt: off`-heavy input burns quadratic CPU, and this pass runs before any formatting so it is reachable through unauthenticated `blackd`.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
