### PR TITLE
Docs: mention MegaLinter on the integrations page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -198,6 +198,8 @@
 
 - Document `vim-python-pep8-indent`, which provides an `indentexpr` for Black-style
   insert-mode indentation (#5288)
+- Mention MegaLinter, a CI linters aggregator bundling _Black_, on the integrations
+  page (#5299)
 
 ## Version 26.5.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -198,8 +198,8 @@
 
 - Document `vim-python-pep8-indent`, which provides an `indentexpr` for Black-style
   insert-mode indentation (#5288)
-- Mention MegaLinter, a CI linters aggregator bundling _Black_, on the integrations
-  page (#5299)
+- Mention MegaLinter, a CI linters aggregator bundling _Black_, on the integrations page
+  (#5299)
 
 ## Version 26.5.1
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -20,6 +20,10 @@ following areas:
 - {doc}`Source version control <./source_version_control>`
 - {doc}`Doctest formatting <./doctest_formatting>`
 
+_Black_ is also bundled in [MegaLinter](https://megalinter.io/), an open-source linters
+aggregator for CI, which runs _Black_ out of the box; see its
+[_Black_ page](https://megalinter.io/latest/descriptors/python_black/) for details.
+
 Editors and tools not listed will require external contributions.
 
 Patches welcome! ✨ 🍰 ✨


### PR DESCRIPTION
### Description

Small docs addition: I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI that has been shipping _Black_ out of the box for a while now. This adds a one-paragraph mention of it on the integrations index page, next to the other ways of running _Black_ in CI, with a link to the [dedicated _Black_ page](https://megalinter.io/latest/descriptors/python_black/) on our side.

Happy to reword or move it elsewhere if you'd prefer!

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? _(no code changes)_
- [x] Add an entry in `CHANGES.md` if necessary? _(added a one-liner under Documentation)_
- [x] Add / update tests if necessary? _(docs only)_
- [x] Add new / update outdated documentation?
