### PR TITLE
Fix --line-ranges inserting a blank line after a docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
 - No spurious target version warning when runtime version is included in a
   --target-version flag (#5167)
+- `--line-ranges` no longer inserts an empty line after a docstring when the
+  range covers only the docstring itself (#5312)
 
 ### Highlights
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
 - No spurious target version warning when runtime version is included in a
   --target-version flag (#5167)
-- `--line-ranges` no longer inserts an empty line after a docstring when the
-  range covers only the docstring itself (#5312)
+- `--line-ranges` no longer inserts an empty line after a docstring when the range
+  covers only the docstring itself (#5312)
 
 ### Highlights
 

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -988,6 +988,7 @@ class EmptyLineTracker:
         if (
             len(previous_block.original_line.leaves) != 1
             or not previous_block.original_line.is_docstring
+            or previous_block.original_line.depth != 0
             or current_line.is_class
             or current_line.is_def
         ):

--- a/tests/data/line_ranges_formatted/function_docstring.py
+++ b/tests/data/line_ranges_formatted/function_docstring.py
@@ -1,0 +1,3 @@
+def function():
+    """This is a docstring."""
+    return "Hi There!"


### PR DESCRIPTION
Fixes #5285. closes #5286

## What

`--line-ranges` inserts an empty line after a docstring when the range covers only the docstring:

```python
def function():
    """This is a docstring."""
    return "Hi There!"
```

`black --line-ranges 2-2` changes it to:

```python
def function():
    """This is a docstring."""

    return "Hi There!"
```

Black deliberately has no opinion on blank lines after (function) docstrings (see #2370), so the file should be left unchanged.

## Root cause

With `--line-ranges`, unchanged statements are converted to `STANDALONE_COMMENT` leaves. When only the docstring is in range, the `def` header (and everything else outside the range) becomes a comment, so `_line_is_module_docstring` sees a docstring whose only preceding "statements" are comments and concludes it is a *module* docstring — which Black always separates from the next statement with one empty line.

A module docstring is by definition the first statement of a module, i.e. at depth 0. A function/class/method docstring is at depth ≥ 1. Requiring depth 0 fixes the misclassification.

## Test

Added `tests/data/line_ranges_formatted/function_docstring.py`; the existing line-by-line harness formats every single line of the file and asserts no change. It fails on main and passes with this change. All of `test_black.py` (166 tests + 8 subtests), `test_format.py` and `test_ranges.py` pass, and the file is self-formatted.
