### PR TITLE
Treat Ruff ignore comments as pragmas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Preserve physical lines ending in canonical Ruff ignore comments such as
+  `# ruff:ignore[...]`, matching existing pragma handling (#5261)
 - Fix dropping the required trailing comma from a single-element tuple used as a lambda
   parameter default under `--skip-magic-trailing-comma` when a standalone comment forces
   the tuple across multiple lines; removing the comma turned the tuple into a bare

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -13,6 +13,7 @@ from black.nodes import (
     WHITESPACE,
     container_of,
     first_leaf_of,
+    is_ruff_ignore_comment_string,
     is_type_comment_string,
     make_simple_prefix,
     preceding_leaf,
@@ -904,10 +905,12 @@ def contains_pragma_comment(comment_list: list[Leaf]) -> bool:
     Returns:
         True iff one of the comments in @comment_list is a pragma used by one
         of the more common static analysis tools for python (e.g. mypy, flake8,
-        pylint).
+    pylint).
     """
     for comment in comment_list:
-        if comment.value.startswith(("# type:", "# noqa", "# pylint:")):
+        if comment.value.startswith(
+            ("# type:", "# noqa", "# pylint:")
+        ) or is_ruff_ignore_comment_string(comment.value):
             return True
 
     return False

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -986,11 +986,11 @@ def is_type_comment_string(value: str, mode: Mode) -> bool:
 
 
 def is_type_ignore_comment(leaf: Leaf, mode: Mode) -> bool:
-    """Return True if the given leaf is a type comment with ignore annotation."""
+    """Return True if the given leaf has a type or Ruff ignore annotation."""
     t = leaf.type
     v = leaf.value
-    return t in {token.COMMENT, STANDALONE_COMMENT} and is_type_ignore_comment_string(
-        v, mode
+    return t in {token.COMMENT, STANDALONE_COMMENT} and (
+        is_type_ignore_comment_string(v, mode) or is_ruff_ignore_comment_string(v)
     )
 
 
@@ -1000,6 +1000,10 @@ def is_type_ignore_comment_string(value: str, mode: Mode) -> bool:
     return is_type_comment_string(value, mode) and value.split(":", 1)[
         1
     ].lstrip().startswith("ignore")
+
+
+def is_ruff_ignore_comment_string(value: str) -> bool:
+    return value.startswith("#") and value[1:].lstrip().startswith("ruff:ignore")
 
 
 def wrap_in_parentheses(

--- a/tests/data/cases/ruff_ignore_pragma.py
+++ b/tests/data/cases/ruff_ignore_pragma.py
@@ -1,0 +1,1 @@
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]

--- a/tests/test_trans.py
+++ b/tests/test_trans.py
@@ -1,4 +1,11 @@
+from black.comments import contains_pragma_comment
 from black.trans import iter_fexpr_spans
+from blib2to3.pgen2 import token
+from blib2to3.pytree import Leaf
+
+
+def test_contains_pragma_comment_for_ruff_ignore() -> None:
+    assert contains_pragma_comment([Leaf(token.COMMENT, "# ruff:ignore[bweh]")])
 
 
 def test_fexpr_spans() -> None:


### PR DESCRIPTION
## Summary

- recognize canonical `# ruff:ignore[...]` comments as Black pragmas
- preserve original physical lines for Ruff ignores, matching `type: ignore`
- add direct and end-to-end regressions for #5260

Fixes #5260, closes #5266

## Testing

- `pytest tests/test_trans.py tests/test_format.py -k ruff`
- `pre-commit run -a`
- `env -u NO_COLOR tox -e py` — 476 passed, 1 skipped; 73 Jupyter tests passed

## AI-assisted contribution

AI assistance was used for investigation, implementation, testing, and review. I reviewed the final diff and verified all reported commands locally.

## Checklist

- [x] The change includes regression coverage.
- [x] Add the PR-numbered entry to `CHANGES.md`.
