### PR TITLE
docs: fix typo in StringParenWrapper docstring

### DIFF
--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1966,7 +1966,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
         * The line is a dictionary key assignment where some valid key is being
           assigned the value of some string.
           OR
-        * The line is an lambda expression and the value is a string.
+        * The line is a lambda expression and the value is a string.
           OR
         * The line starts with an "atom" string that prefers to be wrapped in
           parens. It's preferred to be wrapped when it's is an immediate child of


### PR DESCRIPTION
Small grammar fix in the `StringParenWrapper` docstring: "The line is an lambda expression" -> "The line is a lambda expression".