### PR TITLE
Preserve blank lines before a closing fmt: on comment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Preserve blank lines that come immediately before a `# fmt: on` comment. They are
+  inside the opted-out region, but they live in the prefix of the `# fmt: on` comment
+  rather than in the verbatim block, so they were being capped like any ordinary blank
+  run (#5300)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Preserve blank lines that come immediately before a `# fmt: on` comment. They are
-  inside the opted-out region, but they live in the prefix of the `# fmt: on` comment
-  rather than in the verbatim block, so they were being capped like any ordinary blank
-  run (#5300)
+- Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import NamedTuple, Optional, TypeVar, Union, cast
 
 from black.brackets import COMMA_PRIORITY, DOT_PRIORITY, BracketTracker
+from black.comments import FMT_ON, contains_fmt_directive
 from black.mode import Mode, Preview
 from black.nodes import (
     BRACKETS,
@@ -1009,7 +1010,16 @@ class EmptyLineTracker:
             # Consume the first leaf's extra newlines.
             first_leaf = current_line.leaves[0]
             before = first_leaf.prefix.count("\n")
-            before = min(before, max_allowed)
+            # The blank lines that terminate a `# fmt: off` region live in the
+            # prefix of the `# fmt: on` comment, not in the verbatim block, so
+            # capping them here would edit formatting that was opted out of.
+            if not (
+                first_leaf.type == STANDALONE_COMMENT
+                and contains_fmt_directive(first_leaf.value, FMT_ON)
+                and self.previous_line is not None
+                and self.previous_line.is_fmt_pass_converted()
+            ):
+                before = min(before, max_allowed)
             first_leaf.prefix = ""
         else:
             before = 0

--- a/tests/data/cases/fmtonoff9.py
+++ b/tests/data/cases/fmtonoff9.py
@@ -1,0 +1,40 @@
+# Regression test for https://github.com/psf/black/issues/2877.
+# Blank lines that terminate a `# fmt: off` region are inside the region, so
+# they must be preserved rather than collapsed to the usual maximum.
+x = 1
+# fmt: off
+a = 1
+
+
+
+# fmt: on
+y = 2
+
+
+def f():
+    x = 1
+    # fmt: off
+    a = 1
+
+
+
+
+    # fmt: on
+    y = 2
+
+
+# yapf: disable
+b = 1
+
+
+
+# yapf: enable
+z = 2
+
+
+# fmt:off
+c = 1
+
+
+# fmt:on
+w = 2


### PR DESCRIPTION
### Description

Blank lines immediately before a closing `# fmt: on` are collapsed to the usual maximum, even though they are inside the opted-out region:

```python
x = 1
# fmt: off
a = 1
                 # <- three blank lines
# fmt: on
y = 2
```

comes back with two. Reproduced on current `main` (74371e2).

`convert_one_fmt_off_pair` → `_handle_regular_fmt_block` collapses the region into a single `STANDALONE_COMMENT` whose `hidden_value` is verbatim, which is why blanks *between* statements survive. But the blank run that *terminates* the region is not part of that value — it lives in the prefix of the following `# fmt: on` comment, which is owned by the normal blank-line machinery. So `_maybe_empty_lines` applies `before = min(before, max_allowed)` to it like any ordinary blank run.

I confirmed the mechanism by instrumenting `EmptyLineTracker._maybe_empty_lines` rather than reading it off: for the input above the `# fmt: on` line logs `raw_nl=4 -> before=2`.

The loss is one-shot — the output is stable on a second pass — which matches the report of a fresh diff every time the file is regenerated.

### Scope

The issue bundles two defects and this takes only the first. The second symptom, blank lines lost at end of file, is a different mechanism (end-of-file newline normalisation, in `generate_ignored_nodes`) and is separately tracked as still-open #496. `tests/util.read_data` also strips the final newline, so it cannot be covered by a `tests/data/cases` fixture as-is. I did not want to bury an unrelated fix in this PR.

Fixes the mid-file half of #2877.

### Checklist

- [x] Added a test case (`tests/data/cases/fmtonoff9.py`, no `# output` section, so it asserts the input is left untouched)
- [x] Added entry to `CHANGES.md`

### Testing

I checked the fixture is not vacuous: with `src/black/lines.py` reverted, `test_simple_format[fmtonoff9]` fails; with it applied, it passes.

Covered in the fixture: three and four blank lines, nested inside a `def`, `# yapf: disable`/`# yapf: enable`, and the no-space `# fmt:off`/`# fmt:on` spelling. I also checked separately that a bare `# fmt: on` with no preceding `# fmt: off` is still capped normally — those blanks are not in an opted-out region, so they should be.

Full suite: 478 passed, 3 skipped. No existing fixture depended on the old behaviour (7 `fmtonoff*`, 3 `line_ranges_fmt_off*`, 20+ `fmtskip*` all unchanged). `black --check` on the two changed files is clean.
