### PR TITLE
fix(comments): treat # ruff: comments as pragmas in contains_pragma_comment

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -904,10 +904,10 @@ def contains_pragma_comment(comment_list: list[Leaf]) -> bool:
     Returns:
         True iff one of the comments in @comment_list is a pragma used by one
         of the more common static analysis tools for python (e.g. mypy, flake8,
-        pylint).
+        pylint, ruff).
     """
     for comment in comment_list:
-        if comment.value.startswith(("# type:", "# noqa", "# pylint:")):
+        if comment.value.startswith(("# type:", "# noqa", "# pylint:", "# ruff:")):
             return True
 
     return False


### PR DESCRIPTION
## Description
This PR resolves issue #5260 by adding `# ruff:` to the pragma prefixes in `contains_pragma_comment()` in `src/black/comments.py`.
Closes #5261, fixes #5260

## Details
- Ensures `# ruff:ignore` and `# ruff:noqa` comments are treated as pragmas, preventing unnecessary line splits when comments follow long lines.