### PR TITLE
Respect the magic trailing comma in starred type parameter lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
 
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
+- Respect the magic trailing comma in a PEP 695 type parameter list containing a
+  `*TypeVarTuple` or `**ParamSpec`, which previously collapsed back onto one line
+  (#5244)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`
   statement after another standalone comment (#5189)
 - Fix a crash when splitting `case case if ...` match patterns at very small line

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -73,6 +73,8 @@ VARARGS_PARENTS: Final = {
     syms.trailer,  # single argument to call
     syms.typedargslist,
     syms.varargslist,  # lambdas
+    syms.typevartuple,  # star in a PEP 695 type parameter list
+    syms.paramspec,  # double star in a PEP 695 type parameter list
 }
 UNPACKING_PARENTS: Final = {
     syms.atom,  # single element of a list or set literal

--- a/tests/data/cases/type_params.py
+++ b/tests/data/cases/type_params.py
@@ -13,6 +13,12 @@ def it_gets_worse[WhatIsTheLongestTypeVarNameYouCanThinkOfEnoughToMakeBlackSplit
 
 def magic[Trailing, Comma,](): pass
 
+def magic_starred[T, *Ts, **P,](): pass
+
+class MagicStarred[T, *Ts, **P,]: pass
+
+type MagicStarredAlias[T, *Ts, **P,] = int
+
 def weird_syntax[T: lambda: 42, U: a or b](): pass
 
 def name_3[name_0: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if aaaaaaaaaaa else name_3](): pass
@@ -60,6 +66,29 @@ def magic[
     Comma,
 ]():
     pass
+
+
+def magic_starred[
+    T,
+    *Ts,
+    **P,
+]():
+    pass
+
+
+class MagicStarred[
+    T,
+    *Ts,
+    **P,
+]:
+    pass
+
+
+type MagicStarredAlias[
+    T,
+    *Ts,
+    **P,
+] = int
 
 
 def weird_syntax[T: lambda: 42, U: a or b]():


### PR DESCRIPTION
## Summary

Fixes #5243. A magic trailing comma explodes a PEP 695 type-parameter list of plain type vars, but was silently ignored once the list contained a `*TypeVarTuple` or `**ParamSpec`:

```python
class C[
    T,
    *Ts,
    **P,
]:
    pass
```

collapsed back to

```python
class C[
    T, *Ts, **P,
]:
    pass
```

## Root cause

`is_split_before_delimiter` / `is_split_after_delimiter` deliberately skip a star that `is_vararg()` recognises, with the comment:

```python
# * and ** might also be MATH_OPERATORS but in this case they are not.
# Don't treat them as a delimiter.
```

`is_vararg()` decides that by checking the star's parent against `VARARGS_PARENTS`, which listed the argument/lambda nodes but **not** the PEP 695 `typevartuple` and `paramspec` nodes:

```
leaf='*'  parent_sym=typevartuple   is_vararg=False
leaf='**' parent_sym=paramspec      is_vararg=False
```

So the stars in a type-parameter list were scored as `*` and `**` math operators, and that delimiter outranked the comma when the line was split — which is why the trailing comma stopped mattering.

Adding both nodes to `VARARGS_PARENTS` restores the intended "not a delimiter" treatment.

## Scope

Fixes `def`, `async def`, `class` and `type` aliases alike, matching the issue. The non-magic case is unchanged — `def all_in[T: int, U: (bytes, str), *Ts, **P]()` still stays on one line (pinned by the existing fixture case).

## Tests

Added `magic_starred` (def), `MagicStarred` (class) and `MagicStarredAlias` (type alias) to `tests/data/cases/type_params.py`, right beside the existing plain-type-var `magic[Trailing, Comma,]` case.

Reverting only `src/` fails the fixture with exactly the reported collapse, on all three constructs:

```
-    *Ts,
+    T, *Ts, **P,
-    *Ts,
+    T, *Ts, **P,
-    *Ts,
+    T, *Ts, **P,
```

## Verification

- `pytest tests/ -k "not symlink"` → **464 passed, 3 skipped, 8 subtests passed** — no formatting regressions across the fixture corpus
- The 6 deselected `symlink` tests fail on a clean tree on my machine (`OSError: WinError 1314 A required privilege is not held by the client` — Windows needs elevation to create symlinks), verified by stashing; unrelated to this change

I'll add the `CHANGES.md` entry under **Stable style** in a follow-up commit on this branch, since the file asks for the PR number rather than the issue number and I only get that once this is opened.
