### PR TITLE
don't treat a t-string in docstring position as a docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Stop treating a t-string in docstring position as a docstring (for example
+  `t"  spam  "` as the first statement of a module, class or function). t-strings
+  evaluate to `Template`, never `str`, so stripping and reindenting one changed the
+  value of the template and tripped Black's AST safety check (#5287)
 - Fix unparseable output for a t-string whose replacement field contains a quote (for
   example `t'\'{a["b"]}\''`). The guards that keep quote normalisation away from the
   inside of an f-string replacement field were never reached for t-strings, so the

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -579,7 +579,9 @@ def is_docstring(node: NL) -> bool:
             return False
 
         prefix = get_string_prefix(node.value)
-        if set(prefix).intersection("bBfF"):
+        # Bytes, f-strings and t-strings never evaluate to str, so they are not
+        # docstrings even in docstring position.
+        if set(prefix).intersection("bBfFtT"):
             return False
 
     if (

--- a/tests/data/cases/t_docstring.py
+++ b/tests/data/cases/t_docstring.py
@@ -1,0 +1,58 @@
+# flags: --minimum-version=3.14
+def tea():
+    t" not a docstring"
+
+def tea2():
+    t' also not a docstring'
+
+def triple_quoted_template():
+    t"""   not a docstring   """
+
+def triple_quoted_template2():
+    t'''
+      also not a docstring
+      '''
+
+def raw_template():
+    rt"  not a docstring  "
+
+def capitalized_template():
+    T" NOT A DOCSTRING"
+
+class Pot:
+    t"  not a docstring either  "
+
+t"  module level, still not a docstring  "
+
+# output
+def tea():
+    t" not a docstring"
+
+
+def tea2():
+    t" also not a docstring"
+
+
+def triple_quoted_template():
+    t"""   not a docstring   """
+
+
+def triple_quoted_template2():
+    t"""
+      also not a docstring
+      """
+
+
+def raw_template():
+    rt"  not a docstring  "
+
+
+def capitalized_template():
+    T" NOT A DOCSTRING"
+
+
+class Pot:
+    t"  not a docstring either  "
+
+
+t"  module level, still not a docstring  "


### PR DESCRIPTION
### Description

Carrying on from #5265 I went back over the t-string paths looking for other f-string
guards that had not been extended, and `is_docstring` is one. It rejects bytes and
f-strings with `set(prefix).intersection("bBfF")`, a list written well before PEP 750, so
a t-string sitting as the first statement of a module, class or function is classified as
a docstring and `visit_STRING` runs the whole docstring rewrite over it: `.strip()` for a
single-line literal, `fix_multiline_docstring` for a triple-quoted one. What that touches
is not indentation inside a docstring but the content of a runtime value, so
`t"   spam   "` comes back as `t"spam"` and the `Template.strings` it builds goes from
`('   spam   ',)` to `('spam',)`. Python never takes a t-string as `__doc__`
(`ast.get_docstring` returns `None`, and so does `f.__doc__`), so there was never
anything here to reindent.

On 3.14 the AST safety check does notice, so under the default `--safe` the symptom is
`INTERNAL ERROR: ... produced code that is not equivalent to the source. Please report a
bug` and the file cannot be formatted at all, while `--fast`, `blackd` with
`X-Fast-Or-Safe: fast` and a direct `format_str` skip that check and write the shortened
template out silently, which is the half I find harder to live with. The test belongs in
`is_docstring` rather than in `visit_STRING` because the blank-line handling in
`lines.py` reaches the same predicate through `Line.is_docstring`, and pushing it to the
call sites would mean repeating the prefix check in each of them. An f-string against
t-string differential over 18 constructs in stable and preview is how I satisfied myself
this was the last gap: 20 divergences before the patch, none after. Formatting black's
own `src`, `tests`, `scripts` and `docs` in stable, preview, `--skip-string-normalization`
and pyi modes gives 1356 results and the only one that moves is the new case. One thing
to flag while I am here: `T` stays uppercase in the expected output because
`normalize_string_prefix` lowercases `F` and `B` but not `T`, which reads like a separate
oversight and I have kept it out of this patch.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
