### PR TITLE
fix(pytree): initialize bracket_depth in Leaf __init__

### DIFF
--- a/src/blib2to3/pytree.py
+++ b/src/blib2to3/pytree.py
@@ -473,7 +473,7 @@ class Leaf(Base):
     # Default values for instance variables
     value: str
     fixers_applied: list[Any]
-    bracket_depth: int
+    bracket_depth: int = 0
     # Changed later in brackets.py
     opening_bracket: Optional["Leaf"] = None
     used_names: set[str] | None
@@ -494,6 +494,7 @@ class Leaf(Base):
         fixers_applied: list[Any] = [],
         opening_bracket: Optional["Leaf"] = None,
         fmt_pass_converted_first_leaf: Optional["Leaf"] = None,
+        bracket_depth: int = 0,
     ) -> None:
         """
         Initializer.
@@ -513,6 +514,7 @@ class Leaf(Base):
         self.children = []
         self.opening_bracket = opening_bracket
         self.fmt_pass_converted_first_leaf = fmt_pass_converted_first_leaf
+        self.bracket_depth = bracket_depth
 
     def __repr__(self) -> str:
         """Return a canonical string representation."""


### PR DESCRIPTION
## Description
Fixes #5214, closes #5221, closes #5215
This PR resolves issue #5214 by initializing `bracket_depth: int = 0` in `Leaf.__init__()` and as a class attribute in `src/blib2to3/pytree.py`.

## Details
- Prevents `AttributeError: 'Leaf' object has no attribute 'bracket_depth'` when processing newly constructed `Leaf` instances during line formatting.