### PR TITLE
docs: mention Vim PEP 8 indentation plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,9 @@
 <!-- Major changes to documentation and policies. Small docs changes
      don't need a changelog entry. -->
 
+- Document `vim-python-pep8-indent`, which provides an `indentexpr` for Black-style
+  insert-mode indentation (#5288)
+
 ## Version 26.5.1
 
 ### Stable style

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -353,11 +353,11 @@ nnoremap <F9> :Black<CR>
 
 ### Vim indentation plugin
 
-For insert-mode indentation that follows the same hanging-bracket style as _Black_,
-you can also use the
-[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
-It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
-For example, with [vim-plug](https://junegunn.github.io/vim-plug/):
+For insert-mode indentation that follows the same hanging-bracket style as _Black_, you
+can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
+provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
+example, with [vim-plug](https://junegunn.github.io/vim-plug/):
 
 ```vim
 Plug 'Vimjas/vim-python-pep8-indent'

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -210,6 +210,16 @@ global setting, follow these steps:
 
 ### Official plugin
 
+For insert-mode indentation that follows the same hanging-bracket style as _Black_,
+you can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
+It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
+For example, with Vundle:
+
+```vim
+Plugin 'Vimjas/vim-python-pep8-indent'
+```
+
 Commands and shortcuts:
 
 - `:Black` to format the entire file (ranges not supported);

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -210,11 +210,11 @@ global setting, follow these steps:
 
 ### Official plugin
 
-For insert-mode indentation that follows the same hanging-bracket style as _Black_,
-you can also use the
-[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
-It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
-For example, with Vundle:
+For insert-mode indentation that follows the same hanging-bracket style as _Black_, you
+can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
+provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
+example, with Vundle:
 
 ```vim
 Plugin 'Vimjas/vim-python-pep8-indent'

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -492,11 +492,11 @@ Use [Thonny-black-formatter](https://github.com/ettore-galli/thonny-black-format
 
 ## Vim indentation plugin
 
-For insert-mode indentation that follows the same hanging-bracket style as _Black_,
-you can also use the
-[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
-It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
-For example, with Vundle:
+For insert-mode indentation that follows the same hanging-bracket style as _Black_, you
+can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
+provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
+example, with Vundle:
 
 ```vim
 Plugin 'Vimjas/vim-python-pep8-indent'

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -210,18 +210,6 @@ global setting, follow these steps:
 
 ### Official plugin
 
-For insert-mode indentation that follows the same hanging-bracket style as _Black_, you
-can also use the
-[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
-provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
-example, with Vundle:
-
-```vim
-Plugin 'Vimjas/vim-python-pep8-indent'
-```
-
-Commands and shortcuts:
-
 - `:Black` to format the entire file (ranges not supported);
   - you can optionally pass `target_version=<version>` with the same values as in the
     command line.
@@ -501,3 +489,15 @@ hook global WinSetOption filetype=python %{
 ## Thonny
 
 Use [Thonny-black-formatter](https://github.com/ettore-galli/thonny-black-formatter).
+
+## Vim indentation plugin
+
+For insert-mode indentation that follows the same hanging-bracket style as _Black_,
+you can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
+It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
+For example, with Vundle:
+
+```vim
+Plugin 'Vimjas/vim-python-pep8-indent'
+```

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -351,6 +351,24 @@ nnoremap <F9> :Black<CR>
    let g:ale_fixers.python = ['black']
    ```
 
+### Vim indentation plugin
+
+For insert-mode indentation that follows the same hanging-bracket style as _Black_,
+you can also use the
+[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin.
+It provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file.
+For example, with [vim-plug](https://junegunn.github.io/vim-plug/):
+
+```vim
+Plug 'Vimjas/vim-python-pep8-indent'
+```
+
+With Vundle, use:
+
+```vim
+Plugin 'Vimjas/vim-python-pep8-indent'
+```
+
 ## Neovim
 
 ### Via conform.nvim
@@ -489,15 +507,3 @@ hook global WinSetOption filetype=python %{
 ## Thonny
 
 Use [Thonny-black-formatter](https://github.com/ettore-galli/thonny-black-formatter).
-
-## Vim indentation plugin
-
-For insert-mode indentation that follows the same hanging-bracket style as _Black_, you
-can also use the
-[`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
-provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
-example, with Vundle:
-
-```vim
-Plugin 'Vimjas/vim-python-pep8-indent'
-```

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -210,6 +210,8 @@ global setting, follow these steps:
 
 ### Official plugin
 
+Commands and shortcuts:
+
 - `:Black` to format the entire file (ranges not supported);
   - you can optionally pass `target_version=<version>` with the same values as in the
     command line.

--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -359,7 +359,7 @@ For insert-mode indentation that follows the same hanging-bracket style as _Blac
 can also use the
 [`vim-python-pep8-indent`](https://github.com/Vimjas/vim-python-pep8-indent) plugin. It
 provides Vim's `indentexpr`; _Black_ remains responsible for formatting the file. For
-example, with [vim-plug](https://junegunn.github.io/vim-plug/):
+example, with vim-plug:
 
 ```vim
 Plug 'Vimjas/vim-python-pep8-indent'


### PR DESCRIPTION
## Summary

- document `vim-python-pep8-indent` as an option for Black-style insert-mode indentation
- clarify that the Vim plugin provides `indentexpr` while Black remains the formatter
- include a Vundle installation example

## Verification

- `git diff --check`
- documentation-only change; no runtime code paths changed

Closes #3151