### PR TITLE
feat(cache): support custom_cache_dir parameter in get_cache_dir and get_cache_file

### DIFF
--- a/src/black/cache.py
+++ b/src/black/cache.py
@@ -28,19 +28,18 @@ class FileData(NamedTuple):
     hash: str
 
 
-def get_cache_dir() -> Path:
+def get_cache_dir(custom_cache_dir: Path | str | None = None) -> Path:
     """Get the cache directory used by black.
 
     Users can customize this directory on all systems using `BLACK_CACHE_DIR`
-    environment variable. By default, the cache directory is the user cache directory
-    under the black application.
-
-    This result is immediately set to a constant `black.cache.CACHE_DIR` as to avoid
-    repeated calls.
+    environment variable or passing a custom directory. By default, the cache directory
+    is the user cache directory under the black application.
     """
-    # NOTE: Function mostly exists as a clean way to test getting the cache directory.
-    default_cache_dir = user_cache_dir("black")
-    cache_dir = Path(os.environ.get("BLACK_CACHE_DIR", default_cache_dir))
+    if custom_cache_dir is not None:
+        cache_dir = Path(custom_cache_dir)
+    else:
+        default_cache_dir = user_cache_dir("black")
+        cache_dir = Path(os.environ.get("BLACK_CACHE_DIR", default_cache_dir))
     cache_dir = cache_dir / __version__
     return cache_dir
 
@@ -48,8 +47,9 @@ def get_cache_dir() -> Path:
 CACHE_DIR = get_cache_dir()
 
 
-def get_cache_file(mode: Mode) -> Path:
-    return CACHE_DIR / f"cache.{mode.get_cache_key()}.pickle"
+def get_cache_file(mode: Mode, custom_cache_dir: Path | str | None = None) -> Path:
+    cache_dir = get_cache_dir(custom_cache_dir) if custom_cache_dir is not None else CACHE_DIR
+    return cache_dir / f"cache.{mode.get_cache_key()}.pickle"
 
 
 @dataclass


### PR DESCRIPTION
## Description
This PR resolves issue #5174 by adding a `custom_cache_dir` parameter to `get_cache_dir()` and `get_cache_file()` in `src/black/cache.py`. Fixes #5175, closes #5201

## Details
- Allows programmatic callers and tools to specify custom cache directory locations directly.