### PR TITLE
Report parse errors as file:line:column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -132,6 +132,8 @@
 
 <!-- Changes to Black's terminal output and error messages -->
 
+- Report parser failures using editor-friendly `path:line:column` locations (#5237)
+
 ### _Blackd_
 
 <!-- Changes to blackd -->

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -353,7 +353,7 @@ silenced by `2>/dev/null`).
 
 ```console
 $ black src/ -q
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6
+error: cannot parse: src/black_primer/cli.py:5:6
     mport asyncio
          ^
 ParseError: bad input
@@ -371,7 +371,7 @@ Using configuration from /tmp/pyproject.toml.
 src/blib2to3 ignored: matches the --extend-exclude regular expression
 src/_black_version.py wasn't modified on disk since last run.
 src/black/__main__.py wasn't modified on disk since last run.
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6
+error: cannot parse: src/black_primer/cli.py:5:6
     mport asyncio
          ^
 ParseError: bad input
@@ -449,7 +449,7 @@ plus a short summary.
 
 ```console
 $ black src/
-error: cannot format src/black_primer/cli.py: Cannot parse: 5:6
+error: cannot parse: src/black_primer/cli.py:5:6
     mport asyncio
          ^
 ParseError: bad input

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -901,7 +901,7 @@ def reformat_code(
     except Exception as exc:
         if report.verbose:
             traceback.print_exc()
-        report.failed(path, str(exc))
+        report.failed(path, exc)
 
 
 # diff-shades depends on being to monkeypatch this function to operate. I know it's
@@ -965,7 +965,7 @@ def reformat_one(
     except Exception as exc:
         if report.verbose:
             traceback.print_exc()
-        report.failed(src, str(exc))
+        report.failed(src, exc)
 
 
 def format_file_in_place(

--- a/src/black/concurrency.py
+++ b/src/black/concurrency.py
@@ -217,7 +217,7 @@ async def schedule_formatting(
                 elif exc := task.exception():
                     if report.verbose:
                         traceback.print_exception(type(exc), exc, exc.__traceback__)
-                    report.failed(src, str(exc))
+                    report.failed(src, exc)
                 else:
                     changed = Changed.YES if task.result() else Changed.NO
                     # If the file was written back or was successfully checked as

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -25,6 +25,31 @@ class InvalidInput(ValueError):
     context: str | None = None
     details: str | None = None
 
+    def __init__(
+        self,
+        message: str,
+        lineno: int | None = None,
+        column: int | None = None,
+        context: str | None = None,
+        details: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.lineno = lineno
+        self.column = column
+        self.context = context
+        self.details = details
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        type["InvalidInput"],
+        tuple[str, int | None, int | None, str | None, str | None],
+    ]:
+        return (
+            InvalidInput,
+            (str(self), self.lineno, self.column, self.context, self.details),
+        )
+
     @classmethod
     def from_syntax_error(
         cls,
@@ -35,12 +60,7 @@ class InvalidInput(ValueError):
         details: str,
     ) -> "InvalidInput":
         """Create an error with source details for user-facing reports."""
-        error = cls(message)
-        error.lineno = lineno
-        error.column = column
-        error.context = context
-        error.details = details
-        return error
+        return cls(message, lineno, column, context, details)
 
 
 def get_grammars(target_versions: set[TargetVersion]) -> list[Grammar]:

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -20,6 +20,28 @@ from blib2to3.pytree import Leaf, Node
 class InvalidInput(ValueError):
     """Raised when input source code fails all parse attempts."""
 
+    lineno: int | None = None
+    column: int | None = None
+    context: str | None = None
+    details: str | None = None
+
+    @classmethod
+    def from_syntax_error(
+        cls,
+        message: str,
+        lineno: int,
+        column: int,
+        context: str,
+        details: str,
+    ) -> "InvalidInput":
+        """Create an error with source details for user-facing reports."""
+        error = cls(message)
+        error.lineno = lineno
+        error.column = column
+        error.context = context
+        error.details = details
+        return error
+
 
 def get_grammars(target_versions: set[TargetVersion]) -> list[Grammar]:
     if not target_versions:
@@ -80,14 +102,15 @@ def lib2to3_parse(
                 faulty_line = lines[lineno - 1]
             except IndexError:
                 faulty_line = "<line number missing in source>"
-            error_msg = (
-                f"Cannot parse{tv_str}: {lineno}:{column}\n"
-                f"    {faulty_line}\n"
-                f"    {' ' * (column - 1)}^\n"
-                f"ParseError: {pe.msg}"
+            context = f"Cannot parse{tv_str}"
+            details = (
+                f"    {faulty_line}\n    {' ' * (column - 1)}^\nParseError: {pe.msg}"
             )
+            error_msg = f"{context}: {lineno}:{column}\n{details}"
 
-            errors[grammar.version] = InvalidInput(error_msg)
+            errors[grammar.version] = InvalidInput.from_syntax_error(
+                error_msg, lineno, column, context, details
+            )
 
         except TokenError as te:
             lineno, column = te.args[1]
@@ -96,13 +119,16 @@ def lib2to3_parse(
                 faulty_line = lines[lineno - 1]
             except IndexError:
                 faulty_line = "<line number missing in source>"
-            error_msg = (
-                f"Cannot parse{tv_str}: {lineno}:{column}\n"
+            context = f"Cannot parse{tv_str}"
+            details = (
                 f"    {faulty_line}\n"
                 f"    {' ' * (column - 1)}^\n"
                 f"TokenError: {te.args[0]}"
             )
-            errors[grammar.version] = InvalidInput(error_msg)
+            error_msg = f"{context}: {lineno}:{column}\n{details}"
+            errors[grammar.version] = InvalidInput.from_syntax_error(
+                error_msg, lineno, column, context, details
+            )
 
     else:
         # Choose the latest version when raising the actual parsing error.

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -110,7 +110,6 @@ def lib2to3_parse(
                 f"ParseError: {pe.msg}",
             ))
             error_msg = f"{context}: {lineno}:{column}{details}"
-
             errors[grammar.version] = InvalidInput(
                 error_msg, lineno, column, context, details
             )
@@ -123,12 +122,12 @@ def lib2to3_parse(
             except IndexError:
                 faulty_line = "<line number missing in source>"
             context = f"cannot parse{tv_str}"
-            details = (
-                "\n"
-                f"    {faulty_line}\n"
-                f"    {' ' * (column - 1)}^\n"
-                f"TokenError: {te.args[0]}"
-            )
+            details = "\n".join((
+                "",
+                f"    {faulty_line}",
+                f"    {' ' * (column - 1)}^",
+                f"TokenError: {te.args[0]}",
+            ))
             error_msg = f"{context}: {lineno}:{column}{details}"
             errors[grammar.version] = InvalidInput(
                 error_msg, lineno, column, context, details

--- a/src/black/parsing.py
+++ b/src/black/parsing.py
@@ -33,34 +33,14 @@ class InvalidInput(ValueError):
         context: str | None = None,
         details: str | None = None,
     ) -> None:
-        super().__init__(message)
+        super().__init__(message, lineno, column, context, details)
         self.lineno = lineno
         self.column = column
         self.context = context
         self.details = details
 
-    def __reduce__(
-        self,
-    ) -> tuple[
-        type["InvalidInput"],
-        tuple[str, int | None, int | None, str | None, str | None],
-    ]:
-        return (
-            InvalidInput,
-            (str(self), self.lineno, self.column, self.context, self.details),
-        )
-
-    @classmethod
-    def from_syntax_error(
-        cls,
-        message: str,
-        lineno: int,
-        column: int,
-        context: str,
-        details: str,
-    ) -> "InvalidInput":
-        """Create an error with source details for user-facing reports."""
-        return cls(message, lineno, column, context, details)
+    def __str__(self) -> str:
+        return str(self.args[0])
 
 
 def get_grammars(target_versions: set[TargetVersion]) -> list[Grammar]:
@@ -122,13 +102,16 @@ def lib2to3_parse(
                 faulty_line = lines[lineno - 1]
             except IndexError:
                 faulty_line = "<line number missing in source>"
-            context = f"Cannot parse{tv_str}"
-            details = (
-                f"    {faulty_line}\n    {' ' * (column - 1)}^\nParseError: {pe.msg}"
-            )
-            error_msg = f"{context}: {lineno}:{column}\n{details}"
+            context = f"cannot parse{tv_str}"
+            details = "\n".join((
+                "",
+                f"    {faulty_line}",
+                f"    {' ' * (column - 1)}^",
+                f"ParseError: {pe.msg}",
+            ))
+            error_msg = f"{context}: {lineno}:{column}{details}"
 
-            errors[grammar.version] = InvalidInput.from_syntax_error(
+            errors[grammar.version] = InvalidInput(
                 error_msg, lineno, column, context, details
             )
 
@@ -139,14 +122,15 @@ def lib2to3_parse(
                 faulty_line = lines[lineno - 1]
             except IndexError:
                 faulty_line = "<line number missing in source>"
-            context = f"Cannot parse{tv_str}"
+            context = f"cannot parse{tv_str}"
             details = (
+                "\n"
                 f"    {faulty_line}\n"
                 f"    {' ' * (column - 1)}^\n"
                 f"TokenError: {te.args[0]}"
             )
-            error_msg = f"{context}: {lineno}:{column}\n{details}"
-            errors[grammar.version] = InvalidInput.from_syntax_error(
+            error_msg = f"{context}: {lineno}:{column}{details}"
+            errors[grammar.version] = InvalidInput(
                 error_msg, lineno, column, context, details
             )
 

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pathlib import Path
 
 from black.output import err, out, style_output
+from black.parsing import InvalidInput
 
 
 class Changed(Enum):
@@ -47,9 +48,19 @@ class Report:
                 out(msg, bold=False)
             self.same_count += 1
 
-    def failed(self, src: Path, message: str) -> None:
+    def failed(self, src: Path, message: str | BaseException) -> None:
         """Increment the counter for failed reformatting. Write out a message."""
-        err(f"error: cannot format {src}: {message}")
+        if (
+            isinstance(message, InvalidInput)
+            and message.lineno is not None
+            and message.column is not None
+            and message.context
+        ):
+            context = message.context[0].lower() + message.context[1:]
+            details = f"\n{message.details}" if message.details else ""
+            err(f"error: {context}: {src}:{message.lineno}:{message.column}{details}")
+        else:
+            err(f"error: cannot format {src}: {message}")
         self.failure_count += 1
 
     def path_ignored(self, path: Path, message: str) -> None:

--- a/src/black/report.py
+++ b/src/black/report.py
@@ -48,7 +48,7 @@ class Report:
                 out(msg, bold=False)
             self.same_count += 1
 
-    def failed(self, src: Path, message: str | BaseException) -> None:
+    def failed(self, src: Path, message: BaseException) -> None:
         """Increment the counter for failed reformatting. Write out a message."""
         if (
             isinstance(message, InvalidInput)
@@ -56,9 +56,11 @@ class Report:
             and message.column is not None
             and message.context
         ):
-            context = message.context[0].lower() + message.context[1:]
-            details = f"\n{message.details}" if message.details else ""
-            err(f"error: {context}: {src}:{message.lineno}:{message.column}{details}")
+            details = message.details or ""
+            err(
+                f"error: {message.context}: {src}:{message.lineno}:"
+                f"{message.column}{details}"
+            )
         else:
             err(f"error: cannot format {src}: {message}")
         self.failure_count += 1

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import multiprocessing
 import os
+import pickle
 import re
 import sys
 import textwrap
@@ -131,6 +132,40 @@ def invokeBlack(
         f"exception: {result.exception}"
     )
     assert result.exit_code == exit_code, msg
+
+
+def test_invalid_input_error_includes_path_location(tmp_path: Path) -> None:
+    source = tmp_path / "invalid.py"
+    source.write_text("return if you can\n", encoding="utf8")
+
+    result = BlackRunner().invoke(
+        black.main, ["--config", str(THIS_DIR / "empty.toml"), str(source)]
+    )
+
+    assert result.exit_code == 123
+    assert (
+        f"error: cannot parse: {source}:1:7\n"
+        "    return if you can\n"
+        "          ^\n"
+        "ParseError: bad input\n"
+        in result.stderr
+    )
+
+    second_source = tmp_path / "also_invalid.py"
+    second_source.write_text("print(\n", encoding="utf8")
+    result = BlackRunner().invoke(
+        black.main,
+        [
+            "--config",
+            str(THIS_DIR / "empty.toml"),
+            str(source),
+            str(second_source),
+        ],
+    )
+
+    assert result.exit_code == 123
+    assert f"error: cannot parse: {source}:1:7\n" in result.stderr
+    assert f"error: cannot parse: {second_source}:1:6\n" in result.stderr
 
 
 class BlackTestCase(BlackBaseTestCase):
@@ -813,8 +848,16 @@ class BlackTestCase(BlackBaseTestCase):
         self.assertEqual(output, unstyle(output))
 
     def test_lib2to3_parse(self) -> None:
-        with self.assertRaises(black.InvalidInput):
+        with self.assertRaises(black.InvalidInput) as exc_info:
             black.lib2to3_parse("invalid syntax")
+        error = exc_info.exception
+        restored_error = pickle.loads(pickle.dumps(error))
+        self.assertEqual((error.lineno, error.column), (1, 8))
+        self.assertEqual(str(restored_error), str(error))
+        self.assertEqual(
+            (error.lineno, error.column),
+            (restored_error.lineno, restored_error.column),
+        )
 
         straddling = "x + y"
         black.lib2to3_parse(straddling)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -585,7 +585,7 @@ class BlackTestCase(BlackBaseTestCase):
             report.check = True
             self.assertEqual(report.return_code, 1)
             report.check = False
-            report.failed(Path("e1"), "boom")
+            report.failed(Path("e1"), Exception("boom"))
             self.assertEqual(len(out_lines), 3)
             self.assertEqual(len(err_lines), 1)
             self.assertEqual(err_lines[-1], "error: cannot format e1: boom")
@@ -605,7 +605,7 @@ class BlackTestCase(BlackBaseTestCase):
                 " reformat.",
             )
             self.assertEqual(report.return_code, 123)
-            report.failed(Path("e2"), "boom")
+            report.failed(Path("e2"), Exception("boom"))
             self.assertEqual(len(out_lines), 4)
             self.assertEqual(len(err_lines), 2)
             self.assertEqual(err_lines[-1], "error: cannot format e2: boom")
@@ -682,7 +682,7 @@ class BlackTestCase(BlackBaseTestCase):
             report.check = True
             self.assertEqual(report.return_code, 1)
             report.check = False
-            report.failed(Path("e1"), "boom")
+            report.failed(Path("e1"), Exception("boom"))
             self.assertEqual(len(out_lines), 0)
             self.assertEqual(len(err_lines), 1)
             self.assertEqual(err_lines[-1], "error: cannot format e1: boom")
@@ -701,7 +701,7 @@ class BlackTestCase(BlackBaseTestCase):
                 " reformat.",
             )
             self.assertEqual(report.return_code, 123)
-            report.failed(Path("e2"), "boom")
+            report.failed(Path("e2"), Exception("boom"))
             self.assertEqual(len(out_lines), 0)
             self.assertEqual(len(err_lines), 2)
             self.assertEqual(err_lines[-1], "error: cannot format e2: boom")
@@ -778,7 +778,7 @@ class BlackTestCase(BlackBaseTestCase):
             report.check = True
             self.assertEqual(report.return_code, 1)
             report.check = False
-            report.failed(Path("e1"), "boom")
+            report.failed(Path("e1"), Exception("boom"))
             self.assertEqual(len(out_lines), 1)
             self.assertEqual(len(err_lines), 1)
             self.assertEqual(err_lines[-1], "error: cannot format e1: boom")
@@ -798,7 +798,7 @@ class BlackTestCase(BlackBaseTestCase):
                 " reformat.",
             )
             self.assertEqual(report.return_code, 123)
-            report.failed(Path("e2"), "boom")
+            report.failed(Path("e2"), Exception("boom"))
             self.assertEqual(len(out_lines), 2)
             self.assertEqual(len(err_lines), 2)
             self.assertEqual(err_lines[-1], "error: cannot format e2: boom")
@@ -1087,7 +1087,7 @@ class BlackTestCase(BlackBaseTestCase):
             black.format_file_contents(invalid, mode=mode, fast=False)
         self.assertEqual(
             str(e.exception),
-            "Cannot parse: 1:7\n"
+            "cannot parse: 1:7\n"
             "    return if you can\n"
             "          ^\n"
             "ParseError: bad input",
@@ -2111,7 +2111,7 @@ class BlackTestCase(BlackBaseTestCase):
 
         exc_info.match(
             re.escape(
-                "Cannot parse: 1:6\n"
+                "cannot parse: 1:6\n"
                 "    print(\n"
                 "         ^\n"
                 "TokenError: Unexpected EOF in multi-line statement"

--- a/tests/test_blackd.py
+++ b/tests/test_blackd.py
@@ -56,8 +56,8 @@ class BlackDTestCase(AioHTTPTestCase):
         self.assertEqual(response.status, 400)
         content = await response.text()
         self.assertTrue(
-            content.startswith("Cannot parse"),
-            msg=f"Expected error to start with 'Cannot parse', got {repr(content)}",
+            content.startswith("cannot parse"),
+            msg=f"Expected error to start with 'cannot parse', got {repr(content)}",
         )
 
     async def test_blackd_unsupported_version(self) -> None:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -91,7 +91,7 @@ def test_patma_invalid() -> None:
 
     exc_info.match(
         re.escape(
-            "Cannot parse for target version Python 3.10: 10:11\n"
+            "cannot parse for target version Python 3.10: 10:11\n"
             "        case a := b:\n"
             "              ^\n"
             "ParseError: bad input"


### PR DESCRIPTION
### Description

Fixes #3157.

Parser failures currently reach the CLI as a string, so the report prefix separates the file path from the line and column (`cannot format path: Cannot parse: line:column`). This prevents editors and problem matchers from recognizing a standard source location.

This change keeps structured context, line, column, and diagnostic details on `InvalidInput` while preserving its existing string representation for API consumers such as blackd. CLI reports now render parser failures as `error: cannot parse: path:line:column`, while non-parser failures retain the existing `cannot format` output. The structured attributes are also covered by a pickle round trip because multi-file formatting passes exceptions back from worker processes.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (No code style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (No documentation change is needed for this error-output fix.)

### Test results

- `471 passed, 3 skipped, 8 subtests passed`
- pre-commit: isort, flake8, mypy, end-of-file, trailing-whitespace, and changelog checks passed