### PR TITLE
Preserve ruff ignore pragmas when splitting lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Preserve line-scoped `ruff:ignore` pragmas instead of moving them into nested
+  expressions when splitting long lines (#5276)
 - Fix unparseable output for a t-string whose replacement field contains a quote (for
   example `t'\'{a["b"]}\''`). The guards that keep quote normalisation away from the
   inside of an f-string replacement field were never reached for t-strings, so the

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -907,7 +907,7 @@ def contains_pragma_comment(comment_list: list[Leaf]) -> bool:
         pylint).
     """
     for comment in comment_list:
-        if comment.value.startswith(("# type:", "# noqa", "# pylint:")):
+        if comment.value.startswith(("# type:", "# noqa", "# pylint:", "# ruff:")):
             return True
 
     return False

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -19,6 +19,7 @@ from black.nodes import (
     is_multiline_string,
     is_one_sequence_between,
     is_one_tuple,
+    is_ruff_ignore_comment,
     is_type_comment,
     is_type_ignore_comment,
     is_with_or_async_with_stmt,
@@ -340,7 +341,11 @@ class Line:
             # line.
             for node in self.leaves[-2:]:
                 for comment in self.comments.get(id(node), []):
-                    if is_type_ignore_comment(comment, mode=self.mode):
+                    # Ruff ignore annotations are line-scoped just like
+                    # type-ignore comments, so moving either can change meaning.
+                    if is_type_ignore_comment(
+                        comment, mode=self.mode
+                    ) or is_ruff_ignore_comment(comment):
                         return True
 
         return False

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -1002,6 +1002,21 @@ def is_type_ignore_comment_string(value: str, mode: Mode) -> bool:
     ].lstrip().startswith("ignore")
 
 
+def is_ruff_ignore_comment(leaf: Leaf) -> bool:
+    """Return True if the given leaf is a line-scoped Ruff ignore comment."""
+    if leaf.type not in {token.COMMENT, STANDALONE_COMMENT}:
+        return False
+
+    value = leaf.value
+    if not value.startswith("#"):
+        return False
+
+    directive = value[1:].lstrip()
+    return directive.startswith("ruff:") and directive.split(":", 1)[
+        1
+    ].lstrip().startswith("ignore")
+
+
 def wrap_in_parentheses(
     parent: Node, child: LN, *, visible: bool = True, index: int | None = None
 ) -> None:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -83,6 +83,15 @@ def test_empty() -> None:
     assert_format(source, expected)
 
 
+@pytest.mark.parametrize("pragma", ["# ruff:ignore[bweh]", "# ruff: ignore[bweh]"])
+def test_ruff_ignore_pragma_prevents_splitting(pragma: str) -> None:
+    source = (
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        f" = 5  {pragma}\n"
+    )
+    assert_format(source, source)
+
+
 def test_patma_invalid() -> None:
     source, expected = read_data("miscellaneous", "pattern_matching_invalid")
     mode = black.Mode(target_versions={black.TargetVersion.PY310})


### PR DESCRIPTION
### Description

Fixes #5260.

Ruff's line-scoped `ruff:ignore` pragmas could be moved onto a nested expression when Black split an overlong line, changing which diagnostic the pragma suppresses. This change recognizes Ruff directives as pragmas and treats `ruff:ignore` comments like `type: ignore` comments when deciding whether a physical line can be split.

Both `# ruff:ignore[...]` and `# ruff: ignore[...]` forms are covered by regression tests.

Validation:

- `pytest tests/test_format.py -q` (232 passed)
- pre-commit on changed files: isort, flake8, mypy, EOF, trailing whitespace passed
- `git diff --check`

AI assistance was used during implementation. I independently reproduced the formatting change, reviewed the final diff, and ran the validation above.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (No style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (No documentation change is needed.)