### PR TITLE
Fix typos in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -377,7 +377,7 @@ The following change was not in any previous stable release:
 
 - Regenerated the `_width_table.py` and added tests for the Khmer language (#4253)
 
-This release alo bumps `pathspec` to v1 and fixes inconsistencies with Git's
+This release also bumps `pathspec` to v1 and fixes inconsistencies with Git's
 `.gitignore` logic (#4958). Now, files will be ignored if a pattern matches them, even
 if the parent directory is directly unignored. For example, Black would previously
 format `exclude/not_this/foo.py` with this `.gitignore`:
@@ -388,7 +388,7 @@ exclude/
 ```
 
 Now, `exclude/not_this/foo.py` will remain ignored. To ensure `exclude/not_this/` and
-all of it's children are included in formatting (and in Git), use this `.gitignore`:
+all of its children are included in formatting (and in Git), use this `.gitignore`:
 
 ```
 */exclude/*


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :) -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution,
     please still tick them so we know you've gone through the checklist.

     - Please familiarize yourself with Black's stability policy, linked
       below. Code style changes are only allowed under the `--preview` flag
       until maintainers move them to stable in the next calendar year.
     - All user-facing changes should get a changelog entry. If this isn't
       user-facing, signal to us that this should get the magical label to
       silence the check.
     - Tests are required for all bugfixes and new features.
     - Documentation changes are necessary for most formatting changes and
       other enhancements. -->

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [ ] Add an entry in `CHANGES.md` if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

<!-- Just as a reminder, everyone in all psf/black spaces, including PRs, must
     follow the PSF Code of Conduct (link below).

     Finally, thanks once again for your time and effort. If you have any
     feedback regarding your experience contributing here, please let us know!

     Helpful links:

     - PSF COC: https://www.python.org/psf/conduct/
     - Contributing docs: https://black.readthedocs.io/en/latest/contributing/index.html
     - Chat on Python Discord: https://discord.gg/RtVdv86PrH
     - Stability policy: https://black.readthedocs.io/en/stable/the_black_code_style/index.html -->

## Description

Fix two minor typos in the changelog:

* Change `alo` to `also`.
* Change `it's` to `its`.

These changes improve the grammar and readability of the changelog without changing its meaning.
