### PR TITLE
avoid quadratic leaf re-adding in get_leaves_inside_matching_brackets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,9 @@
   search for each converted block within its parent's child list from the previous
   conversion's position instead of rescanning the whole list from the start on every
   node removal (#5232)
+- Improve performance on deeply nested bracketed expressions by collecting each leaf
+  once in `get_leaves_inside_matching_brackets` instead of re-adding the whole span of
+  enclosed leaves for every surrounding bracket pair (#5242)
 
 ### Output
 

--- a/src/black/brackets.py
+++ b/src/black/brackets.py
@@ -404,17 +404,26 @@ def get_leaves_inside_matching_brackets(leaves: Sequence[Leaf]) -> set[LeafID]:
         )
     except StopIteration:
         return set()
-    bracket_stack = []
-    ids = set()
+    # Each open bracket collects the ids of the leaves at its own nesting level.
+    # When the matching closing bracket is reached the pair is confirmed as inside
+    # matching brackets, so those ids are kept (the ids of any nested pair are
+    # already kept, having been flushed when that inner pair closed). Unmatched
+    # opening brackets are dropped along with the ids they collected. Collecting
+    # each leaf under a single level keeps this linear instead of re-adding every
+    # enclosed leaf once per surrounding bracket.
+    ids: set[LeafID] = set()
+    bracket_stack: list[tuple[int, list[LeafID]]] = []
     for i in range(start_index, len(leaves)):
         leaf = leaves[i]
         if leaf.type in OPENING_BRACKETS:
-            bracket_stack.append((BRACKET[leaf.type], i))
-        if leaf.type in CLOSING_BRACKETS:
+            bracket_stack.append((BRACKET[leaf.type], [id(leaf)]))
+        elif leaf.type in CLOSING_BRACKETS:
             if bracket_stack and leaf.type == bracket_stack[-1][0]:
-                _, start = bracket_stack.pop()
-                for j in range(start, i + 1):
-                    ids.add(id(leaves[j]))
+                _, level_ids = bracket_stack.pop()
+                level_ids.append(id(leaf))
+                ids.update(level_ids)
             else:
                 break
+        elif bracket_stack:
+            bracket_stack[-1][1].append(id(leaf))
     return ids


### PR DESCRIPTION
### Description

Profiling on inputs with deeply nested brackets kept pointing at
`get_leaves_inside_matching_brackets` in `brackets.py`, which runs while splitting
long lines (`should_split_funcdef_with_rhs` on return-type leaves, and the head
component of `bracket_split_build_line`). It gathers the ids of leaves sitting inside
matching bracket pairs, but on every matched closing bracket it re-adds the entire span
from the opening bracket to the closing one through an inner `for j in range(start, i + 1)`
loop. A leaf wrapped in `k` nested pairs is added `k` times, so the pass is O(n·depth)
and turns quadratic on something like a heavily subscripted annotation. A direct
microbenchmark shows the tell-tale 4x-per-doubling curve (a 4000-deep nested sequence
takes ~0.65s), and the helper is on the pre-auth formatting path reachable through
blackd, so a small crafted input buys disproportionate work.

Instead of re-adding the whole enclosed span each time a pair closes, each leaf id is
now collected under its innermost open bracket and flushed into the result only once,
when that bracket's matching close is reached; unmatched openings simply drop the ids
they collected. Keeping the bookkeeping on the bracket stack means every id is recorded
and unioned at most once, so the helper is linear while the returned set is identical. I
checked equivalence against the previous implementation over 200k randomised bracket
sequences and the full format suite stays byte-identical; the 4000-deep input drops from
~0.65s to ~0.005s.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy? (n/a, no style change)
- [x] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary? (byte-identical behaviour, covered by the existing format suite)
- [ ] Add new / update outdated documentation? (n/a)
