### PR TITLE
Keep the required trailing comma of a one-element subscript under --skip-magic-trailing-comma

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@
   expression and failed Black's AST safety check (#5246)
 - Fix unstable formatting when an inline comment sits on optional parentheses (for
   example a parenthesized assert message or assignment RHS) (#5241)
+- Fix `--skip-magic-trailing-comma` dropping the syntactically required trailing comma
+  of a one-element subscript (`a[x,]`) when the line is long enough to be split and
+  contains a power operator. `hug_power_op` rebuilt the line from cloned leaves, whose
+  missing parent kept the guards for required commas from firing, so the index stopped
+  being a one-tuple and Black failed its own AST safety check (#5272)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
 - Respect the magic trailing comma in a PEP 695 type parameter list containing a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,11 +31,9 @@
   expression and failed Black's AST safety check (#5246)
 - Fix unstable formatting when an inline comment sits on optional parentheses (for
   example a parenthesized assert message or assignment RHS) (#5241)
-- Fix `--skip-magic-trailing-comma` dropping the syntactically required trailing comma
-  of a one-element subscript (`a[x,]`) when the line is long enough to be split and
-  contains a power operator. `hug_power_op` rebuilt the line from cloned leaves, whose
-  missing parent kept the guards for required commas from firing, so the index stopped
-  being a one-tuple and Black failed its own AST safety check (#5272)
+- Fix `--skip-magic-trailing-comma` dropping the trailing comma of a one-element
+  subscript (`a[x,]`) when the line is long enough to be split and contains a power
+  operator (#5272)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
 - Respect the magic trailing comma in a PEP 695 type parameter list containing a

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -109,11 +109,7 @@ def hug_power_op(
     new_line = line.clone()
     should_hug = False
     for idx, leaf in enumerate(line.leaves):
-        new_leaf = leaf.clone()
-        if should_hug:
-            new_leaf.prefix = ""
-            should_hug = False
-
+        hug_this_leaf = should_hug
         should_hug = (
             (0 < idx < len(line.leaves) - 1)
             and leaf.type == token.DOUBLESTAR
@@ -121,8 +117,18 @@ def hug_power_op(
             and line.leaves[idx - 1].value != "lambda"
             and is_simple_operand(idx + 1, kind=1)
         )
-        if should_hug:
+
+        if hug_this_leaf or should_hug:
+            new_leaf = leaf.clone()
             new_leaf.prefix = ""
+        else:
+            # Only the operands around a hugged `**` need a copy. Reuse the leaf
+            # otherwise: a clone has no parent, and the trailing-comma guards in
+            # `Line.append` read the tree to tell a syntactically required comma
+            # (a one-tuple, or a one-element subscript like `a[x,]`) from a magic
+            # one. Without a parent they can't, so the comma was being dropped
+            # under --skip-magic-trailing-comma.
+            new_leaf = leaf
 
         # We have to be careful to make a new line properly:
         # - bracket related metadata must be maintained (handled by Line.append)

--- a/tests/data/cases/skip_magic_trailing_comma.py
+++ b/tests/data/cases/skip_magic_trailing_comma.py
@@ -58,6 +58,11 @@ func(
     argument6,
 )
 
+# Also keep it when the line is long enough to be split and a power operator
+# sends it through hug_power_op, which used to rebuild the line from leaves that
+# had lost their place in the tree.
+value = alpha[beta,]() ** gamma * delta << epsilon | zeta < eta ^ theta * iota + kappa + mu
+
 # output
 # We should not remove the trailing comma in a single-element subscript.
 a: tuple[int,]
@@ -97,3 +102,10 @@ func1(arg1).func2(arg2).func3(arg3).func4(arg4).func5(arg5)
 a, b, c, d = func1(arg1) and func2(arg2)
 
 func(argument1, (one, two), argument4, argument5, argument6)
+
+# Also keep it when the line is long enough to be split and a power operator
+# sends it through hug_power_op, which used to rebuild the line from leaves that
+# had lost their place in the tree.
+value = (
+    alpha[beta,]() ** gamma * delta << epsilon | zeta < eta ^ theta * iota + kappa + mu
+)


### PR DESCRIPTION
### Description

`--skip-magic-trailing-comma` drops the trailing comma from a one-element subscript when the line is long enough to be split and contains a power operator, which turns `a[x,]` (indexing with a one-tuple) into `a[x]` and trips Black's own AST safety check:

```py
value = alpha[beta,]() ** gamma * delta << epsilon | zeta < eta ^ theta * iota + kappa + mu
```

```console
$ black --skip-magic-trailing-comma file.py
error: cannot format file.py: INTERNAL ERROR: Black produced code that is not equivalent to the source.
```

The comma survives on a short line — `tests/data/cases/skip_magic_trailing_comma.py` opens by asserting exactly that — so this is the same rule failing on a longer one. Under `--fast` there is no safety net and the changed code is written out.

`hug_power_op` is the path. It rebuilds the line with `leaf.clone()` for every leaf, and a clone has no parent, so both tree-based guards that protect a required comma stop working: `has_magic_trailing_comma`'s single-element-subscript branch needs `closing.parent.type == syms.trailer`, and the one-tuple guard in `Line.append` needs `leaf.parent`. Neither can fire, the comma looks magic, and `remove_trailing_comma()` takes it.

Only the operands either side of a hugged `**` actually need their prefix rewritten, so this stops cloning the rest and reuses the leaf, keeping it attached to the tree. Reusing leaves across lines is what `bracket_split_build_line` already does, and with `preformatted=True` `Line.append` does not touch the prefix — it only re-runs `BracketTracker.mark`, which recomputes the same metadata for an identical leaf sequence.

The one-tuple guard the same clone breaks (`foo(lambda x=(1,): x)`, already in that case file) is fixed by this too; I could not build a failing example for it because the lambda cases are short enough not to reach `hug_power_op`.

Found with a randomised run of `scripts/fuzz.py`'s property — the committed harness pins `derandomize=True, max_examples=1000`, so it re-explores the same thousand inputs on every CI run and never reaches this one.

### Verification

- Case added to `tests/data/cases/skip_magic_trailing_comma.py`. It fails on `main` (`alpha[beta]()` in the output) and passes with the change.
- `pytest`: 474 passed, 3 skipped, unchanged from `main`. `black --check .`, `flake8`, `isort`, `mypy` clean.
- Formatted 716 files from scrapy, pydantic, Pillow and fontTools with `--skip-magic-trailing-comma` before and after, comparing output hashes: **zero differences**, no errors either way. Power-operator hugging is unaffected (`x = a ** b` still becomes `x = a**b`).

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? — no style change; this restores the documented behaviour for a case that was crashing
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation? — no documented behaviour changes
