### PR TITLE
Fix unstable formatting with comments on optional parens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix unstable formatting when an inline comment sits on optional parentheses
+  (for example a parenthesized assert message or assignment RHS). Black no longer
+  omits those parentheses in a way that re-parents the comment and changes the
+  split on a second pass (#3701, #3706, #4384)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Fix unstable formatting when an inline comment sits on optional parentheses
-  (for example a parenthesized assert message or assignment RHS). Black no longer
-  omits those parentheses in a way that re-parents the comment and changes the
-  split on a second pass (#3701, #3706, #4384)
+- Fix unstable formatting when an inline comment sits on optional parentheses (for
+  example a parenthesized assert message or assignment RHS). Black no longer omits those
+  parentheses in a way that re-parents the comment and changes the split on a second
+  pass (#3701, #3706, #4384)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,9 +18,7 @@
 <!-- Changes that affect Black's stable style -->
 
 - Fix unstable formatting when an inline comment sits on optional parentheses (for
-  example a parenthesized assert message or assignment RHS). Black no longer omits those
-  parentheses in a way that re-parents the comment and changes the split on a second
-  pass (#3701, #3706, #4384)
+  example a parenthesized assert message or assignment RHS) (#5241)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1485,6 +1485,15 @@ def can_omit_invisible_parens(
     """
     line = rhs.body
 
+    # Don't omit optional parens when the opening paren carries an inline comment.
+    # Omitting them re-parents the comment onto a different leaf after the next
+    # parse, which can make the RHS splitter choose a different shape on each
+    # pass (unstable formatting / "different code on the second pass"). See
+    # issues #3701, #3706, and #4384.
+    if rhs.opening_bracket.type == token.LPAR and not rhs.opening_bracket.value:
+        if rhs.head.comments.get(id(rhs.opening_bracket)):
+            return False
+
     # We can't omit parens if doing so would result in a type: ignore comment
     # sharing a line with other comments, as that breaks type: ignore parsing.
     # Check if the opening bracket (last leaf of head) has comments that would merge

--- a/tests/data/cases/unstable_comment_on_optional_parens.py
+++ b/tests/data/cases/unstable_comment_on_optional_parens.py
@@ -1,0 +1,27 @@
+# Regression for https://github.com/psf/black/issues/3701
+# Inline comment on optional parentheses must not migrate across formatter passes.
+assert some_long_name, (  # long __________________________ comment
+        'long ___________________________________ string %s' % str(variable))
+
+
+# Related case from https://github.com/psf/black/issues/4384
+if 1:
+    takeoff_effective_friction_coefficient = (  # From Torenbeek, Eq. 5-76; an approximation
+            friction_coefficient +
+            0.72 * (CD_zero_lift / CL_max)
+    )
+
+# output
+
+# Regression for https://github.com/psf/black/issues/3701
+# Inline comment on optional parentheses must not migrate across formatter passes.
+assert some_long_name, (  # long __________________________ comment
+    "long ___________________________________ string %s" % str(variable)
+)
+
+
+# Related case from https://github.com/psf/black/issues/4384
+if 1:
+    takeoff_effective_friction_coefficient = (  # From Torenbeek, Eq. 5-76; an approximation
+        friction_coefficient + 0.72 * (CD_zero_lift / CL_max)
+    )


### PR DESCRIPTION
### Description

Fixes multi-pass instability when an inline comment sits on optional parentheses (assert message / assignment RHS). Omitting those parens re-parented the comment onto a different leaf, so the RHS splitter chose a different shape on the next pass and tripped the second-pass stability check.

`can_omit_invisible_parens` now returns false when the optional opening paren already carries an inline comment, which pins the comment and keeps the formatting stable. Covers the #3701 reproducer and the same class from #3706 / #4384.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the
      [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)?
      (N/A — this is an unstable-formatting bug fix, not a deliberate style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
      (N/A — unintended formatting bug; no style-guide rewrite.)

Fixes #3701
