### PR TITLE
don't re-escape an already escaped quote in normalize_string_quotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix unparseable output for a triple-quoted string whose body ends in an already
+  escaped double quote (for example `'''\'''\"'''`). Switching to `"""` escaped the
+  backslash instead of the quote, leaving the closing quotes bare, so Black failed on
+  its own output (#5262)
 - Fix dropping the required trailing comma from a single-element tuple used as a lambda
   parameter default under `--skip-magic-trailing-comma` when a standalone comment forces
   the tuple across multiple lines; removing the comma turned the tuple into a bare

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -168,6 +168,21 @@ def _cached_compile(pattern: str) -> Pattern[str]:
     return re.compile(pattern)
 
 
+def _ends_with_unescaped_quote(body: str) -> bool:
+    """Does `body` end in a `"` that is not already backslash-escaped?
+
+    A backslash only escapes the quote when it is not itself escaped, so the run
+    of backslashes in front of the quote has to be of even length for the quote
+    to still need escaping.
+    """
+    if body[-1:] != '"':
+        return False
+
+    preceding = body[:-1]
+    backslashes = len(preceding) - len(preceding.rstrip("\\"))
+    return backslashes % 2 == 0
+
+
 def normalize_string_quotes(s: str) -> str:
     """Prefer double quotes but only if it doesn't cause more escaping.
 
@@ -227,7 +242,7 @@ def normalize_string_quotes(s: str) -> str:
                 # Do not introduce backslashes in interpolated expressions
                 return s
 
-    if new_quote == '"""' and new_body[-1:] == '"':
+    if new_quote == '"""' and _ends_with_unescaped_quote(new_body):
         # edge case:
         new_body = new_body[:-1] + '\\"'
     orig_escape_count = body.count("\\")
@@ -286,7 +301,7 @@ def normalize_fstring_quotes(
         new_segment = sub_twice(unescaped_new_quote, rf"\1\\{new_quote}", new_segment)
         new_segments.append(new_segment)
 
-    if new_quote == '"""' and new_segments[-1].endswith('"'):
+    if new_quote == '"""' and _ends_with_unescaped_quote(new_segments[-1]):
         # edge case:
         new_segments[-1] = new_segments[-1][:-1] + '\\"'
 

--- a/tests/data/cases/string_quotes_escaped_trailing_quote.py
+++ b/tests/data/cases/string_quotes_escaped_trailing_quote.py
@@ -1,0 +1,21 @@
+# Regression test for quote normalisation of triple-quoted strings whose body
+# already ends in an escaped double quote.
+x = '''\'''\"'''
+y = b'''\'''\"'''
+z = '''a\"'''
+# Here the backslashes escape each other, so the trailing quote is bare and
+# escaping it would add an escape - the original quotes are kept.
+w = '''\\"'''
+v = '''a"'''
+
+# output
+
+# Regression test for quote normalisation of triple-quoted strings whose body
+# already ends in an escaped double quote.
+x = """'''\""""
+y = b"""'''\""""
+z = """a\""""
+# Here the backslashes escape each other, so the trailing quote is bare and
+# escaping it would add an escape - the original quotes are kept.
+w = '''\\"'''
+v = '''a"'''


### PR DESCRIPTION
### Description

`normalize_string_quotes` escapes a trailing `"` in the body so that it is not glued to
the closing `"""`, but it never checks whether that quote is already escaped. For
`x = '''\'''\"'''` (valid Python, value `'''"`) the handler drops the quote and appends
`\"`, so the backslash that was escaping the quote ends up escaping a backslash and the
quote is left bare; the literal it emits, `"""'''\\""""`, terminates early and strands a
`"`. Black's forced second pass then re-parses its own output and fails with
`InvalidInput: Cannot parse: 1:4 ... TokenError: Failed to parse: UnterminatedString`. I
hit this while fuzzing single string tokens through the normaliser, and enumerating
short triple-quoted bodies turns up 42 distinct shapes that reach it; it reproduces on
26.1.0. Left alone, one such literal makes a whole file unformattable, `blackd` answers
400 for valid input, and the parse error printed points at a line nobody wrote.

The check belongs in the escaping helper rather than at the call sites, since every
caller hands it a raw literal and has no way to know whether the final quote already
carries a backslash. `_ends_with_unescaped_quote` counts the backslash run in front of
the quote and only escapes on an even count, which also leaves `'''\\"'''` alone: there
the backslashes escape each other, the quote really is bare, and escaping it would add
an escape. `normalize_fstring_quotes` repeats the same edge case so it shares the helper
now; that path is unreachable today because its call site is commented out, but the
defect is identical and leaving half of it fixed seemed worse. On behaviour: comparing
the old and the new function over 2.89M string literals from `tests/data`, Black's own
sources and the CPython stdlib gives byte-identical output, so nothing that formats
today moves. The single delta is that a body ending in an already escaped quote now
converts to `"""` instead of being corrupted or declined, because the spurious backslash
used to inflate `new_escape_count`. I read that as part of the same defect rather than a
style change, but say the word if you would rather see it preview-gated.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
