### PR TITLE
don't escape nested quotes inside t-string replacement fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix unparseable output for a t-string whose replacement field contains a quote (for
+  example `t'\'{a["b"]}\''`). The guards that keep quote normalisation away from the
+  inside of an f-string replacement field were never reached for t-strings, so the
+  nested quotes were escaped and Black failed on its own output (#5265)
 - Fix unparseable output for a triple-quoted string whose body ends in an already
   escaped double quote (for example `'''\'''\"'''`). Switching to `"""` escaped the
   backslash instead of the quote, leaving the closing quotes bare, so Black failed on

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -615,7 +615,7 @@ class LineGenerator(Visitor[Line]):
         if "\\" in string_leaf.value and any(
             "\\" in str(child)
             for child in node.children
-            if child.type == syms.fstring_replacement_field
+            if child.type == syms.tstring_replacement_field
         ):
             # string normalization doesn't account for nested quotes,
             # causing breakages. skip normalization when nested quotes exist

--- a/src/black/strings.py
+++ b/src/black/strings.py
@@ -227,7 +227,7 @@ def normalize_string_quotes(s: str) -> str:
         new_body = sub_twice(escaped_orig_quote, rf"\1\2{orig_quote}", new_body)
         new_body = sub_twice(unescaped_new_quote, rf"\1\\{new_quote}", new_body)
 
-    if "f" in prefix.casefold():
+    if "f" in prefix.casefold() or "t" in prefix.casefold():
         matches = re.findall(
             r"""
             (?:(?<!\{)|^)\{  # start of the string or a non-{ followed by a single {

--- a/tests/data/cases/pep_750_nested_quotes.py
+++ b/tests/data/cases/pep_750_nested_quotes.py
@@ -1,0 +1,34 @@
+# flags: --minimum-version=3.14
+# Regression test for t-strings whose replacement fields contain quotes.
+# Normalising the outer quotes would escape the inner ones and produce a
+# t-string that no longer parses, so these are left alone.
+x = t'\'{a["b"]}\''
+y = t'\'{"x"}\''
+# The same applies when the replacement field also carries a backslash.
+z = t'\'{a["\n"]}\''
+w = t'\'{"\n"}\''
+# A backslash in the replacement field stops normalisation on its own, so the
+# escaped quote in the literal part is kept as it is.
+v = t'{"\n"}\"'
+u = t'{a["\n"]}\"'
+# t-strings with nothing to escape are still normalised to double quotes.
+n = t'{a}'
+m = t'{a}\n'
+
+# output
+
+# Regression test for t-strings whose replacement fields contain quotes.
+# Normalising the outer quotes would escape the inner ones and produce a
+# t-string that no longer parses, so these are left alone.
+x = t'\'{a["b"]}\''
+y = t'\'{"x"}\''
+# The same applies when the replacement field also carries a backslash.
+z = t'\'{a["\n"]}\''
+w = t'\'{"\n"}\''
+# A backslash in the replacement field stops normalisation on its own, so the
+# escaped quote in the literal part is kept as it is.
+v = t'{"\n"}\"'
+u = t'{a["\n"]}\"'
+# t-strings with nothing to escape are still normalised to double quotes.
+n = t"{a}"
+m = t"{a}\n"


### PR DESCRIPTION
### Description

Black emits a t-string it cannot parse when a replacement field contains a quote. I came
at this from the f-string side, checking that t-strings had inherited the same
protections, and they had not: `visit_tstring` tests `child.type ==
syms.fstring_replacement_field`, but a `tstring` node's children are
`tstring_replacement_field` (symbol 356 against 299), so that bail-out has never fired
for a single t-string. `normalize_string_quotes` then gates its "do not introduce
backslashes in interpolated expressions" check on `"f" in prefix.casefold()`, which is
false for `t`, `rt` and `tr`. With both guards bypassed, `t'\'{a["b"]}\''` normalises to
`t"'{a[\"b\"]}'"` and the forced second pass falls over on its own output with
`InvalidInput: Cannot parse: 1:9 ... TokenError: Failed to parse:
UnexpectedCharacterAfterBackslash`. One such literal makes a whole file unformattable and
`blackd` answers 400 for valid input, so it seems worth closing before 3.14 t-strings
turn up in real code.

Both checks belong where they already sit rather than at the call site, since the caller
only has the finished literal and cannot tell a quote inside a replacement field from one
in the literal part. They are not redundant either: the `visit_tstring` symbol covers a
field that already carries a backslash, while the prefix check catches the backslashes
normalisation itself introduces, and reverting either one puts the committed case back
into failure (the first with a diff, the second with the parse error). On behaviour, I
compared 59k formatting results across a synthetic prefix/quote matrix and the repo's own
sources in stable and preview: 10 crashes fixed, nothing newly broken, and no literal
without a `t` prefix moves at all. What does move is t-strings carrying a backslash in a
replacement field, which are now left alone instead of being requoted; that is the
f-string behaviour they should have had from the start, and 20736 f/t pairs across raw
and non-raw prefixes now agree exactly. I read that as part of the same defect rather
than a style change, but say the word if you would rather see it split.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
