### PR TITLE
Improve formatting performance for subscript chains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,6 +103,7 @@
 
 <!-- Changes that improve Black's performance. -->
 
+- Improve formatting performance for long chains of simple subscript trailers (#5275)
 - Improve performance on strings containing many consecutive backslashes (#5163)
 - Improve performance when merging implicitly concatenated f-strings whose expressions
   contain long string literals (#5165)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -988,31 +988,48 @@ def _first_right_hand_split(
     _maybe_split_omitting_optional_parens to get an opinion whether to prefer
     splitting on the right side of an assignment statement.
     """
-    tail_leaves: list[Leaf] = []
-    body_leaves: list[Leaf] = []
-    head_leaves: list[Leaf] = []
-    current_leaves = tail_leaves
     opening_bracket: Leaf | None = None
     closing_bracket: Leaf | None = None
-    for leaf in reversed(line.leaves):
-        if current_leaves is body_leaves:
-            if leaf is opening_bracket:
-                current_leaves = head_leaves if body_leaves else tail_leaves
-        current_leaves.append(leaf)
-        if current_leaves is tail_leaves:
-            if leaf.type in CLOSING_BRACKETS and id(leaf) not in omit:
-                opening_bracket = leaf.opening_bracket
-                closing_bracket = leaf
-                current_leaves = body_leaves
+    if line._simple_subscript_widths is not None:
+        closing_index = next(
+            (
+                index
+                for index in range(len(line.leaves) - 1, 1, -1)
+                if line.leaves[index].type == token.RSQB
+                and id(line.leaves[index]) not in omit
+            ),
+            None,
+        )
+        if closing_index is not None:
+            opening_index = closing_index - 2
+            opening_bracket = line.leaves[opening_index]
+            closing_bracket = line.leaves[closing_index]
+            head_leaves = line.leaves[: opening_index + 1]
+            body_leaves = line.leaves[opening_index + 1 : closing_index]
+            tail_leaves = line.leaves[closing_index:]
+    if opening_bracket is None or closing_bracket is None:
+        tail_leaves = []
+        body_leaves = []
+        head_leaves = []
+        current_leaves = tail_leaves
+        for leaf in reversed(line.leaves):
+            if current_leaves is body_leaves:
+                if leaf is opening_bracket:
+                    current_leaves = head_leaves if body_leaves else tail_leaves
+            current_leaves.append(leaf)
+            if current_leaves is tail_leaves:
+                if leaf.type in CLOSING_BRACKETS and id(leaf) not in omit:
+                    opening_bracket = leaf.opening_bracket
+                    closing_bracket = leaf
+                    current_leaves = body_leaves
+        tail_leaves.reverse()
+        body_leaves.reverse()
+        head_leaves.reverse()
     if not (opening_bracket and closing_bracket and head_leaves):
         # If there is no opening or closing_bracket that means the split failed and
         # all content is in the tail.  Otherwise, if `head_leaves` are empty, it means
         # the matching `opening_bracket` wasn't available on `line` anymore.
         raise CannotSplit("No brackets found")
-
-    tail_leaves.reverse()
-    body_leaves.reverse()
-    head_leaves.reverse()
 
     body: Line | None = None
     if (
@@ -1323,6 +1340,37 @@ def bracket_split_build_line(
 
     leaves_to_track: set[LeafID] = set()
     if component is _BracketSplitComponent.head:
+        if original._simple_subscript_widths is not None:
+            previous = next(
+                (leaf for leaf in reversed(leaves) if leaf.type == token.RSQB),
+                None,
+            )
+            if previous is not None:
+                result.leaves.extend(leaves)
+                result._simple_subscript_widths = original._simple_subscript_widths
+                result.bracket_tracker.previous = previous
+                return result
+        tracked_leaves = _simple_subscript_chain_leaves(leaves, original)
+        if tracked_leaves is not None:
+            result.leaves.extend(leaves)
+            for index in range(0, len(tracked_leaves), 3):
+                opening_bracket = tracked_leaves[index]
+                body_leaf = tracked_leaves[index + 1]
+                closing_bracket = tracked_leaves[index + 2]
+                opening_bracket.bracket_depth = 0
+                body_leaf.bracket_depth = 1
+                closing_bracket.bracket_depth = 0
+            result.bracket_tracker.previous = tracked_leaves[-1]
+            widths: list[int] = []
+            width = 4 * result.depth
+            for leaf in leaves:
+                if not leaf.prefix.isascii() or not leaf.value.isascii():
+                    break
+                width += len(leaf.prefix) + len(leaf.value)
+                widths.append(width)
+            else:
+                result._simple_subscript_widths = widths
+            return result
         leaves_to_track = get_leaves_inside_matching_brackets(leaves)
     # Populate the line
     for leaf in leaves:
@@ -1338,6 +1386,45 @@ def bracket_split_build_line(
     ):
         result.should_split_rhs = True
     return result
+
+
+def _simple_subscript_chain_leaves(
+    leaves: list[Leaf], original: Line
+) -> list[Leaf] | None:
+    """Return complete single-token subscript trailers, or None for other brackets."""
+    if original.comments:
+        return None
+
+    tracked_leaves: list[Leaf] = []
+    invisible_opening_seen = False
+    index = 0
+    while index < len(leaves):
+        leaf = leaves[index]
+        if (
+            leaf.type == token.LSQB
+            and index + 2 < len(leaves)
+            and leaves[index + 1].type in {token.NAME, token.NUMBER, token.STRING}
+            and leaves[index + 2].type == token.RSQB
+            and leaves[index + 2].opening_bracket is leaf
+            and leaf.parent is not None
+            and leaf.parent.type == syms.trailer
+        ):
+            tracked_leaves.extend(leaves[index : index + 3])
+            index += 3
+            continue
+        if leaf.type in BRACKETS:
+            if (
+                not leaf.value
+                and leaf.type == token.LPAR
+                and not invisible_opening_seen
+            ):
+                invisible_opening_seen = True
+            # The final opening bracket belongs to the split being built, not to a
+            # complete trailer that needs tracking.
+            elif index != len(leaves) - 1 or leaf.type != token.LSQB:
+                return None
+        index += 1
+    return tracked_leaves or None
 
 
 def dont_increase_indentation(split_func: Transformer) -> Transformer:
@@ -2155,7 +2242,7 @@ def _over_length_only_due_to_subscript_comment(line: Line, mode: Mode) -> bool:
     the annotation in extra parens and migrates the comment outside the
     subscript, which then oscillates on the next formatter pass.
     """
-    if not line.leaves:
+    if not line.leaves or not line.comments:
         return False
     # The over-length must be caused entirely by a trailing comment.
     indent = "    " * line.depth

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -55,6 +55,7 @@ class Line:
     _complex_subscript_cache: dict[LeafID, bool] = field(
         default_factory=dict, repr=False
     )
+    _simple_subscript_widths: list[int] | None = field(default=None, repr=False)
 
     def append(
         self, leaf: Leaf, preformatted: bool = False, track_bracket: bool = False
@@ -1358,6 +1359,8 @@ def is_line_short_enough(line: Line, *, mode: Mode, line_str: str = "") -> bool:
     if it should be inlined or split up.
     Uses the provided `line_str` rendering, if any, otherwise computes a new one.
     """
+    if not line_str and line._simple_subscript_widths is not None:
+        return line._simple_subscript_widths[len(line.leaves) - 1] <= mode.line_length
     if not line_str:
         line_str = line_to_string(line)
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2239,6 +2239,25 @@ class BlackTestCase(BlackBaseTestCase):
                 "Failed to properly detect encoding on second line",
             )
 
+    def test_long_subscript_chain_avoids_retracking_prefixes(self) -> None:
+        from black.brackets import BracketTracker
+
+        source = "x = a" + "".join(f"[{index}]" for index in range(160)) + "\n"
+        mark_calls = 0
+        original_mark = BracketTracker.mark
+
+        def counting_mark(self: BracketTracker, leaf: Any) -> None:
+            nonlocal mark_calls
+            mark_calls += 1
+            original_mark(self, leaf)
+
+        with patch.object(BracketTracker, "mark", counting_mark):
+            formatted = black.format_str(source, mode=Mode())
+
+        assert len(formatted.splitlines()) == 233
+        assert mark_calls < 100_000
+        assert black.format_str(formatted, mode=Mode()) == formatted
+
 
 class TestCaching:
     def test_get_cache_dir(


### PR DESCRIPTION
### Description

Fixes #5270.

Long chains of single-token subscript trailers repeatedly rebuild the same prefix `Line` and `BracketTracker` state during recursive right-hand splitting. This patch detects that narrowly defined no-comment shape, reuses the already validated leaf metadata, caches cumulative ASCII widths for prefix heads, and falls back to the existing path for complex subscripts, comments, non-ASCII text, or other bracket shapes.

The formatting result is unchanged. In local CPython 3.12 benchmarks for `x = a[0][1]...` at the default line length:

| Subscripts | Before | After |
| --- | ---: | ---: |
| 80 | 1.48 s | 0.25 s |
| 160 | 11.08 s | 0.80 s |
| 320 | 45.43 s | 1.80 s |

Output SHA-256 matched the base branch at every benchmark size. A 135-case matrix covering numeric, name, and string subscripts across multiple line lengths and contexts also matched byte-for-byte.

Validation:
- `pytest tests/test_format.py -q` (230 passed)
- `pytest tests/test_black.py -q -k "not symlink"` (160 passed, 6 deselected, 8 subtests passed)
- pre-commit on changed files: isort, flake8, mypy, EOF, trailing whitespace passed
- `git diff --check`
- New regression test bounds repeated `BracketTracker.mark()` calls and verifies idempotence

The three excluded `test_black.py` cases require Windows symlink privileges and fail locally with `WinError 1314`; they are unrelated to this change.

AI assistance was used during implementation. I independently reproduced the issue, profiled the split path, reviewed the final diff, compared outputs against an untouched base worktree, and ran the validation above.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (No style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (No documentation change is needed.)
