### PR TITLE
DOC: fix typo in docs/faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-The most common questions and issues users face are aggregated to this FAQ.
+The most common questions and issues users face are aggregated into this FAQ.
 
 ```{contents}
 :local:


### PR DESCRIPTION
Fix a small grammar/preposition error in the FAQ intro: change "aggregated to this FAQ" to "aggregated into this FAQ".

Doc-only change, no code affected.