### PR TITLE
docs: fix typos in docstrings, and remove some unused code

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1998,7 +1998,6 @@ def maybe_make_parens_invisible_in_atom(
             # these ones aren't useful to end users, but they do please fuzzers
             syms.for_stmt,
             syms.del_stmt,
-            syms.for_stmt,
         ]:
             return False
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -217,8 +217,9 @@ class LineGenerator(Visitor[Line]):
         This implementation is shared for `if`, `while`, `for`, `try`, `except`,
         `def`, `with`, `class`, `assert`, and assignments.
 
-        The relevant Python language `keywords` for a given statement will be
-        NAME leaves within it. This methods puts those on a separate line.
+        The relevant Python language `keywords` for a given statement
+        appear as NAME leaves within it. This method puts those on a
+        separate line.
 
         `parens` holds a set of string leaf values immediately after which
         invisible parens should be put.

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -457,7 +457,7 @@ def preceding_leaf(node: LN | None) -> Leaf | None:
 
 def prev_siblings_are(node: LN | None, tokens: list[NodeType | None]) -> bool:
     """Return if the `node` and its previous siblings match types against the provided
-    list of tokens; the provided `node`has its type matched against the last element in
+    list of tokens; the provided `node` has its type matched against the last element in
     the list.  `None` can be used as the first element to declare that the start of the
     list is anchored at the start of its parent's children."""
     if not tokens:

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -141,8 +141,6 @@ ALWAYS_NO_SPACE: Final = CLOSING_BRACKETS | {
     token.BANG,
 }
 
-RARROW = 55
-
 
 @mypyc_attr(allow_interpreted_subclasses=True)
 class Visitor(Generic[T]):

--- a/src/black/numerics.py
+++ b/src/black/numerics.py
@@ -45,7 +45,9 @@ def format_float_or_int_string(text: str) -> str:
 def normalize_numeric_literal(leaf: Leaf) -> None:
     """Normalizes numeric (float, int, and complex) literals.
 
-    All letters used in the representation are normalized to lowercase."""
+    All letters used in the representation are normalized to lowercase,
+    except for hexadecimal literals, which are normalized to uppercase
+    after the `0x` prefix."""
     text = leaf.value.lower()
     if text.startswith(("0o", "0b")):
         # Leave octal and binary literals alone.

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -1985,7 +1985,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
         * The line is a dictionary key assignment where some valid key is being
           assigned the value of some string.
           OR
-        * The line is an lambda expression and the value is a string.
+        * The line is a lambda expression and the value is a string.
           OR
         * The line starts with an "atom" string that prefers to be wrapped in
           parens. It's preferred to be wrapped when it's is an immediate child of

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2513,7 +2513,7 @@ class StringParser:
             if (current_state, next_token) in self._goto:
                 self._state = self._goto[current_state, next_token]
             else:
-                # Otherwise, we check if a the current state was assigned a
+                # Otherwise, we check if the current state was assigned a
                 # default.
                 if (current_state, self.DEFAULT_TOKEN) in self._goto:
                     self._state = self._goto[current_state, self.DEFAULT_TOKEN]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

Consolidated multiple very small docstring typo PRs from @TheGreatApollyon, as well as a couple unused code PRs.

@TheGreatApollyon, in the future, please don't make tiny PRs like that that don't really matter. Especially since these are only internal docstrings, and each change was only one line each. If you have a few changes to make, like you do here, it may be appropriate to open them all together in one PR. Otherwise, it just adds unnecessary noise to the PR list and commit history. Thanks!

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/stable/the_black_code_style/index.html -->
