### PR TITLE
Fix target version inference for strict-greater requires-python specifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@
   (#5244)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`
   statement after another standalone comment (#5189)
+- Fix target version inference from ``requires-python`` for strict-greater specifiers
+  such as ``>3.7``: per PEP 440 this is equivalent to ``>3.7.0`` and must include
+  ``py37`` (e.g. ``>3.7,<3.10`` now yields py37, py38 and py39 instead of only py38
+  and py39) (#3581)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
 - Fix multiline docstring indentation when leading tabs are used inside indented

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
   statement after another standalone comment (#5189)
 - Fix target version inference from `requires-python` for strict-greater specifiers such
   as `>3.7`: per PEP 440 this is equivalent to `>3.7.0` and must include `py37` (e.g.
-  `>3.7,<3.10` now yields py37, py38 and py39 instead of only py38 and py39) (#3581)
+  `>3.7,<3.10` now yields py37, py38 and py39 instead of only py38 and py39) (#5269)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
 - Fix multiline docstring indentation when leading tabs are used inside indented

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,10 +38,9 @@
   (#5244)
 - Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`
   statement after another standalone comment (#5189)
-- Fix target version inference from ``requires-python`` for strict-greater specifiers
-  such as ``>3.7``: per PEP 440 this is equivalent to ``>3.7.0`` and must include
-  ``py37`` (e.g. ``>3.7,<3.10`` now yields py37, py38 and py39 instead of only py38
-  and py39) (#3581)
+- Fix target version inference from `requires-python` for strict-greater specifiers such
+  as `>3.7`: per PEP 440 this is equivalent to `>3.7.0` and must include `py37` (e.g.
+  `>3.7,<3.10` now yields py37, py38 and py39 instead of only py38 and py39) (#3581)
 - Fix a crash when splitting `case case if ...` match patterns at very small line
   lengths (#5147)
 - Fix multiline docstring indentation when leading tabs are used inside indented

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -217,7 +217,10 @@ def strip_specifier_set(specifier_set: SpecifierSet) -> SpecifierSet:
             specifiers.append(stripped)
         elif s.operator == ">":
             version = Version(s.version)
-            if len(version.release) > 2:
+            # Per PEP 440, `>3.7` is equivalent to `>3.7.0`, so it should include
+            # any `3.7.x` (e.g. `3.7.0`). A stripped `major.minor` form therefore
+            # needs the inclusive `>=` operator whenever a minor version is present.
+            if len(version.release) >= 2:
                 s = Specifier(f">={version.major}.{version.minor}")
             specifiers.append(s)
         else:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1607,10 +1607,15 @@ class BlackTestCase(BlackBaseTestCase):
                 ],
             ),
             ("<3.6", [TargetVersion.PY33, TargetVersion.PY34, TargetVersion.PY35]),
-            (">3.7,<3.10", [TargetVersion.PY38, TargetVersion.PY39]),
+            # Per PEP 440, `>3.7` is equivalent to `>3.7.0`, so `py37` is included.
+            (
+                ">3.7,<3.10",
+                [TargetVersion.PY37, TargetVersion.PY38, TargetVersion.PY39],
+            ),
             (
                 ">3.7,!=3.8,!=3.9",
                 [
+                    TargetVersion.PY37,
                     TargetVersion.PY310,
                     TargetVersion.PY311,
                     TargetVersion.PY312,
@@ -1675,11 +1680,33 @@ class BlackTestCase(BlackBaseTestCase):
             ("3.2", None),
             ("2.7.18", None),
             ("==2.7", None),
-            (">3.10,<3.11", None),
+            (">3.10,<3.11", [TargetVersion.PY310]),
         ]:
             test_toml = {"project": {"requires-python": version}}
             result = black.files.infer_target_version(test_toml)
             self.assertEqual(result, expected)
+
+    def test_infer_target_version_pep440_greater_than(self) -> None:
+        # Regression test for https://github.com/psf/black/issues/3581
+        # Per PEP 440, ``>3.7`` is equivalent to ``>3.7.0``, so any ``3.7.x``
+        # (e.g. ``3.7.0``) is included. ``>3.7,<3.10`` must therefore yield
+        # py37, py38 and py39 -- not just py38 and py39.
+        self.assertEqual(
+            black.files.infer_target_version(
+                {"project": {"requires-python": ">3.7,<3.10"}}
+            ),
+            [TargetVersion.PY37, TargetVersion.PY38, TargetVersion.PY39],
+        )
+        # ``>3.7`` (without a patch component) must behave like ``>=3.7`` and
+        # keep py37, matching the equivalent ``>3.7.0`` / ``>=3.7`` forms.
+        self.assertEqual(
+            black.files.infer_target_version(
+                {"project": {"requires-python": ">3.7"}}
+            ),
+            black.files.infer_target_version(
+                {"project": {"requires-python": ">=3.7"}}
+            ),
+        )
 
     def test_read_pyproject_toml(self) -> None:
         test_toml_file = THIS_DIR / "test.toml"

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1700,12 +1700,8 @@ class BlackTestCase(BlackBaseTestCase):
         # ``>3.7`` (without a patch component) must behave like ``>=3.7`` and
         # keep py37, matching the equivalent ``>3.7.0`` / ``>=3.7`` forms.
         self.assertEqual(
-            black.files.infer_target_version(
-                {"project": {"requires-python": ">3.7"}}
-            ),
-            black.files.infer_target_version(
-                {"project": {"requires-python": ">=3.7"}}
-            ),
+            black.files.infer_target_version({"project": {"requires-python": ">3.7"}}),
+            black.files.infer_target_version({"project": {"requires-python": ">=3.7"}}),
         )
 
     def test_read_pyproject_toml(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #3581 — Black's target-version inference from `requires-python` dropped valid Python versions for strict-greater specifiers.

Per PEP 440, `>3.7` is equivalent to `>3.7.0`, so any `3.7.x` (e.g. `3.7.0`) is included. `strip_specifier_set` only widened a `>` operator to the inclusive `>=` when a *patch* component was present (`len(release) > 2`), so `>3.7` was left strict and `py37` was dropped from the inferred target versions.

Now `>` becomes `>=` whenever a minor version is present, making `>3.7` behave like `>3.7.0` / `>=3.7`.

### Before / after

| requires-python | Before | After |
| --- | --- | --- |
| `>3.7,<3.10` | `py38, py39` | `py37, py38, py39` |
| `>3.7,!=3.8,!=3.9` | `py310..py315` | `py37, py310..py315` |
| `>3.10,<3.11` | `None` | `py310` |
| `>=3.7` / `>3.7.0` | unchanged | unchanged |

These all now match the equivalent `>=3.7` / `>3.7.0` forms, as PEP 440 requires.

## Test plan

- Updated `test_infer_target_version` expectations to the PEP 440-compliant results.
- Added `test_infer_target_version_pep440_greater_than` regression test (covers #3581).
- `pytest tests/test_black.py -k infer_target_version` passes.

## Checklist

- [x] Changes are covered by tests
- [x] CHANGES.md updated