### PR TITLE
remove unused RARROW constant

### DIFF
--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -141,8 +141,6 @@ ALWAYS_NO_SPACE: Final = CLOSING_BRACKETS | {
     token.BANG,
 }
 
-RARROW = 55
-
 
 @mypyc_attr(allow_interpreted_subclasses=True)
 class Visitor(Generic[T]):


### PR DESCRIPTION
The `RARROW` constant in `black/nodes.py` was never used — all call sites reference `token.RARROW` from `blib2to3.pgen2.token` directly, and nothing imports it from `black.nodes`. It also lacked the `Final` annotation every other module-level constant in the file has. Removing it eliminates the redundant duplicate definition.