### PR TITLE
Preserve function docstring spacing with line ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the
   value of the template and tripped Black's AST safety check (#5287)
+- Preserve existing spacing after a function docstring when `--line-ranges` selects the
+  docstring; Black no longer inserts a blank line outside the requested range (#5286)
 - Fix unparseable output for a t-string whose replacement field contains a quote (for
   example `t'\'{a["b"]}\''`). The guards that keep quote normalisation away from the
   inside of an f-string replacement field were never reached for t-strings, so the

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -993,7 +993,10 @@ class EmptyLineTracker:
         ):
             return False
         while previous_block := previous_block.previous_block:
-            if not previous_block.original_line.is_comment:
+            if (
+                not previous_block.original_line.is_comment
+                or previous_block.original_line.is_fmt_pass_converted()
+            ):
                 return False
         return True
 

--- a/tests/data/line_ranges_formatted/basic.py
+++ b/tests/data/line_ranges_formatted/basic.py
@@ -36,6 +36,11 @@ class Foo:
             return number + 1
 
 
+def function_with_docstring():
+    """Function doc."""
+    return "Hi There!"
+
+
 try:
     for i in range(10):
         while condition:


### PR DESCRIPTION
### Description

Fixes #5285.

When line-range formatting replaces out-of-range code with `fmt: pass` placeholders, those placeholders are represented as comment lines. The blank-line tracker could therefore scan past the enclosing function boundary and misclassify its docstring as a module docstring, adding a blank line that was outside the requested formatting range.

Treating a converted `fmt: pass` line as a scope boundary preserves the existing spacing. The regression fixture exercises every single-line range across a formatted function whose docstring has no following blank line.

Validation:
- `pytest tests/test_format.py -q` (230 passed)
- pre-commit on changed files: isort, flake8, mypy, prettier, EOF, trailing whitespace passed
- `git diff --check`

AI assistance was used during implementation. I independently reviewed the line-range conversion path and final diff, reproduced the regression through the line-by-line fixture, and ran the validation above.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (No style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (No documentation change is needed.)
