### PR TITLE
Preserve single-element tuple comma under --skip-magic-trailing-comma

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix dropping the required trailing comma from a single-element tuple used as a lambda
+  parameter default under `--skip-magic-trailing-comma` when a standalone comment forces
+  the tuple across multiple lines; removing the comma turned the tuple into a bare
+  expression and failed Black's AST safety check (#5246)
 - Fix unstable formatting when an inline comment sits on optional parentheses (for
   example a parenthesized assert message or assignment RHS) (#5241)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -18,6 +18,7 @@ from black.nodes import (
     is_import,
     is_multiline_string,
     is_one_sequence_between,
+    is_one_tuple,
     is_type_comment,
     is_type_ignore_comment,
     is_with_or_async_with_stmt,
@@ -91,7 +92,16 @@ class Line:
             if self.mode.magic_trailing_comma:
                 if self.has_magic_trailing_comma(leaf):
                     self.magic_trailing_comma = leaf
-            elif self.has_magic_trailing_comma(leaf):
+            elif self.has_magic_trailing_comma(leaf) and not (
+                # A one-element tuple's trailing comma is syntactically required,
+                # not magic, so it must never be removed. This is normally caught
+                # by has_magic_trailing_comma, but that check misses the tuple
+                # when its opening bracket was split onto an earlier line (for
+                # example by a standalone comment inside the tuple), so verify
+                # against the tree here before dropping the comma.
+                leaf.parent is not None
+                and is_one_tuple(leaf.parent)
+            ):
                 self.remove_trailing_comma()
         if not self.append_comment(leaf):
             self.leaves.append(leaf)

--- a/tests/data/cases/skip_magic_trailing_comma.py
+++ b/tests/data/cases/skip_magic_trailing_comma.py
@@ -16,6 +16,17 @@ set_of_types = {tuple[int,],}
 # Except single element tuples
 small_tuple = (1,)
 
+# Also keep the comma when a standalone comment splits the opening paren of a
+# single-element tuple used as a lambda parameter default onto a previous line.
+foo(lambda x=(
+    # comment
+    1,
+): x)
+[lambda x=(
+    # comment
+    1,
+): x]
+
 # Trailing commas in multiple chained non-nested parens.
 zero(
     one,
@@ -64,6 +75,19 @@ set_of_types = {tuple[int,]}
 
 # Except single element tuples
 small_tuple = (1,)
+
+# Also keep the comma when a standalone comment splits the opening paren of a
+# single-element tuple used as a lambda parameter default onto a previous line.
+foo(
+    lambda x=(
+    # comment
+    1,): x
+)
+[
+    lambda x=(
+    # comment
+    1,): x
+]
 
 # Trailing commas in multiple chained non-nested parens.
 zero(one).two(three).four(five)


### PR DESCRIPTION
### Description

Running with `--skip-magic-trailing-comma`, Black could delete the required trailing comma from a single-element tuple, turning `(x,)` into `(x)` and changing the code's meaning. It shows up when the tuple is a lambda parameter default and a standalone comment forces it across multiple lines, e.g.:

```python
foo(lambda x=(
    # comment
    1,
): x)
```

Black rewrote the `1,` to `1`, which made the formatted output non-equivalent to the source and tripped the AST safety check (`INTERNAL ERROR ... produced code that is not equivalent`).

The trailing comma of a one-element tuple is syntactically required, so it is never a magic trailing comma. `Line.has_magic_trailing_comma` normally recognizes this, but its one-tuple check (`is_one_sequence_between`) looks for the opening bracket in the current line's leaves. When a standalone comment inside the tuple splits the opening `(` onto an earlier line, it is no longer among those leaves, so the tuple is misread as an ordinary collection and the comma gets dropped during line construction.

I guarded the comma removal in `Line.append` with a tree-based `is_one_tuple` check, which does not depend on where the brackets landed. The magic-trailing-comma (default) code path is untouched, so stable formatting elsewhere is unchanged; genuine magic commas (single-argument calls, lists, sets, multi-element tuples) are still removed as before.

### How I tested

- Added input/output cases to `tests/data/cases/skip_magic_trailing_comma.py`; confirmed they fail before the change and pass after.
- Ran the full test suite (`pytest tests/`) — green.
- Fuzzed the fix by running every `tests/data/cases` input through many line lengths and modes (with and without `--skip-magic-trailing-comma`, stable and preview) and checking AST equivalence and stability — no divergences remain.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?