### PR TITLE
remove duplicate syms.for_stmt entry

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1997,7 +1997,6 @@ def maybe_make_parens_invisible_in_atom(
             # these ones aren't useful to end users, but they do please fuzzers
             syms.for_stmt,
             syms.del_stmt,
-            syms.for_stmt,
         ]:
             return False
 


### PR DESCRIPTION
`syms.for_stmt` appears twice in the list of parent types where walrus-assignment parentheses are kept. The duplicate is harmless (set membership is unaffected) but serves no purpose; drop it to keep the list tidy.