### PR TITLE
Fix crash on async def/with/for with semicolon and fmt: skip (#5307)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and `async for` statements containing a semicolon (#5308)
+- Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
+  `async for` statements containing a semicolon (#5308)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and `async for` statements containing a semicolon (#5308)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -683,6 +683,19 @@ def _get_compound_statement_header(
 
     # Collect all header leaves before the body
     header_leaves: list[LN] = []
+    if (
+        compound_stmt.parent is not None
+        and compound_stmt.parent.type in (syms.async_stmt, syms.async_funcdef)
+    ):
+        for child in compound_stmt.parent.children:
+            if child is compound_stmt:
+                break
+            if isinstance(child, Leaf):
+                if child.type not in (token.NEWLINE, token.INDENT):
+                    header_leaves.append(child)
+            else:
+                header_leaves.extend(child.leaves())
+
     for child in compound_stmt.children:
         if child is body_node:
             break

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -683,9 +683,9 @@ def _get_compound_statement_header(
 
     # Collect all header leaves before the body
     header_leaves: list[LN] = []
-    if (
-        compound_stmt.parent is not None
-        and compound_stmt.parent.type in (syms.async_stmt, syms.async_funcdef)
+    if compound_stmt.parent is not None and compound_stmt.parent.type in (
+        syms.async_stmt,
+        syms.async_funcdef,
     ):
         for child in compound_stmt.parent.children:
             if child is compound_stmt:

--- a/tests/data/cases/fmtskip10.py
+++ b/tests/data/cases/fmtskip10.py
@@ -4,6 +4,9 @@ for i in range(10): print(i)  # fmt: skip
 if True: print("this"); print("that")  # fmt: skip
 while True: print("loop"); break  # fmt: skip
 for x in [1, 2]: print(x); print("done")  # fmt: skip
+async with give_me_async_context(): print("a"); # fmt: skip
+async def give_me_async_context(): print("a"); # fmt: skip
+async for x in give_me_async_gen(): print("a"); # fmt: skip
 def f(x: int): return x # fmt: skip
 
 j =     1 # fmt: skip


### PR DESCRIPTION
## Summary

Fixes #5307.

Black crashes when `# fmt: skip` is used with one-line `async def` and `async with` statements containing a semicolon.

For example:

```python
async with give_me_async_context(): print("a");  # fmt: skip
async def give_me_async_context(): print("a");  # fmt: skip