### PR TITLE
Fix fix_fmt_skip_in_one_liners on with and async with statements (#4853)

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -669,6 +669,23 @@ def _should_keep_compound_statement_inline(
     return any(leaf.type == token.SEMI for leaf in target.leaves())
 
 
+def _collect_header_leaves(node: LN, body_node: Node) -> tuple[list[LN], bool]:
+    """Collect header leaves before body_node. Returns (leaves, found_body)."""
+    if node is body_node:
+        return [], True
+    if isinstance(node, Leaf):
+        if node.type not in (token.NEWLINE, token.INDENT):
+            return [node], False
+        return [], False
+    res: list[LN] = []
+    for child in node.children:
+        child_leaves, found = _collect_header_leaves(child, body_node)
+        res.extend(child_leaves)
+        if found:
+            return res, True
+    return res, False
+
+
 def _get_compound_statement_header(
     body_node: Node, simple_stmt_parent: Node
 ) -> list[LN]:
@@ -681,17 +698,14 @@ def _get_compound_statement_header(
     if compound_stmt is None or compound_stmt.type not in _COMPOUND_STATEMENTS:
         return []
 
-    # Collect all header leaves before the body
-    header_leaves: list[LN] = []
-    for child in compound_stmt.children:
-        if child is body_node:
-            break
-        if isinstance(child, Leaf):
-            if child.type not in (token.NEWLINE, token.INDENT):
-                header_leaves.append(child)
-        else:
-            header_leaves.extend(child.leaves())
-    return header_leaves
+    if (
+        compound_stmt.parent is not None
+        and compound_stmt.parent.type in {syms.async_stmt, syms.async_funcdef}
+    ):
+        compound_stmt = compound_stmt.parent
+
+    leaves, _ = _collect_header_leaves(compound_stmt, body_node)
+    return leaves
 
 
 def _find_closest_previous_sibling(node: LN) -> LN | None:

--- a/tests/data/cases/fmtskip10.py
+++ b/tests/data/cases/fmtskip10.py
@@ -6,8 +6,16 @@ while True: print("loop"); break  # fmt: skip
 for x in [1, 2]: print(x); print("done")  # fmt: skip
 def f(x: int): return x # fmt: skip
 
+
 j =     1 # fmt: skip
 while j < 10: j += 1  # fmt: skip
+with give_me_context(): pass  # fmt: skip
+with give_me_context() as ctx: print("a"); print("b")  # fmt: skip
+
+
+async def f():
+    async with give_me_async_context() as ctx: print("a"); print("b")  # fmt: skip
+
 
 b = [c for c in "A very long string that would normally generate some kind of collapse, since it is this long"] # fmt: skip
 


### PR DESCRIPTION
### Summary
Fixes an issue in `fix_fmt_skip_in_one_liners` where compound statements (specifically `with` and `async with` one-liners containing `# fmt: skip`) were split into invalid syntax across separate lines.

### Changes
- Added `_collect_header_leaves()` in `src/black/comments.py` to recursively collect all tokens preceding the statement body, including `ASYNC` tokens from parent `async_stmt` nodes.
- Added test cases covering `with` and `async with` one-liners in `tests/data/cases/fmtskip10.py`.
- All 232 test cases in the test suite pass.

Fixes #5302