### PR TITLE
Don't hug brackets when it would merge two `type: ignore` comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,9 @@
   as a comprehension's iterable down to a single pair (e.g. `[x for x in ((lambda: 0))]`
   becomes `[x for x in (lambda: 0)]`). Previously the inner pair was stripped too,
   leaving the bare expression and crashing Black (#5200)
+- Don't hug brackets when doing so would join two `type: ignore` comments onto one line.
+  The AST records `type: ignore` per line, so merging them dropped a `TypeIgnore` entry
+  and Black failed its own equivalence check (#5271)
 
 ### Configuration
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -4,7 +4,7 @@ Generating lines of code.
 
 import re
 import sys
-from collections.abc import Collection, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from dataclasses import replace
 from enum import Enum, auto
 from functools import partial, wraps
@@ -67,6 +67,7 @@ from black.nodes import (
     is_tuple,
     is_tuple_containing_star,
     is_tuple_containing_walrus,
+    is_type_ignore_comment,
     is_type_ignore_comment_string,
     is_vararg,
     is_walrus_assignment,
@@ -1061,6 +1062,17 @@ def _first_right_hand_split(
                     should_hug = False
                 else:
                     should_hug = True
+            if should_hug and (
+                _hugging_merges_type_ignores(line, head_leaves, hugged_opening_leaves)
+                or _hugging_merges_type_ignores(
+                    line, hugged_closing_leaves, tail_leaves
+                )
+            ):
+                # Hugging joins these leaves onto one physical line, and their
+                # trailing comments come along. `type: ignore` is recorded per
+                # line by the AST, so two of them landing on the same line would
+                # drop one and make the output non-equivalent.
+                should_hug = False
             if should_hug:
                 body_leaves = inner_body_leaves
                 head_leaves.extend(hugged_opening_leaves)
@@ -1289,6 +1301,19 @@ def _ensure_trailing_comma(
     ):
         return False
     return True
+
+
+def _hugging_merges_type_ignores(line: Line, *leaf_groups: Iterable[Leaf]) -> bool:
+    """Return True if hugging these groups would put two `type: ignore`s on a line."""
+    seen = 0
+    for leaves in leaf_groups:
+        for leaf in leaves:
+            for comment in line.comments_after(leaf):
+                if is_type_ignore_comment(comment, mode=line.mode):
+                    seen += 1
+                    if seen > 1:
+                        return True
+    return False
 
 
 def bracket_split_build_line(

--- a/tests/data/cases/preview_hug_parens_with_type_ignore.py
+++ b/tests/data/cases/preview_hug_parens_with_type_ignore.py
@@ -1,0 +1,58 @@
+# flags: --unstable
+# A `type: ignore` is recorded per line by the AST, so hugging must not join two
+# of them onto one line.
+foo(  # type:ignore
+    [  # type:ignore
+        a
+    ]
+)
+
+items = [  # type: ignore
+    (  # type: ignore
+        {"key1": "val1", "key2": "val2", "key3": "val3"}
+        if some_var == "longstring"
+        else {"key": "val"}
+    )
+]
+
+# One of them is fine, and so are comments that carry no meaning for the AST.
+items = [  # type: ignore
+    (
+        {"key1": "val1", "key2": "val2", "key3": "val3"}
+        if some_var == "longstring"
+        else {"key": "val"}
+    )
+]
+
+func(  # a
+    [  # b
+        "c",
+    ]
+)
+
+# output
+
+# A `type: ignore` is recorded per line by the AST, so hugging must not join two
+# of them onto one line.
+foo(  # type: ignore
+    [a]  # type: ignore
+)
+
+items = [  # type: ignore
+    (  # type: ignore
+        {"key1": "val1", "key2": "val2", "key3": "val3"}
+        if some_var == "longstring"
+        else {"key": "val"}
+    )
+]
+
+# One of them is fine, and so are comments that carry no meaning for the AST.
+items = [  # type: ignore
+    {"key1": "val1", "key2": "val2", "key3": "val3"}
+    if some_var == "longstring"
+    else {"key": "val"}
+]
+
+func([  # a  # b
+    "c",
+])


### PR DESCRIPTION
### Description

Fixes #4036, the crash `hug_parens_with_braces_and_square_brackets` is parked in `UNSTABLE_FEATURES` for.

```py
items = [  # type: ignore
    (  # type: ignore
        {"key1": "val1", "key2": "val2", "key3": "val3"}
        if some_var == "longstring"
        else {"key": "val"}
    )
]
```

```console
$ black --enable-unstable-feature=hug_parens_with_braces_and_square_brackets file.py
INTERNAL ERROR: Black produced code that is not equivalent to the source.
```

Hugging pulls the inner opening bracket up onto the outer one, and the comments attached to both brackets come along:

```py
items = [(  # type: ignore  # type: ignore
```

Merging comments like that is the intended hug style — `preview_hug_parens_with_braces_and_square_brackets.py` already expects `func([  # a  # b`. But `type: ignore` is not an ordinary comment: CPython records one `TypeIgnore` per line in `Module.type_ignores`, so two of them on one line collapse into one and the AST safety check fails.

So the fix is narrow: keep hugging, but not when it would put a second `type: ignore` on a line. Black already treats these comments as load-bearing elsewhere — `contains_unsplittable_type_ignore` guards the rhs-oop choice a few hundred lines down — so the new guard fits the existing pattern.

Both examples in #4036 now format cleanly (the reporter's original one and the one @cobaltt7 added last October, which is the one that still reproduced).

### Verification

- New case file, `preview_hug_parens_with_type_ignore.py`: fails on `main` (unequal output for the first two cases), passes with this change.
- `pytest`: 475 passed, 3 skipped — the baseline 474 plus the new case. `black --check .`, `flake8`, `isort` and `mypy` clean.
- Formatted 376 files from scrapy, pydantic and Pillow with `--unstable` before and after, comparing output hashes: **zero differences**, and no errors either way. The guard only fires on the pathological shape.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? — the feature is unstable-only, and the stable style is untouched
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation? — no documented behaviour changes
