### PR TITLE
keep async keyword with fmt: skip one-line compound statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@
   `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
+- Fix crash on a one-line `async with`/`async for`/`async def` with a
+  semicolon-separated body and `# fmt: skip` (e.g. `async with ctx(): a; b  # fmt: skip`).
+  The leading `async` keyword was left out of the skipped nodes and reformatted onto its
+  own line, so Black failed on its own output (#5311)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,9 +54,10 @@
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
 - Fix crash on a one-line `async with`/`async for`/`async def` with a
-  semicolon-separated body and `# fmt: skip` (e.g. `async with ctx(): a; b  # fmt: skip`).
-  The leading `async` keyword was left out of the skipped nodes and reformatted onto its
-  own line, so Black failed on its own output (#5311)
+  semicolon-separated body and `# fmt: skip` (e.g.
+  `async with ctx(): a; b  # fmt: skip`). The leading `async` keyword was left out of
+  the skipped nodes and reformatted onto its own line, so Black failed on its own output
+  (#5311)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,11 +53,8 @@
   `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
   contents: the whole statement is now preserved instead of being reformatted (and
   previously crashing) (#5161)
-- Fix crash on a one-line `async with`/`async for`/`async def` with a
-  semicolon-separated body and `# fmt: skip` (e.g.
-  `async with ctx(): a; b  # fmt: skip`). The leading `async` keyword was left out of
-  the skipped nodes and reformatted onto its own line, so Black failed on its own output
-  (#5311)
+- Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
+  `async for` statements containing a semicolon (#5311)
 
 ### Preview style
 

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -683,6 +683,17 @@ def _get_compound_statement_header(
 
     # Collect all header leaves before the body
     header_leaves: list[LN] = []
+    # `async with`/`async for`/`async def` wrap the compound statement in an
+    # async_stmt, so the leading ASYNC token is a sibling of compound_stmt rather
+    # than a child. Pick it up first, otherwise it is left out of the ignored
+    # nodes and reformatted onto its own line, breaking the statement.
+    if (
+        compound_stmt.parent is not None
+        and compound_stmt.parent.type == syms.async_stmt
+        and compound_stmt.prev_sibling is not None
+        and compound_stmt.prev_sibling.type == token.ASYNC
+    ):
+        header_leaves.append(compound_stmt.prev_sibling)
     for child in compound_stmt.children:
         if child is body_node:
             break

--- a/tests/data/cases/fmtskip10.py
+++ b/tests/data/cases/fmtskip10.py
@@ -19,3 +19,9 @@ v = (
     .setdefault("d", {})
     .setdefault("e", {})
 )
+
+
+async def afn():
+    async with give_me_async_context(): print("a"); print("b")  # fmt: skip
+    async for i in some_async_iter(): print(i); print("done")  # fmt: skip
+    async def inner(): x = 1; return x  # fmt: skip


### PR DESCRIPTION
### Description

Reported in #5307. Black crashes on a one-line `async with`/`async for`/`async def` that has a semicolon-separated body and a trailing `# fmt: skip`, e.g. `async with ctx(): a; b  # fmt: skip`. The non-async form is fine, and the async form is fine without the semicolon, so it took a while to pin down the combination. The parse error it dies on is misleading (`cannot parse: ... async`) because it comes from Black's second pass reparsing its own output rather than from the input.

Dumping the first-pass output showed the cause: `async` had been split onto its own line, leaving `async\n    with g(): ...`, which is not valid Python. When a one-line compound statement carries a semicolon body under `# fmt: skip`, `_get_compound_statement_header` gathers the header leaves to keep them inline, but it only walks the children of the `with_stmt`/`for_stmt`/`funcdef`. For an async statement the tree wraps that node in an `async_stmt` and the leading `ASYNC` token is a sibling of the compound node, not a child, so it never made it into the skipped nodes and got reformatted on its own. The colon-line form of `# fmt: skip` already handles this via the async_stmt grandparent, but the inline-semicolon path did not. The risk if left as-is is that any file with such a line cannot be formatted at all under `--safe`, and under `--fast` Black would silently emit broken code. Fixed by picking up the `async_stmt`'s leading `ASYNC` token first; the three async variants are added to `fmtskip10.py`.

Close #5307, closes #5308, closes #5314

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
