### PR TITLE
Remove redundant generator parentheses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,8 +58,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Remove redundant parentheses around a generator expression passed as the sole argument
-  to a call (#5304)
+- Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Remove redundant parentheses around a generator expression passed as the sole argument
+  to a call (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -45,6 +45,31 @@ Currently, the following features are included in the preview style:
   statements.
 - `fmt_off_class_blank_lines`: Preserve two blank lines before a top-level class whose
   definition starts inside a `# fmt: off` block after an import.
+- `remove_redundant_generator_parentheses`: Remove redundant parentheses around a
+  generator expression passed as the sole argument to a call.
+  ([see below](labels/remove-redundant-generator-parentheses))
+
+(labels/remove-redundant-generator-parentheses)=
+
+### Redundant generator parentheses
+
+When a generator expression is the sole argument to a call, Black removes the extra
+parentheses around the generator expression. The call's parentheses are sufficient.
+
+```python
+# Before
+any((item.is_valid() for item in items))
+
+# After (with --preview)
+any(item.is_valid() for item in items)
+```
+
+The parentheses around the generator expression remain when the call has another
+argument, because Python requires them in that case:
+
+```python
+next((item for item in items), None)
+```
 
 (labels/wrap-comprehension-in)=
 

--- a/docs/the_black_code_style/future_style.md
+++ b/docs/the_black_code_style/future_style.md
@@ -45,16 +45,15 @@ Currently, the following features are included in the preview style:
   statements.
 - `fmt_off_class_blank_lines`: Preserve two blank lines before a top-level class whose
   definition starts inside a `# fmt: off` block after an import.
-- `remove_redundant_generator_parentheses`: Remove redundant parentheses around a
-  generator expression passed as the sole argument to a call.
-  ([see below](labels/remove-redundant-generator-parentheses))
+- `remove_redundant_generator_parentheses`: Remove redundant parentheses around
+  generator expressions. ([see below](labels/remove-redundant-generator-parentheses))
 
 (labels/remove-redundant-generator-parentheses)=
 
 ### Redundant generator parentheses
 
-When a generator expression is the sole argument to a call, Black removes the extra
-parentheses around the generator expression. The call's parentheses are sufficient.
+Black removes extra parentheses around generator expressions. When a generator
+expression is the sole argument to a call, the call's parentheses are sufficient:
 
 ```python
 # Before
@@ -64,11 +63,15 @@ any((item.is_valid() for item in items))
 any(item.is_valid() for item in items)
 ```
 
-The parentheses around the generator expression remain when the call has another
-argument, because Python requires them in that case:
+In other contexts, Black keeps the parentheses required by Python syntax while removing
+any additional pair:
 
 ```python
-next((item for item in items), None)
+# Before
+[((item for item in items)), fallback]
+
+# After (with --preview)
+[(item for item in items), fallback]
 ```
 
 (labels/wrap-comprehension-in)=

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -585,6 +585,17 @@ class LineGenerator(Visitor[Line]):
 
     def visit_atom(self, node: Node) -> Iterator[Line]:
         """Visit any atom"""
+        if (
+            Preview.remove_redundant_generator_parentheses in self.mode
+            and _has_redundant_generator_parentheses(node)
+        ):
+            maybe_make_parens_invisible_in_atom(
+                node,
+                parent=node.parent or node,
+                mode=self.mode,
+                features=self.features,
+            )
+
         if len(node.children) == 3:
             first = node.children[0]
             last = node.children[-1]
@@ -1629,6 +1640,20 @@ def _is_parenthesized_lambda_or_ternary(node: LN) -> bool:
             return True
         node = middle
     return False
+
+
+def _has_redundant_generator_parentheses(node: LN) -> bool:
+    """Whether `node` adds parentheses around a parenthesized generator."""
+    if (
+        node.type != syms.atom
+        or len(node.children) != 3
+        or not is_lpar_token(node.children[0])
+        or not is_rpar_token(node.children[-1])
+    ):
+        return False
+
+    middle = node.children[1]
+    return is_generator(middle) or _has_redundant_generator_parentheses(middle)
 
 
 def normalize_invisible_parens(

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -377,6 +377,23 @@ class LineGenerator(Visitor[Line]):
             ):
                 wrap_in_parentheses(node, leaf)
 
+        if Preview.remove_redundant_generator_parentheses in self.mode:
+            for child in node.children:
+                if (
+                    child.type == syms.trailer
+                    and len(child.children) == 3
+                    and is_lpar_token(child.children[0])
+                    and is_generator(child.children[1])
+                    and is_rpar_token(child.children[2])
+                ):
+                    maybe_make_parens_invisible_in_atom(
+                        child.children[1],
+                        parent=child,
+                        mode=self.mode,
+                        features=self.features,
+                        remove_generator_parens=True,
+                    )
+
         remove_await_parens(node, mode=self.mode, features=self.features)
 
         yield from self.visit_default(node)
@@ -1959,6 +1976,7 @@ def maybe_make_parens_invisible_in_atom(
     features: Collection[Feature],
     remove_brackets_around_comma: bool = False,
     allow_star_expr: bool = False,
+    remove_generator_parens: bool = False,
 ) -> bool:
     """If it's safe, make the parens in the atom `node` invisible, recursively.
     Additionally, remove repeated, adjacent invisible parens from the atom `node`
@@ -1966,6 +1984,7 @@ def maybe_make_parens_invisible_in_atom(
 
     Returns whether the node should itself be wrapped in invisible parentheses.
     """
+    can_remove_generator_parens = remove_generator_parens and is_generator(node)
     if (
         node.type not in (syms.atom, syms.expr)
         or is_empty_tuple(node)
@@ -1983,6 +2002,7 @@ def maybe_make_parens_invisible_in_atom(
             # and option to skip this check for `for` and `with` statements.
             not remove_brackets_around_comma
             and max_delimiter_priority_in_atom(node) >= COMMA_PRIORITY
+            and not can_remove_generator_parens
             # Remove parentheses around multiple exception types in except and
             # except* without as. See PEP 758 for details.
             and not (
@@ -2003,7 +2023,7 @@ def maybe_make_parens_invisible_in_atom(
         )
         or is_tuple_containing_walrus(node)
         or (not allow_star_expr and is_tuple_containing_star(node))
-        or is_generator(node)
+        or (not can_remove_generator_parens and is_generator(node))
     ):
         return False
 

--- a/src/black/mode.py
+++ b/src/black/mode.py
@@ -264,6 +264,7 @@ class Preview(Enum):
     hug_comparator = auto()
     parenthesize_tuple_in_yield = auto()
     fmt_off_class_blank_lines = auto()
+    remove_redundant_generator_parentheses = auto()
 
 
 UNSTABLE_FEATURES: set[Preview] = {

--- a/src/black/resources/black.schema.json
+++ b/src/black/resources/black.schema.json
@@ -93,7 +93,8 @@
           "pyi_blank_line_after_function_docstring",
           "hug_comparator",
           "parenthesize_tuple_in_yield",
-          "fmt_off_class_blank_lines"
+          "fmt_off_class_blank_lines",
+          "remove_redundant_generator_parentheses"
         ]
       },
       "description": "Enable specific features included in the `--unstable` style. Requires `--preview`. No compatibility guarantees are provided on the behavior or existence of any unstable features."

--- a/tests/data/cases/preview_redundant_generator_parentheses.py
+++ b/tests/data/cases/preview_redundant_generator_parentheses.py
@@ -1,0 +1,51 @@
+# flags: --preview
+
+any((x for x in items))
+service.consume((item for group in groups for item in group if item))
+factory((item for item in iterable))()
+
+any((
+    this_very_long_method_name(obj) or another_long_method_name(obj)
+    for obj in this_iterable
+))
+
+# Existing comment handling may keep the generator parentheses visible.
+any((
+    long_expression_that_exceeds_the_configured_line_length_limit_value  # inline comment
+    for item in iterable
+))
+
+# Parentheses are required when the generator is not the sole argument.
+next((item for item in iterable), None)
+enumerate((item for item in iterable), start=10)
+consume((item for item in iterable),)
+consume(*(item for item in iterable))
+consume(generator=(item for item in iterable))
+
+# output
+
+any(x for x in items)
+service.consume(item for group in groups for item in group if item)
+factory(item for item in iterable)()
+
+any(
+    this_very_long_method_name(obj) or another_long_method_name(obj)
+    for obj in this_iterable
+)
+
+# Existing comment handling may keep the generator parentheses visible.
+any(
+    (
+        long_expression_that_exceeds_the_configured_line_length_limit_value  # inline comment
+        for item in iterable
+    )
+)
+
+# Parentheses are required when the generator is not the sole argument.
+next((item for item in iterable), None)
+enumerate((item for item in iterable), start=10)
+consume(
+    (item for item in iterable),
+)
+consume(*(item for item in iterable))
+consume(generator=(item for item in iterable))

--- a/tests/data/cases/preview_redundant_generator_parentheses.py
+++ b/tests/data/cases/preview_redundant_generator_parentheses.py
@@ -15,6 +15,16 @@ next(((item for item in items)), None)
 consume(generator=((item for item in items)))
 consume(*((item for item in items)))
 
+# Power trailers still require the generator's own parentheses.
+((item for item in items)).send(None)
+((item for item in items))[0]
+((item for item in items)).attribute
+((item for item in items))()
+(item for item in items).send(None)
+(item for item in items)[0]
+(item for item in items).attribute
+(item for item in items)()
+
 any((
     this_very_long_method_name(obj) or another_long_method_name(obj)
     for obj in this_iterable
@@ -49,6 +59,16 @@ outer(inner(item.is_valid() for item in items))
 next((item for item in items), None)
 consume(generator=(item for item in items))
 consume(*(item for item in items))
+
+# Power trailers still require the generator's own parentheses.
+(item for item in items).send(None)
+(item for item in items)[0]
+(item for item in items).attribute
+(item for item in items)()
+(item for item in items).send(None)
+(item for item in items)[0]
+(item for item in items).attribute
+(item for item in items)()
 
 any(
     this_very_long_method_name(obj) or another_long_method_name(obj)

--- a/tests/data/cases/preview_redundant_generator_parentheses.py
+++ b/tests/data/cases/preview_redundant_generator_parentheses.py
@@ -4,6 +4,17 @@ any((x for x in items))
 service.consume((item for group in groups for item in group if item))
 factory((item for item in iterable))()
 
+((item.is_valid() for item in items))
+(((item.is_valid() for item in items)),)
+[((item.is_valid() for item in items)), ""]
+{"foo": ((item.is_valid() for item in items))}
+outer(inner(((item.is_valid() for item in items))))
+((result := transform(item) for item in items))
+((item async for item in stream()))
+next(((item for item in items)), None)
+consume(generator=((item for item in items)))
+consume(*((item for item in items)))
+
 any((
     this_very_long_method_name(obj) or another_long_method_name(obj)
     for obj in this_iterable
@@ -27,6 +38,17 @@ consume(generator=(item for item in iterable))
 any(x for x in items)
 service.consume(item for group in groups for item in group if item)
 factory(item for item in iterable)()
+
+(item.is_valid() for item in items)
+((item.is_valid() for item in items),)
+[(item.is_valid() for item in items), ""]
+{"foo": (item.is_valid() for item in items)}
+outer(inner(item.is_valid() for item in items))
+(result := transform(item) for item in items)
+(item async for item in stream())
+next((item for item in items), None)
+consume(generator=(item for item in items))
+consume(*(item for item in items))
 
 any(
     this_very_long_method_name(obj) or another_long_method_name(obj)


### PR DESCRIPTION
### Description

Closes #2943.

Under `--preview`, this removes redundant extra parentheses around generator expressions, including standalone expressions, tuple/list/dict values, nested calls, and call arguments where Python still requires one visible pair.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?

### Tests

- `.venv/bin/python -m pytest -n 4 -q` (551 passed, 2 skipped, 8 subtests passed)
- `.venv/bin/python -m pytest tests/test_format.py -q` (233 passed)
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/sphinx-build -a -b html -W docs/ docs/_build/`
- Direct and extra-parenthesized generator cases before attribute, subscript, and call trailers
