### PR TITLE
Preserve blank lines before fmt-off classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
+  after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like
   `x[key] = expr` (#5095)
 - Parenthesize tuple expressions in `yield` statements for consistency with function

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -43,6 +43,8 @@ Currently, the following features are included in the preview style:
   anyway; let the bracket explode instead. ([see below](labels/hug-comparator))
 - `parenthesize_tuple_in_yield`: Add parentheses around tuple expressions in `yield`
   statements.
+- `fmt_off_class_blank_lines`: Preserve two blank lines before a top-level class whose
+  definition starts inside a `# fmt: off` block after an import.
 
 (labels/wrap-comprehension-in)=
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1114,6 +1114,17 @@ class EmptyLineTracker:
             )
 
         if (
+            Preview.fmt_off_class_blank_lines in self.mode
+            and self.previous_line.is_import
+            and self.previous_line.depth == 0
+            and current_line.depth == 0
+            and current_line.is_fmt_pass_converted(
+                first_leaf_matches=lambda leaf: leaf.value == "class"
+            )
+        ):
+            return 2, 0
+
+        if (
             self.previous_line.is_import
             and self.previous_line.depth == 0
             and current_line.depth == 0

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -263,6 +263,7 @@ class Preview(Enum):
     pyi_blank_line_after_function_docstring = auto()
     hug_comparator = auto()
     parenthesize_tuple_in_yield = auto()
+    fmt_off_class_blank_lines = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -92,7 +92,8 @@
           "pyi_blank_line_before_decorated_class",
           "pyi_blank_line_after_function_docstring",
           "hug_comparator",
-          "parenthesize_tuple_in_yield"
+          "parenthesize_tuple_in_yield",
+          "fmt_off_class_blank_lines"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/preview_fmt_off_class_blank_lines.py
+++ b/tests/data/cases/preview_fmt_off_class_blank_lines.py
@@ -1,0 +1,17 @@
+# flags: --preview
+
+import sys
+# fmt: off
+class C:
+    def foo(self):
+        print(sys.platform)
+
+# output
+
+import sys
+
+
+# fmt: off
+class C:
+    def foo(self):
+        print(sys.platform)


### PR DESCRIPTION
### Description

Fixes #5225.

When a top-level class starts inside a `# fmt: off` block after an import, the
converted block looks like a standalone comment to the empty-line tracker. This caused
Black to keep only one blank line instead of the two required before a top-level class.

Preserve the converted block's original `class` token when deciding import separation.
The change is limited to a new preview feature, so stable formatting remains unchanged,
and a focused fixture covers the reported input.

### Testing

- `.venv/bin/pytest tests/test_format.py -k preview_fmt_off_class_blank_lines -q`
- `.venv/bin/pytest tests/test_format.py -q`
- `env -u NO_COLOR .venv/bin/pytest -q`
- `env -u NO_COLOR .venv/bin/pre-commit run mypy --files src/black/lines.py src/black/mode.py`
- `env -u NO_COLOR .venv/bin/tox -e run_self`
- `.venv/bin/tox -e generate_schema`

`env -u NO_COLOR .venv/bin/pre-commit run --all-files` passed every hook except
repository-wide mypy, which reports an unchanged `action/main.py` `tomllib`
ignore/stub mismatch under Python 3.14. The targeted mypy hook above passes for both
changed Python modules.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the
checks listed above locally.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?