### PR TITLE
docs: fix typo in StringParser comment

### DIFF
--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2494,7 +2494,7 @@ class StringParser:
             if (current_state, next_token) in self._goto:
                 self._state = self._goto[current_state, next_token]
             else:
-                # Otherwise, we check if a the current state was assigned a
+                # Otherwise, we check if the current state was assigned a
                 # default.
                 if (current_state, self.DEFAULT_TOKEN) in self._goto:
                     self._state = self._goto[current_state, self.DEFAULT_TOKEN]


### PR DESCRIPTION
Small typo in a `StringParser._next_state` comment: "we check if a the current state was assigned a default" -> "we check if the current state was assigned a default".