### PR TITLE
Format symmetric list concatenations in preview

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
+- Format long concatenations of two list displays symmetrically (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,7 +69,9 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
-- Format long concatenations of two list displays symmetrically (#5259)
+- Format long concatenations of two list displays symmetrically when both operands fit
+  on their own delimiter-split line; retain the existing layout when either operand
+  needs an internal split, including for an active magic trailing comma (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,9 +69,9 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
-- Format long concatenations of two list displays symmetrically when both operands fit
-  on their own delimiter-split line; retain the existing layout when either operand
-  needs an internal split, including for an active magic trailing comma (#5259)
+- Format long binary operations between matching list, tuple, dictionary, or set
+  displays symmetrically when both operands fit on their own delimiter-split line
+  (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,7 +58,9 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Format long concatenations of two list displays symmetrically (#5259)
+- Format long concatenations of two list displays symmetrically when both operands fit
+  on their own delimiter-split line; retain the existing layout when either operand
+  needs an internal split, including for an active magic trailing comma (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Format long concatenations of two list displays symmetrically (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,9 +69,8 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
-- Format long binary operations between matching list, tuple, dictionary, or set
-  displays symmetrically when both operands fit on their own delimiter-split line
-  (#5259)
+- Format long binary operations between collection displays symmetrically when both
+  operands fit on their own delimiter-split line (#5259)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -46,14 +46,17 @@ Currently, the following features are included in the preview style:
 - `fmt_off_class_blank_lines`: Preserve two blank lines before a top-level class whose
   definition starts inside a `# fmt: off` block after an import.
 - `symmetric_list_concatenation`: Keep optional parentheses around long concatenations
-  of two list displays so that each operand is formatted on its own line.
+  of two list displays when both operands fit on their own delimiter-split line.
 
 (labels/symmetric-list-concatenation)=
 
 ### Symmetric list concatenation
 
-When a concatenation of two list displays is too long for one line, Black keeps optional
-parentheses around the expression so that the two operands can be split symmetrically.
+When a concatenation of two list displays is too long for one line and both operands fit
+on their own delimiter-split line, Black keeps optional parentheses around the
+expression so that the operands can be split symmetrically. If either list needs an
+internal split, including when an active magic trailing comma forces it onto multiple
+lines, Black retains the existing formatting.
 
 ```python
 # Before

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -74,14 +74,17 @@ any additional pair:
 [(item for item in items), fallback]
 
 - `symmetric_list_concatenation`: Keep optional parentheses around long concatenations
-  of two list displays so that each operand is formatted on its own line.
+  of two list displays when both operands fit on their own delimiter-split line.
 
 (labels/symmetric-list-concatenation)=
 
 ### Symmetric list concatenation
 
-When a concatenation of two list displays is too long for one line, Black keeps optional
-parentheses around the expression so that the two operands can be split symmetrically.
+When a concatenation of two list displays is too long for one line and both operands fit
+on their own delimiter-split line, Black keeps optional parentheses around the
+expression so that the operands can be split symmetrically. If either list needs an
+internal split, including when an active magic trailing comma forces it onto multiple
+lines, Black retains the existing formatting.
 
 ```python
 # Before

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -72,6 +72,31 @@ any additional pair:
 
 # After (with --preview)
 [(item for item in items), fallback]
+
+- `symmetric_list_concatenation`: Keep optional parentheses around long concatenations
+  of two list displays so that each operand is formatted on its own line.
+
+(labels/symmetric-list-concatenation)=
+
+### Symmetric list concatenation
+
+When a concatenation of two list displays is too long for one line, Black keeps optional
+parentheses around the expression so that the two operands can be split symmetrically.
+
+```python
+# Before
+names = ["Alice", "Bob", "Charlie", "Diana", "Edward"] + [
+    "Fiona",
+    "George",
+    "Harriet",
+    "Isabelle",
+]
+
+# After (with --preview)
+names = (
+    ["Alice", "Bob", "Charlie", "Diana", "Edward"]
+    + ["Fiona", "George", "Harriet", "Isabelle"]
+)
 ```
 
 (labels/wrap-comprehension-in)=

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -84,9 +84,9 @@ any additional pair:
 When a binary operation between two collection displays is too long for one line and
 both operands fit on their own delimiter-split line, Black keeps optional parentheses
 around the expression so that the operands can be split symmetrically. This applies to
-every arithmetic and bitwise binary operator between collection displays. If either
-display needs an internal split, including when an active magic trailing comma forces it
-onto multiple lines, Black retains the existing formatting.
+every arithmetic, bitwise, and symbolic comparison operator between collection displays.
+If either display needs an internal split, including when an active magic trailing comma
+forces it onto multiple lines, Black retains the existing formatting.
 
 ```python
 # Before

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -47,6 +47,9 @@ Currently, the following features are included in the preview style:
   definition starts inside a `# fmt: off` block after an import.
 - `remove_redundant_generator_parentheses`: Remove redundant parentheses around
   generator expressions. ([see below](labels/remove-redundant-generator-parentheses))
+- `symmetric_collection_operations`: Keep optional parentheses around long binary
+  operations between collection displays when both operands fit on their own
+  delimiter-split line.
 
 (labels/remove-redundant-generator-parentheses)=
 
@@ -72,10 +75,7 @@ any additional pair:
 
 # After (with --preview)
 [(item for item in items), fallback]
-
-- `symmetric_collection_operations`: Keep optional parentheses around long binary
-  operations between collection displays when both operands fit on their own
-  delimiter-split line.
+```
 
 (labels/symmetric-collection-operations)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -73,18 +73,20 @@ any additional pair:
 # After (with --preview)
 [(item for item in items), fallback]
 
-- `symmetric_list_concatenation`: Keep optional parentheses around long concatenations
-  of two list displays when both operands fit on their own delimiter-split line.
+- `symmetric_list_concatenation`: Keep optional parentheses around long operations
+  between matching list, tuple, dictionary, or set displays when both operands fit on
+  their own delimiter-split line.
 
 (labels/symmetric-list-concatenation)=
 
-### Symmetric list concatenation
+### Symmetric display operations
 
-When a concatenation of two list displays is too long for one line and both operands fit
-on their own delimiter-split line, Black keeps optional parentheses around the
-expression so that the operands can be split symmetrically. If either list needs an
-internal split, including when an active magic trailing comma forces it onto multiple
-lines, Black retains the existing formatting.
+When an operation between two matching displays is too long for one line and both
+operands fit on their own delimiter-split line, Black keeps optional parentheses around
+the expression so that the operands can be split symmetrically. This applies to list and
+tuple concatenation (`+`), dictionary and set union (`|`), and set intersection (`&`).
+If either display needs an internal split, including when an active magic trailing comma
+forces it onto multiple lines, Black retains the existing formatting.
 
 ```python
 # Before

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -73,20 +73,20 @@ any additional pair:
 # After (with --preview)
 [(item for item in items), fallback]
 
-- `symmetric_list_concatenation`: Keep optional parentheses around long operations
-  between matching list, tuple, dictionary, or set displays when both operands fit on
-  their own delimiter-split line.
+- `symmetric_collection_operations`: Keep optional parentheses around long binary
+  operations between collection displays when both operands fit on their own
+  delimiter-split line.
 
-(labels/symmetric-list-concatenation)=
+(labels/symmetric-collection-operations)=
 
 ### Symmetric display operations
 
-When an operation between two matching displays is too long for one line and both
-operands fit on their own delimiter-split line, Black keeps optional parentheses around
-the expression so that the operands can be split symmetrically. This applies to list and
-tuple concatenation (`+`), dictionary and set union (`|`), and set intersection (`&`).
-If either display needs an internal split, including when an active magic trailing comma
-forces it onto multiple lines, Black retains the existing formatting.
+When a binary operation between two collection displays is too long for one line and
+both operands fit on their own delimiter-split line, Black keeps optional parentheses
+around the expression so that the operands can be split symmetrically. This applies to
+every arithmetic and bitwise binary operator between collection displays. If either
+display needs an internal split, including when an active magic trailing comma forces it
+onto multiple lines, Black retains the existing formatting.
 
 ```python
 # Before

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -45,6 +45,31 @@ Currently, the following features are included in the preview style:
   statements.
 - `fmt_off_class_blank_lines`: Preserve two blank lines before a top-level class whose
   definition starts inside a `# fmt: off` block after an import.
+- `symmetric_list_concatenation`: Keep optional parentheses around long concatenations
+  of two list displays so that each operand is formatted on its own line.
+
+(labels/symmetric-list-concatenation)=
+
+### Symmetric list concatenation
+
+When a concatenation of two list displays is too long for one line, Black keeps optional
+parentheses around the expression so that the two operands can be split symmetrically.
+
+```python
+# Before
+names = ["Alice", "Bob", "Charlie", "Diana", "Edward"] + [
+    "Fiona",
+    "George",
+    "Harriet",
+    "Isabelle",
+]
+
+# After (with --preview)
+names = (
+    ["Alice", "Bob", "Charlie", "Diana", "Edward"]
+    + ["Fiona", "George", "Harriet", "Isabelle"]
+)
+```
 
 (labels/wrap-comprehension-in)=
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -31,8 +31,8 @@ from black.lines import (
     append_leaves,
     can_be_split,
     can_omit_invisible_parens,
-    is_symmetric_list_concatenation,
     is_line_short_enough,
+    is_symmetric_list_concatenation,
     line_to_string,
 )
 from black.mode import Feature, Mode, Preview

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -32,7 +32,7 @@ from black.lines import (
     can_be_split,
     can_omit_invisible_parens,
     is_line_short_enough,
-    is_symmetric_collection_operation,
+    is_symmetric_collection_binop,
     line_to_string,
 )
 from black.mode import Feature, Mode, Preview
@@ -1130,13 +1130,13 @@ def _maybe_split_omitting_optional_parens(
     features: Collection[Feature] = (),
     omit: Collection[LeafID] = (),
 ) -> Iterator[Line]:
-    split_symmetric_lists = (
-        Preview.symmetric_list_concatenation in mode
+    split_symmetric_collection_binops = (
+        Preview.symmetric_collection_operations in mode
         and rhs.opening_bracket.type == token.LPAR
         and not rhs.opening_bracket.value
         and rhs.closing_bracket.type == token.RPAR
         and not rhs.closing_bracket.value
-        and is_symmetric_collection_operation(rhs.body, mode.line_length)
+        and is_symmetric_collection_binop(rhs.body, mode.line_length)
     )
     if (
         Feature.FORCE_OPTIONAL_PARENTHESES not in features
@@ -1199,7 +1199,7 @@ def _maybe_split_omitting_optional_parens(
 
     ensure_visible(rhs.opening_bracket)
     ensure_visible(rhs.closing_bracket)
-    if split_symmetric_lists:
+    if split_symmetric_collection_binops:
         rhs.body.should_split_rhs = True
     for result in (rhs.head, rhs.body, rhs.tail):
         if result:

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -32,7 +32,7 @@ from black.lines import (
     can_be_split,
     can_omit_invisible_parens,
     is_line_short_enough,
-    is_symmetric_list_concatenation,
+    is_symmetric_collection_operation,
     line_to_string,
 )
 from black.mode import Feature, Mode, Preview
@@ -1136,7 +1136,7 @@ def _maybe_split_omitting_optional_parens(
         and not rhs.opening_bracket.value
         and rhs.closing_bracket.type == token.RPAR
         and not rhs.closing_bracket.value
-        and is_symmetric_list_concatenation(rhs.body, mode.line_length)
+        and is_symmetric_collection_operation(rhs.body, mode.line_length)
     )
     if (
         Feature.FORCE_OPTIONAL_PARENTHESES not in features

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -31,6 +31,7 @@ from black.lines import (
     append_leaves,
     can_be_split,
     can_omit_invisible_parens,
+    is_symmetric_list_concatenation,
     is_line_short_enough,
     line_to_string,
 )
@@ -1129,6 +1130,14 @@ def _maybe_split_omitting_optional_parens(
     features: Collection[Feature] = (),
     omit: Collection[LeafID] = (),
 ) -> Iterator[Line]:
+    split_symmetric_lists = (
+        Preview.symmetric_list_concatenation in mode
+        and rhs.opening_bracket.type == token.LPAR
+        and not rhs.opening_bracket.value
+        and rhs.closing_bracket.type == token.RPAR
+        and not rhs.closing_bracket.value
+        and is_symmetric_list_concatenation(rhs.body, mode.line_length)
+    )
     if (
         Feature.FORCE_OPTIONAL_PARENTHESES not in features
         # the opening bracket is an optional paren
@@ -1190,6 +1199,8 @@ def _maybe_split_omitting_optional_parens(
 
     ensure_visible(rhs.opening_bracket)
     ensure_visible(rhs.closing_bracket)
+    if split_symmetric_lists:
+        rhs.body.should_split_rhs = True
     for result in (rhs.head, rhs.body, rhs.tail):
         if result:
             yield result

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -10,16 +10,19 @@ from black.mode import Mode, Preview
 from black.nodes import (
     BRACKETS,
     CLOSING_BRACKETS,
+    MATH_OPERATORS,
     OPENING_BRACKETS,
     STANDALONE_COMMENT,
     TEST_DESCENDANTS,
     child_towards,
     first_leaf,
     is_docstring,
+    is_generator,
     is_import,
     is_multiline_string,
     is_one_sequence_between,
     is_one_tuple,
+    is_tuple,
     is_type_comment,
     is_type_ignore_comment,
     is_with_or_async_with_stmt,
@@ -1520,8 +1523,8 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
-def is_symmetric_collection_operation(line: Line, line_length: int) -> bool:
-    """Is `line` a supported pair of single-line display operands?"""
+def is_symmetric_collection_binop(line: Line, line_length: int) -> bool:
+    """Is `line` a binary operation between single-line collection displays?"""
     if len(line.bracket_tracker.delimiters) != 1:
         return False
 
@@ -1546,16 +1549,25 @@ def is_symmetric_collection_operation(line: Line, line_length: int) -> bool:
     right_opening = line.leaves[delimiter_index + 1]
     last = line.leaves[-1]
 
-    display_operation = (
-        (token.LSQB, token.RSQB, token.PLUS),
-        (token.LPAR, token.RPAR, token.PLUS),
-        (token.LBRACE, token.RBRACE, token.VBAR),
-        (token.LBRACE, token.RBRACE, token.AMPER),
-    )
+    collection_display = {
+        (token.LSQB, token.RSQB),
+        (token.LPAR, token.RPAR),
+        (token.LBRACE, token.RBRACE),
+    }
+
+    def is_collection_display(opening: Leaf, closing: Leaf) -> bool:
+        if (opening.type, closing.type) not in collection_display:
+            return False
+        return opening.type != token.LPAR or (
+            opening.parent is not None
+            and is_tuple(opening.parent)
+            and not is_generator(opening.parent)
+        )
+
     if (
-        (first.type, left_closing.type, delimiter.type) not in display_operation
-        or right_opening.type is not first.type
-        or last.type is not left_closing.type
+        not is_collection_display(first, left_closing)
+        or not is_collection_display(right_opening, last)
+        or delimiter.type not in MATH_OPERATORS
         or left_closing.opening_bracket is not first
         or last.opening_bracket is not right_opening
     ):
@@ -1715,8 +1727,8 @@ def can_omit_invisible_parens(
             # line.
             return False
         if (
-            Preview.symmetric_list_concatenation in mode
-            and is_symmetric_collection_operation(line, line_length)
+            Preview.symmetric_collection_operations in mode
+            and is_symmetric_collection_binop(line, line_length)
         ):
             # Retaining the optional parentheses lets the delimiter splitter put
             # each display operand on its own line instead of exploding just one.

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1520,6 +1520,42 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
+def _is_symmetric_list_concatenation(line: Line) -> bool:
+    """Is `line` exactly two list displays joined by a top-level `+`?"""
+    if len(line.bracket_tracker.delimiters) != 1:
+        return False
+
+    delimiter_id = next(iter(line.bracket_tracker.delimiters))
+    try:
+        left_closing_index = next(
+            index for index, leaf in enumerate(line.leaves) if id(leaf) == delimiter_id
+        )
+    except StopIteration:
+        return False
+
+    # Math operators are split *before* the delimiter, so BracketTracker keys
+    # them by the preceding leaf.
+    delimiter_index = left_closing_index + 1
+    if delimiter_index == len(line.leaves) - 1:
+        return False
+
+    first = line.leaves[0]
+    left_closing = line.leaves[left_closing_index]
+    delimiter = line.leaves[delimiter_index]
+    right_opening = line.leaves[delimiter_index + 1]
+    last = line.leaves[-1]
+
+    return (
+        delimiter.type == token.PLUS
+        and first.type == token.LSQB
+        and left_closing.type == token.RSQB
+        and left_closing.opening_bracket is first
+        and right_opening.type == token.LSQB
+        and last.type == token.RSQB
+        and last.opening_bracket is right_opening
+    )
+
+
 def can_omit_invisible_parens(
     rhs: RHSResult,
     line_length: int,
@@ -1644,6 +1680,14 @@ def can_omit_invisible_parens(
             # better. In this case, `rhs.body` is the context managers part of
             # the with statement. `rhs.head` is the `with (` part on the previous
             # line.
+            return False
+        if (
+            Preview.symmetric_list_concatenation in mode
+            and not is_line_short_enough(line, mode=mode)
+            and _is_symmetric_list_concatenation(line)
+        ):
+            # Retaining the optional parentheses lets the delimiter splitter put
+            # each list operand on its own line instead of exploding just one list.
             return False
         # Otherwise it may also read better, but we don't do it today and requires
         # careful considerations for all possible cases. See

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -10,6 +10,7 @@ from black.mode import Mode, Preview
 from black.nodes import (
     BRACKETS,
     CLOSING_BRACKETS,
+    COMPARATORS,
     MATH_OPERATORS,
     OPENING_BRACKETS,
     STANDALONE_COMMENT,
@@ -1567,7 +1568,7 @@ def is_symmetric_collection_binop(line: Line, line_length: int) -> bool:
     if (
         not is_collection_display(first, left_closing)
         or not is_collection_display(right_opening, last)
-        or delimiter.type not in MATH_OPERATORS
+        or delimiter.type not in MATH_OPERATORS | COMPARATORS
         or left_closing.opening_bracket is not first
         or last.opening_bracket is not right_opening
     ):

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1520,8 +1520,8 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
-def is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
-    """Is `line` exactly two single-line lists joined by a top-level `+`?"""
+def is_symmetric_collection_operation(line: Line, line_length: int) -> bool:
+    """Is `line` a supported pair of single-line display operands?"""
     if len(line.bracket_tracker.delimiters) != 1:
         return False
 
@@ -1546,19 +1546,23 @@ def is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
     right_opening = line.leaves[delimiter_index + 1]
     last = line.leaves[-1]
 
-    if not (
-        delimiter.type == token.PLUS
-        and first.type == token.LSQB
-        and left_closing.type == token.RSQB
-        and left_closing.opening_bracket is first
-        and right_opening.type == token.LSQB
-        and last.type == token.RSQB
-        and last.opening_bracket is right_opening
+    display_operation = (
+        (token.LSQB, token.RSQB, token.PLUS),
+        (token.LPAR, token.RPAR, token.PLUS),
+        (token.LBRACE, token.RBRACE, token.VBAR),
+        (token.LBRACE, token.RBRACE, token.AMPER),
+    )
+    if (
+        (first.type, left_closing.type, delimiter.type) not in display_operation
+        or right_opening.type is not first.type
+        or last.type is not left_closing.type
+        or left_closing.opening_bracket is not first
+        or last.opening_bracket is not right_opening
     ):
         return False
 
-    # Keep the existing asymmetric split when either list is already forced to
-    # split by a magic trailing comma.
+    # Keep the existing asymmetric split when either display is already forced
+    # to split by a magic trailing comma.
     if line.mode.magic_trailing_comma and (
         line.leaves[left_closing_index - 1].type == token.COMMA
         or line.leaves[-2].type == token.COMMA
@@ -1712,10 +1716,10 @@ def can_omit_invisible_parens(
             return False
         if (
             Preview.symmetric_list_concatenation in mode
-            and is_symmetric_list_concatenation(line, line_length)
+            and is_symmetric_collection_operation(line, line_length)
         ):
             # Retaining the optional parentheses lets the delimiter splitter put
-            # each list operand on its own line instead of exploding just one list.
+            # each display operand on its own line instead of exploding just one.
             return False
         # Otherwise it may also read better, but we don't do it today and requires
         # careful considerations for all possible cases. See

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1509,6 +1509,42 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
+def _is_symmetric_list_concatenation(line: Line) -> bool:
+    """Is `line` exactly two list displays joined by a top-level `+`?"""
+    if len(line.bracket_tracker.delimiters) != 1:
+        return False
+
+    delimiter_id = next(iter(line.bracket_tracker.delimiters))
+    try:
+        left_closing_index = next(
+            index for index, leaf in enumerate(line.leaves) if id(leaf) == delimiter_id
+        )
+    except StopIteration:
+        return False
+
+    # Math operators are split *before* the delimiter, so BracketTracker keys
+    # them by the preceding leaf.
+    delimiter_index = left_closing_index + 1
+    if delimiter_index == len(line.leaves) - 1:
+        return False
+
+    first = line.leaves[0]
+    left_closing = line.leaves[left_closing_index]
+    delimiter = line.leaves[delimiter_index]
+    right_opening = line.leaves[delimiter_index + 1]
+    last = line.leaves[-1]
+
+    return (
+        delimiter.type == token.PLUS
+        and first.type == token.LSQB
+        and left_closing.type == token.RSQB
+        and left_closing.opening_bracket is first
+        and right_opening.type == token.LSQB
+        and last.type == token.RSQB
+        and last.opening_bracket is right_opening
+    )
+
+
 def can_omit_invisible_parens(
     rhs: RHSResult,
     line_length: int,
@@ -1633,6 +1669,14 @@ def can_omit_invisible_parens(
             # better. In this case, `rhs.body` is the context managers part of
             # the with statement. `rhs.head` is the `with (` part on the previous
             # line.
+            return False
+        if (
+            Preview.symmetric_list_concatenation in mode
+            and not is_line_short_enough(line, mode=mode)
+            and _is_symmetric_list_concatenation(line)
+        ):
+            # Retaining the optional parentheses lets the delimiter splitter put
+            # each list operand on its own line instead of exploding just one list.
             return False
         # Otherwise it may also read better, but we don't do it today and requires
         # careful considerations for all possible cases. See

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1520,11 +1520,12 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
-def _is_symmetric_list_concatenation(line: Line) -> bool:
-    """Is `line` exactly two list displays joined by a top-level `+`?"""
+def _is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
+    """Is `line` exactly two single-line lists joined by a top-level `+`?"""
     if len(line.bracket_tracker.delimiters) != 1:
         return False
 
+    # Delimiters is keyed by leaf ID, not line position.
     delimiter_id = next(iter(line.bracket_tracker.delimiters))
     try:
         left_closing_index = next(
@@ -1545,7 +1546,7 @@ def _is_symmetric_list_concatenation(line: Line) -> bool:
     right_opening = line.leaves[delimiter_index + 1]
     last = line.leaves[-1]
 
-    return (
+    if not (
         delimiter.type == token.PLUS
         and first.type == token.LSQB
         and left_closing.type == token.RSQB
@@ -1553,6 +1554,34 @@ def _is_symmetric_list_concatenation(line: Line) -> bool:
         and right_opening.type == token.LSQB
         and last.type == token.RSQB
         and last.opening_bracket is right_opening
+    ):
+        return False
+
+    # Keep the existing asymmetric split when either list is already forced to
+    # split by a magic trailing comma.
+    if line.mode.magic_trailing_comma and (
+        line.leaves[left_closing_index - 1].type == token.COMMA
+        or line.leaves[-2].type == token.COMMA
+    ):
+        return False
+
+    def rendered_width(start: int, end: int) -> int | None:
+        leaves = line.leaves[start:end]
+        rendered = "    " * line.depth
+        for index, leaf in enumerate(leaves):
+            rendered += leaf.value if index == 0 else str(leaf)
+            rendered += "".join(str(comment) for comment in line.comments_after(leaf))
+        if "\n" in rendered:
+            return None
+        return str_width(rendered)
+
+    left_width = rendered_width(0, delimiter_index)
+    right_width = rendered_width(delimiter_index, len(line.leaves))
+    return (
+        left_width is not None
+        and right_width is not None
+        and left_width <= line_length
+        and right_width <= line_length
     )
 
 
@@ -1684,7 +1713,7 @@ def can_omit_invisible_parens(
         if (
             Preview.symmetric_list_concatenation in mode
             and not is_line_short_enough(line, mode=mode)
-            and _is_symmetric_list_concatenation(line)
+            and _is_symmetric_list_concatenation(line, line_length)
         ):
             # Retaining the optional parentheses lets the delimiter splitter put
             # each list operand on its own line instead of exploding just one list.

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1509,11 +1509,12 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
-def _is_symmetric_list_concatenation(line: Line) -> bool:
-    """Is `line` exactly two list displays joined by a top-level `+`?"""
+def _is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
+    """Is `line` exactly two single-line lists joined by a top-level `+`?"""
     if len(line.bracket_tracker.delimiters) != 1:
         return False
 
+    # Delimiters is keyed by leaf ID, not line position.
     delimiter_id = next(iter(line.bracket_tracker.delimiters))
     try:
         left_closing_index = next(
@@ -1534,7 +1535,7 @@ def _is_symmetric_list_concatenation(line: Line) -> bool:
     right_opening = line.leaves[delimiter_index + 1]
     last = line.leaves[-1]
 
-    return (
+    if not (
         delimiter.type == token.PLUS
         and first.type == token.LSQB
         and left_closing.type == token.RSQB
@@ -1542,6 +1543,34 @@ def _is_symmetric_list_concatenation(line: Line) -> bool:
         and right_opening.type == token.LSQB
         and last.type == token.RSQB
         and last.opening_bracket is right_opening
+    ):
+        return False
+
+    # Keep the existing asymmetric split when either list is already forced to
+    # split by a magic trailing comma.
+    if line.mode.magic_trailing_comma and (
+        line.leaves[left_closing_index - 1].type == token.COMMA
+        or line.leaves[-2].type == token.COMMA
+    ):
+        return False
+
+    def rendered_width(start: int, end: int) -> int | None:
+        leaves = line.leaves[start:end]
+        rendered = "    " * line.depth
+        for index, leaf in enumerate(leaves):
+            rendered += leaf.value if index == 0 else str(leaf)
+            rendered += "".join(str(comment) for comment in line.comments_after(leaf))
+        if "\n" in rendered:
+            return None
+        return str_width(rendered)
+
+    left_width = rendered_width(0, delimiter_index)
+    right_width = rendered_width(delimiter_index, len(line.leaves))
+    return (
+        left_width is not None
+        and right_width is not None
+        and left_width <= line_length
+        and right_width <= line_length
     )
 
 
@@ -1673,7 +1702,7 @@ def can_omit_invisible_parens(
         if (
             Preview.symmetric_list_concatenation in mode
             and not is_line_short_enough(line, mode=mode)
-            and _is_symmetric_list_concatenation(line)
+            and _is_symmetric_list_concatenation(line, line_length)
         ):
             # Retaining the optional parentheses lets the delimiter splitter put
             # each list operand on its own line instead of exploding just one list.

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1520,7 +1520,7 @@ def _is_annotated_assignment(head: Line) -> bool:
     return False
 
 
-def _is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
+def is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
     """Is `line` exactly two single-line lists joined by a top-level `+`?"""
     if len(line.bracket_tracker.delimiters) != 1:
         return False
@@ -1537,7 +1537,7 @@ def _is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
     # Math operators are split *before* the delimiter, so BracketTracker keys
     # them by the preceding leaf.
     delimiter_index = left_closing_index + 1
-    if delimiter_index == len(line.leaves) - 1:
+    if delimiter_index >= len(line.leaves) - 1:
         return False
 
     first = line.leaves[0]
@@ -1568,9 +1568,9 @@ def _is_symmetric_list_concatenation(line: Line, line_length: int) -> bool:
     def rendered_width(start: int, end: int) -> int | None:
         leaves = line.leaves[start:end]
         rendered = "    " * line.depth
+        # End-of-line comments do not determine whether the operand itself fits.
         for index, leaf in enumerate(leaves):
             rendered += leaf.value if index == 0 else str(leaf)
-            rendered += "".join(str(comment) for comment in line.comments_after(leaf))
         if "\n" in rendered:
             return None
         return str_width(rendered)
@@ -1712,8 +1712,7 @@ def can_omit_invisible_parens(
             return False
         if (
             Preview.symmetric_list_concatenation in mode
-            and not is_line_short_enough(line, mode=mode)
-            and _is_symmetric_list_concatenation(line, line_length)
+            and is_symmetric_list_concatenation(line, line_length)
         ):
             # Retaining the optional parentheses lets the delimiter splitter put
             # each list operand on its own line instead of exploding just one list.

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -265,6 +265,7 @@ class Preview(Enum):
     parenthesize_tuple_in_yield = auto()
     fmt_off_class_blank_lines = auto()
     remove_redundant_generator_parentheses = auto()
+    symmetric_list_concatenation = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -265,7 +265,7 @@ class Preview(Enum):
     parenthesize_tuple_in_yield = auto()
     fmt_off_class_blank_lines = auto()
     remove_redundant_generator_parentheses = auto()
-    symmetric_list_concatenation = auto()
+    symmetric_collection_operations = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -264,6 +264,7 @@ class Preview(Enum):
     hug_comparator = auto()
     parenthesize_tuple_in_yield = auto()
     fmt_off_class_blank_lines = auto()
+    symmetric_list_concatenation = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -95,7 +95,7 @@
           "parenthesize_tuple_in_yield",
           "fmt_off_class_blank_lines",
           "remove_redundant_generator_parentheses",
-          "symmetric_list_concatenation"
+          "symmetric_collection_operations"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -93,7 +93,8 @@
           "pyi_blank_line_after_function_docstring",
           "hug_comparator",
           "parenthesize_tuple_in_yield",
-          "fmt_off_class_blank_lines"
+          "fmt_off_class_blank_lines",
+          "symmetric_list_concatenation"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -94,7 +94,8 @@
           "hug_comparator",
           "parenthesize_tuple_in_yield",
           "fmt_off_class_blank_lines",
-          "remove_redundant_generator_parentheses"
+          "remove_redundant_generator_parentheses",
+          "symmetric_list_concatenation"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -62,11 +62,14 @@ from pytokens import TokenType
 
 from . import token as _token
 
-__all__ = [x for x in dir(_token) if x[0] != "_"] + [
-    "tokenize",
-    "generate_tokens",
-    "untokenize",
-]
+__all__ = (
+    [x for x in dir(_token) if x[0] != "_"]
+    + [
+        "tokenize",
+        "generate_tokens",
+        "untokenize",
+    ]
+)
 del _token
 
 Coord = tuple[int, int]

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -62,14 +62,11 @@ from pytokens import TokenType
 
 from . import token as _token
 
-__all__ = (
-    [x for x in dir(_token) if x[0] != "_"]
-    + [
-        "tokenize",
-        "generate_tokens",
-        "untokenize",
-    ]
-)
+__all__ = [x for x in dir(_token) if x[0] != "_"] + [
+    "tokenize",
+    "generate_tokens",
+    "untokenize",
+]
 del _token
 
 Coord = tuple[int, int]

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -12,7 +12,16 @@ commented = (
     + ["fourth_long_value", "fifth_long_value", "sixth_long_value"]
 )
 
-# A body that fits inside optional parentheses keeps the existing bracket split.
+commented_left = (
+    ["first_value", "second_value", "third_value"]  # abc
+    + ["fourth_value", "fifth_value", "sixth_value"]
+)
+commented_right = (
+    ["first_value", "second_value", "third_value"]
+    + ["fourth_value", "fifth_value", "sixth_value"]  # abc
+)
+
+# Split symmetrically even when the RHS alone fits inside optional parentheses.
 values = [first_value, second_value, third_value] + [fourth_value, fifth_value, sixth_value]
 
 # Chained concatenations already use the normal delimiter split.
@@ -60,12 +69,20 @@ commented = (
     + ["fourth_long_value", "fifth_long_value", "sixth_long_value"]
 )
 
-# A body that fits inside optional parentheses keeps the existing bracket split.
-values = [first_value, second_value, third_value] + [
-    fourth_value,
-    fifth_value,
-    sixth_value,
-]
+commented_left = (
+    ["first_value", "second_value", "third_value"]  # abc
+    + ["fourth_value", "fifth_value", "sixth_value"]
+)
+commented_right = (
+    ["first_value", "second_value", "third_value"]
+    + ["fourth_value", "fifth_value", "sixth_value"]  # abc
+)
+
+# Split symmetrically even when the RHS alone fits inside optional parentheses.
+values = (
+    [first_value, second_value, third_value]
+    + [fourth_value, fifth_value, sixth_value]
+)
 
 # Chained concatenations already use the normal delimiter split.
 chained = (

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -25,6 +25,21 @@ mixed_right = list_with_a_very_long_name + ["first_long_value", "second_long_val
 # Short concatenations stay on one line.
 small = [1, 2] + [3, 4]
 
+# Lists that already require bracket splitting keep the existing formatting.
+long_left = ["first_value_with_an_extremely_long_name", "second_value_with_an_extremely_long_name", "third"] + ["short"]
+long_right = ["short"] + ["first_value_with_an_extremely_long_name", "second_value_with_an_extremely_long_name", "third"]
+both_long = ["first_value_with_an_extremely_long_name", "second_value_with_an_extremely_long_name", "third"] + ["fourth_value_with_an_extremely_long_name", "fifth_value_with_an_extremely_long_name", "sixth"]
+
+# Magic trailing commas also keep the existing formatting.
+magic_left = [
+    "first_long_value",
+    "second_long_value",
+] + ["third_long_value", "fourth_long_value"]
+magic_right = ["first_long_value", "second_long_value"] + [
+    "third_long_value",
+    "fourth_long_value",
+]
+
 # output
 
 # Regression test for https://github.com/psf/black/issues/260.
@@ -73,3 +88,34 @@ mixed_right = list_with_a_very_long_name + [
 
 # Short concatenations stay on one line.
 small = [1, 2] + [3, 4]
+
+# Lists that already require bracket splitting keep the existing formatting.
+long_left = [
+    "first_value_with_an_extremely_long_name",
+    "second_value_with_an_extremely_long_name",
+    "third",
+] + ["short"]
+long_right = ["short"] + [
+    "first_value_with_an_extremely_long_name",
+    "second_value_with_an_extremely_long_name",
+    "third",
+]
+both_long = [
+    "first_value_with_an_extremely_long_name",
+    "second_value_with_an_extremely_long_name",
+    "third",
+] + [
+    "fourth_value_with_an_extremely_long_name",
+    "fifth_value_with_an_extremely_long_name",
+    "sixth",
+]
+
+# Magic trailing commas also keep the existing formatting.
+magic_left = [
+    "first_long_value",
+    "second_long_value",
+] + ["third_long_value", "fourth_long_value"]
+magic_right = ["first_long_value", "second_long_value"] + [
+    "third_long_value",
+    "fourth_long_value",
+]

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -1,0 +1,75 @@
+# flags: --preview
+
+# Regression test for https://github.com/psf/black/issues/260.
+search_fields = (["file__%s" % field for field in FileAdmin.search_fields] + ["resource__%s" % field for field in ResourceAdmin.search_fields])
+
+# Plain list displays receive the same symmetric treatment.
+names = ["Alice", "Bob", "Charlie", "Diana", "Edward"] + ["Fiona", "George", "Harriet", "Isabelle"]
+
+# Comments on an operand stay attached and formatting remains stable.
+commented = (
+    ["first_long_value", "second_long_value", "third_long_value"]  # first list
+    + ["fourth_long_value", "fifth_long_value", "sixth_long_value"]
+)
+
+# A body that fits inside optional parentheses keeps the existing bracket split.
+values = [first_value, second_value, third_value] + [fourth_value, fifth_value, sixth_value]
+
+# Chained concatenations already use the normal delimiter split.
+chained = ["first_long_value", "second_long_value"] + ["third_long_value", "fourth_long_value"] + ["fifth_long_value", "sixth_long_value"]
+
+# Mixed operands are not symmetric list concatenations.
+mixed_left = ["first_long_value", "second_long_value", "third_long_value"] + tuple_with_a_very_long_name
+mixed_right = list_with_a_very_long_name + ["first_long_value", "second_long_value", "third_long_value"]
+
+# Short concatenations stay on one line.
+small = [1, 2] + [3, 4]
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/260.
+search_fields = (
+    ["file__%s" % field for field in FileAdmin.search_fields]
+    + ["resource__%s" % field for field in ResourceAdmin.search_fields]
+)
+
+# Plain list displays receive the same symmetric treatment.
+names = (
+    ["Alice", "Bob", "Charlie", "Diana", "Edward"]
+    + ["Fiona", "George", "Harriet", "Isabelle"]
+)
+
+# Comments on an operand stay attached and formatting remains stable.
+commented = (
+    ["first_long_value", "second_long_value", "third_long_value"]  # first list
+    + ["fourth_long_value", "fifth_long_value", "sixth_long_value"]
+)
+
+# A body that fits inside optional parentheses keeps the existing bracket split.
+values = [first_value, second_value, third_value] + [
+    fourth_value,
+    fifth_value,
+    sixth_value,
+]
+
+# Chained concatenations already use the normal delimiter split.
+chained = (
+    ["first_long_value", "second_long_value"]
+    + ["third_long_value", "fourth_long_value"]
+    + ["fifth_long_value", "sixth_long_value"]
+)
+
+# Mixed operands are not symmetric list concatenations.
+mixed_left = [
+    "first_long_value",
+    "second_long_value",
+    "third_long_value",
+] + tuple_with_a_very_long_name
+mixed_right = list_with_a_very_long_name + [
+    "first_long_value",
+    "second_long_value",
+    "third_long_value",
+]
+
+# Short concatenations stay on one line.
+small = [1, 2] + [3, 4]

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -26,6 +26,10 @@ collection_right_shift = {"first_long_value", "second_long_value"} >> {"third_lo
 collection_xor = ["first_long_value", "second_long_value"] ^ ["third_long_value", "fourth_long_value"]
 mixed_collection_operands = ["first_long_value", "second_long_value"] + ("third_long_value", "fourth_long_value")
 
+# Symbolic comparisons between collection displays also split symmetrically.
+list_equality = ["first_long_value", "second_long_value"] == ["third_long_value", "fourth_long_value"]
+list_comprehension_equality = [item for item in source_items] == [first_value, second_value, third_value]
+
 # Parenthesized scalars and generator expressions are not collection displays.
 parenthesized_scalars = (first_function_with_a_really_long_name(first_argument)) + (second_function_with_a_really_long_name(second_argument))
 generator_operands = (first_item for first_item in first_collection_with_a_really_long_name) + (second_item for second_item in second_collection_with_a_really_long_name)
@@ -150,6 +154,16 @@ collection_xor = (
 mixed_collection_operands = (
     ["first_long_value", "second_long_value"]
     + ("third_long_value", "fourth_long_value")
+)
+
+# Symbolic comparisons between collection displays also split symmetrically.
+list_equality = (
+    ["first_long_value", "second_long_value"]
+    == ["third_long_value", "fourth_long_value"]
+)
+list_comprehension_equality = (
+    [item for item in source_items]
+    == [first_value, second_value, third_value]
 )
 
 # Parenthesized scalars and generator expressions are not collection displays.

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -12,6 +12,24 @@ dictionary_values = {"first_long_key": first_long_value, "second_long_key": seco
 set_union = {"first_long_value", "second_long_value"} | {"third_long_value", "fourth_long_value"}
 set_intersection = {"first_long_value", "second_long_value"} & {"third_long_value", "fourth_long_value"}
 
+# Every arithmetic and bitwise binary operator gets the same treatment when both operands
+# are collections.
+collection_subtraction = ["first_long_value", "second_long_value"] - ["third_long_value", "fourth_long_value"]
+collection_product = ("first_long_value", "second_long_value") * ("third_long_value", "fourth_long_value")
+collection_division = {"first_long_value", "second_long_value"} / {"third_long_value", "fourth_long_value"}
+collection_floor_division = ["first_long_value", "second_long_value"] // ["third_long_value", "fourth_long_value"]
+collection_modulo = {"first_long_value", "second_long_value"} % {"third_long_value", "fourth_long_value"}
+collection_matrix = ["first_long_value", "second_long_value"] @ ["third_long_value", "fourth_long_value"]
+collection_power = ("first_long_value", "second_long_value") ** ("third_long_value", "fourth_long_value")
+collection_shift = {"first_long_value", "second_long_value"} << {"third_long_value", "fourth_long_value"}
+collection_right_shift = {"first_long_value", "second_long_value"} >> {"third_long_value", "fourth_long_value"}
+collection_xor = ["first_long_value", "second_long_value"] ^ ["third_long_value", "fourth_long_value"]
+mixed_collection_operands = ["first_long_value", "second_long_value"] + ("third_long_value", "fourth_long_value")
+
+# Parenthesized scalars and generator expressions are not collection displays.
+parenthesized_scalars = (first_function_with_a_really_long_name(first_argument)) + (second_function_with_a_really_long_name(second_argument))
+generator_operands = (first_item for first_item in first_collection_with_a_really_long_name) + (second_item for second_item in second_collection_with_a_really_long_name)
+
 # Comments on an operand stay attached and formatting remains stable.
 commented = (
     ["first_long_value", "second_long_value", "third_long_value"]  # first list
@@ -86,6 +104,61 @@ set_intersection = (
     {"first_long_value", "second_long_value"}
     & {"third_long_value", "fourth_long_value"}
 )
+
+# Every arithmetic and bitwise binary operator gets the same treatment when both operands
+# are collections.
+collection_subtraction = (
+    ["first_long_value", "second_long_value"]
+    - ["third_long_value", "fourth_long_value"]
+)
+collection_product = (
+    ("first_long_value", "second_long_value")
+    * ("third_long_value", "fourth_long_value")
+)
+collection_division = (
+    {"first_long_value", "second_long_value"}
+    / {"third_long_value", "fourth_long_value"}
+)
+collection_floor_division = (
+    ["first_long_value", "second_long_value"]
+    // ["third_long_value", "fourth_long_value"]
+)
+collection_modulo = (
+    {"first_long_value", "second_long_value"}
+    % {"third_long_value", "fourth_long_value"}
+)
+collection_matrix = (
+    ["first_long_value", "second_long_value"]
+    @ ["third_long_value", "fourth_long_value"]
+)
+collection_power = (
+    ("first_long_value", "second_long_value")
+    ** ("third_long_value", "fourth_long_value")
+)
+collection_shift = (
+    {"first_long_value", "second_long_value"}
+    << {"third_long_value", "fourth_long_value"}
+)
+collection_right_shift = (
+    {"first_long_value", "second_long_value"}
+    >> {"third_long_value", "fourth_long_value"}
+)
+collection_xor = (
+    ["first_long_value", "second_long_value"]
+    ^ ["third_long_value", "fourth_long_value"]
+)
+mixed_collection_operands = (
+    ["first_long_value", "second_long_value"]
+    + ("third_long_value", "fourth_long_value")
+)
+
+# Parenthesized scalars and generator expressions are not collection displays.
+parenthesized_scalars = (first_function_with_a_really_long_name(first_argument)) + (
+    second_function_with_a_really_long_name(second_argument)
+)
+generator_operands = (
+    first_item for first_item in first_collection_with_a_really_long_name
+) + (second_item for second_item in second_collection_with_a_really_long_name)
 
 # Comments on an operand stay attached and formatting remains stable.
 commented = (

--- a/tests/data/cases/preview_symmetric_list_concatenation.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation.py
@@ -6,6 +6,12 @@ search_fields = (["file__%s" % field for field in FileAdmin.search_fields] + ["r
 # Plain list displays receive the same symmetric treatment.
 names = ["Alice", "Bob", "Charlie", "Diana", "Edward"] + ["Fiona", "George", "Harriet", "Isabelle"]
 
+# The matching tuple, dictionary, and set operations are also symmetric.
+tuple_values = ("first_long_value", "second_long_value") + ("third_long_value", "fourth_long_value")
+dictionary_values = {"first_long_key": first_long_value, "second_long_key": second_long_value} | {"third_long_key": third_long_value, "fourth_long_key": fourth_long_value}
+set_union = {"first_long_value", "second_long_value"} | {"third_long_value", "fourth_long_value"}
+set_intersection = {"first_long_value", "second_long_value"} & {"third_long_value", "fourth_long_value"}
+
 # Comments on an operand stay attached and formatting remains stable.
 commented = (
     ["first_long_value", "second_long_value", "third_long_value"]  # first list
@@ -61,6 +67,24 @@ search_fields = (
 names = (
     ["Alice", "Bob", "Charlie", "Diana", "Edward"]
     + ["Fiona", "George", "Harriet", "Isabelle"]
+)
+
+# The matching tuple, dictionary, and set operations are also symmetric.
+tuple_values = (
+    ("first_long_value", "second_long_value")
+    + ("third_long_value", "fourth_long_value")
+)
+dictionary_values = (
+    {"first_long_key": first_long_value, "second_long_key": second_long_value}
+    | {"third_long_key": third_long_value, "fourth_long_key": fourth_long_value}
+)
+set_union = (
+    {"first_long_value", "second_long_value"}
+    | {"third_long_value", "fourth_long_value"}
+)
+set_intersection = (
+    {"first_long_value", "second_long_value"}
+    & {"third_long_value", "fourth_long_value"}
 )
 
 # Comments on an operand stay attached and formatting remains stable.

--- a/tests/data/cases/preview_symmetric_list_concatenation_line_length.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation_line_length.py
@@ -1,0 +1,12 @@
+# flags: --preview --line-length=60
+
+values = [first_value, second_value] + [third_value, fourth_value]
+short_values = [first_value] + [second_value]
+
+# output
+
+values = (
+    [first_value, second_value]
+    + [third_value, fourth_value]
+)
+short_values = [first_value] + [second_value]

--- a/tests/data/cases/preview_symmetric_list_concatenation_skip_magic.py
+++ b/tests/data/cases/preview_symmetric_list_concatenation_skip_magic.py
@@ -1,0 +1,15 @@
+# flags: --preview --skip-magic-trailing-comma
+
+# Ignored trailing commas do not prevent symmetric formatting.
+values = [
+    "first_long_value",
+    "second_long_value",
+] + ["third_long_value", "fourth_long_value"]
+
+# output
+
+# Ignored trailing commas do not prevent symmetric formatting.
+values = (
+    ["first_long_value", "second_long_value"]
+    + ["third_long_value", "fourth_long_value"]
+)

--- a/tests/data/cases/stable_symmetric_list_concatenation.py
+++ b/tests/data/cases/stable_symmetric_list_concatenation.py
@@ -1,0 +1,4 @@
+# Stable style must keep the existing asymmetric bracket split.
+search_fields = ["file__%s" % field for field in FileAdmin.search_fields] + [
+    "resource__%s" % field for field in ResourceAdmin.search_fields
+]


### PR DESCRIPTION
### Description

Closes #260.

When a long expression is exactly two list displays or comprehensions joined by one top-level `+`, preserve its optional parentheses under `--preview` only when each operand fits on its own delimiter-split line. This lets the existing delimiter splitter place each operand on its own line instead of exploding only the right-hand list. Long operands, active magic-trailing-comma layouts, stable style, short expressions, chained concatenations, and mixed operands keep their current behavior.

The patch adds the preview feature flag, native format fixtures, schema entry, future-style documentation, changelog entry, and the required self-format dogfood change.

Validation:
- `env -u NO_COLOR tox -e py` (480 passed, 1 skipped; Jupyter 73 passed)
- focused symmetric-list fixtures (4 passed)
- `tox -e run_self,generate_schema`
- strict Sphinx build with `-W`
- full pre-commit suite
- 16,000-case list/line-length/magic-comma idempotence review matrix
- `git diff --check`
- independent review completed with no remaining findings

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?