### PR TITLE
avoid quadratic per-leaf subtree walk in is_complex_subscript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,10 @@
   search for each converted block within its parent's child list from the previous
   conversion's position instead of rescanning the whole list from the start on every
   node removal (#5232)
+- Improve performance on lists and subscripts holding one large expression that contains
+  no comparison or arithmetic sub-node (for example a long run of implicitly concatenated
+  strings inside `[]`) by caching the `is_complex_subscript` subtree walk per node instead
+  of re-walking the whole bracketed expression for every leaf (#5239)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,9 +128,9 @@
   conversion's position instead of rescanning the whole list from the start on every
   node removal (#5232)
 - Improve performance on lists and subscripts holding one large expression that contains
-  no comparison or arithmetic sub-node (for example a long run of implicitly concatenated
-  strings inside `[]`) by caching the `is_complex_subscript` subtree walk per node instead
-  of re-walking the whole bracketed expression for every leaf (#5239)
+  no comparison or arithmetic sub-node (for example a long run of implicitly
+  concatenated strings inside `[]`) by caching the `is_complex_subscript` subtree walk
+  per node instead of re-walking the whole bracketed expression for every leaf (#5239)
 
 ### Output
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -51,6 +51,9 @@ class Line:
     inside_brackets: bool = False
     should_split_rhs: bool = False
     magic_trailing_comma: Leaf | None = None
+    _complex_subscript_cache: dict[LeafID, bool] = field(
+        default_factory=dict, repr=False
+    )
 
     def append(
         self, leaf: Leaf, preformatted: bool = False, track_bracket: bool = False
@@ -443,9 +446,22 @@ class Line:
             if subscript_start.type == syms.subscriptlist:
                 subscript_start = child_towards(subscript_start, leaf)
 
-        return subscript_start is not None and any(
-            n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
-        )
+        if subscript_start is None:
+            return False
+
+        # The pre_order walk only depends on subscript_start, which is stable
+        # while a line is built, so cache it per node. Without this, appending
+        # every leaf of a large bracketed expression that holds no TEST_DESCENDANTS
+        # node (e.g. a long run of implicitly concatenated strings) re-walks the
+        # whole subtree each time, which is quadratic.
+        key = id(subscript_start)
+        cached = self._complex_subscript_cache.get(key)
+        if cached is None:
+            cached = any(
+                n.type in TEST_DESCENDANTS for n in subscript_start.pre_order()
+            )
+            self._complex_subscript_cache[key] = cached
+        return cached
 
     def enumerate_with_length(
         self, is_reversed: bool = False


### PR DESCRIPTION
Profiling a file that packs a long run of implicitly concatenated strings into a single subscript or list (`x = ["s0" "s1" ... "sn"]`) showed the whole run going quadratic in the default style, with `Line.is_complex_subscript` and `pre_order` dominating the trace. `append` calls it once per leaf while a square bracket is open, and when the bracketed body is one node that holds no comparison or arithmetic sub-node the `any(... in subscript_start.pre_order())` walk never short-circuits, so each of the n string leaves re-walks the entire subtree. A comma-separated subscript dodges this because `subscriptlist` narrows to the relevant child through `child_towards`, but a single implicitly concatenated string sits directly under the bracket and gets walked in full every time. It is reachable pre-auth through blackd, and left unfixed a 4000-string list takes several seconds where a comma list of the same size is near-instant.

The walk result depends only on `subscript_start`, which does not change while a line is being built, so I cache it per node on the `Line`. Keeping the cache at this layer rather than having callers skip the call preserves the exact spacing behaviour `is_complex_subscript` drives for genuine complex slices, and the `subscriptlist` branch still narrows per child so each distinct child is walked once. Output is byte-identical across the test data and the black source tree in stable and preview modes, and the same 4000-string input drops from ~3.4s to ~0.18s with the curve going from quadratic to linear.