### PR TITLE
docs: correct normalize_numeric_literal docstring

### DIFF
--- a/src/black/numerics.py
+++ b/src/black/numerics.py
@@ -45,7 +45,8 @@ def format_float_or_int_string(text: str) -> str:
 def normalize_numeric_literal(leaf: Leaf) -> None:
     """Normalizes numeric (float, int, and complex) literals.
 
-    All letters used in the representation are normalized to lowercase."""
+    All letters used in the representation are normalized to lowercase,
+    except for hexadecimal digits, which are normalized to uppercase."""
     text = leaf.value.lower()
     if text.startswith(("0o", "0b")):
         # Leave octal and binary literals alone.

--- a/src/black/numerics.py
+++ b/src/black/numerics.py
@@ -46,7 +46,8 @@ def normalize_numeric_literal(leaf: Leaf) -> None:
     """Normalizes numeric (float, int, and complex) literals.
 
     All letters used in the representation are normalized to lowercase,
-    except for hexadecimal digits, which are normalized to uppercase."""
+    except for hexadecimal literals, which are normalized to uppercase
+    after the `0x` prefix."""
     text = leaf.value.lower()
     if text.startswith(("0o", "0b")):
         # Leave octal and binary literals alone.


### PR DESCRIPTION
`normalize_numeric_literal`'s docstring claims "All letters used in the representation are normalized to lowercase", but hexadecimal literals end up with **uppercase** digits (`format_hex` uppercases everything after the `0x` prefix):

```python
>>> from black.numerics import format_hex
>>> format_hex("0x12b3")
'0x12B3'
```

The docstring currently describes behavior that is the opposite of what the function does for hex literals. Clarify it so the exception is documented.