### PR TITLE
docs: fix typo in visit_stmt docstring

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -218,7 +218,7 @@ class LineGenerator(Visitor[Line]):
         `def`, `with`, `class`, `assert`, and assignments.
 
         The relevant Python language `keywords` for a given statement will be
-        NAME leaves within it. This methods puts those on a separate line.
+        NAME leaves within it. This method puts those on a separate line.
 
         `parens` holds a set of string leaf values immediately after which
         invisible parens should be put.

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -217,8 +217,9 @@ class LineGenerator(Visitor[Line]):
         This implementation is shared for `if`, `while`, `for`, `try`, `except`,
         `def`, `with`, `class`, `assert`, and assignments.
 
-        The relevant Python language `keywords` for a given statement will be
-        NAME leaves within it. This method puts those on a separate line.
+        The relevant Python language `keywords` for a given statement
+        appear as NAME leaves within it. This method puts those on a
+        separate line.
 
         `parens` holds a set of string leaf values immediately after which
         invisible parens should be put.


### PR DESCRIPTION
Small grammar fix in the `visit_stmt` docstring: "This methods puts those on a separate line." -> "This method puts those on a separate line."