### PR TITLE
fix: handle async with/def/for + semicolon + `# fmt: skip` crash (issue #5307)

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -634,6 +634,18 @@ def _find_compound_statement_context(parent: Node) -> Node | None:
     if parent.parent.type in _COMPOUND_STATEMENTS:
         return parent
 
+    # Case 3: Async one-line form.
+    # The async keyword wraps the compound statement:
+    #     async def f(): print("a"); print("b")  # fmt: skip
+    #     async with ctx(): print("a"); print("b")  # fmt: skip
+    # Structure: async_stmt -> compound_stmt -> simple_stmt
+    if (
+        isinstance(parent.parent, Node)
+        and parent.parent.parent is not None
+        and parent.parent.parent.type == syms.async_stmt
+    ):
+        return parent
+
     return None
 
 
@@ -683,6 +695,16 @@ def _get_compound_statement_header(
 
     # Collect all header leaves before the body
     header_leaves: list[LN] = []
+
+    # Special case: async_stmt wraps the compound statement, and the ASYNC
+    # token is a sibling of the compound statement (not a child).
+    if isinstance(compound_stmt.parent, Node) and compound_stmt.parent.type == syms.async_stmt:
+        async_stmt = compound_stmt.parent
+        if async_stmt.prev_sibling is not None and async_stmt.prev_sibling.type == token.ASYNC:
+            header_leaves.append(async_stmt.prev_sibling)
+        elif async_stmt.children and isinstance(async_stmt.children[0], Leaf) and async_stmt.children[0].type == token.ASYNC:
+            header_leaves.append(async_stmt.children[0])
+
     for child in compound_stmt.children:
         if child is body_node:
             break

--- a/tests/data/cases/fmtskip10.py
+++ b/tests/data/cases/fmtskip10.py
@@ -19,3 +19,5 @@ v = (
     .setdefault("d", {})
     .setdefault("e", {})
 )
+async def foo(): return "mock"  # fmt: skip
+async with give_me_async_context(): print("a");  # fmt: skip


### PR DESCRIPTION
## Summary

Black crashes with a `ParseError` when formatting a one-line `async with` or `async def` statement that has a semicolon-separated body and a `# fmt: skip` comment:

```python
async with give_me_async_context(): print("a");  # fmt: skip
async def give_me_async_context(): print("a");  # fmt: skip
```

## Root Cause

The `# fmt: skip` handling in `comments.py` preserves the entire compound statement header inline when the body contains semicolons. However, for `async` statements, the `ASYNC` token is a sibling of the compound statement inside the `async_stmt` wrapper node — it is not a child of the `with_stmt`/`funcdef`. This means the header collection logic in `_get_compound_statement_header` was missing the `async` keyword, causing Black to split it onto its own line during the first pass. On the second pass, `async` alone on a line is not valid Python, resulting in a parse error.

## Fix

1. In `_get_compound_statement_header`: when the compound statement's parent is an `async_stmt`, also include the `ASYNC` token in the header leaves.

2. In `_find_compound_statement_context`: added a new Case 3 to handle the `async_stmt` wrapper structure (`async_stmt -> compound_stmt -> simple_stmt`).

## Tests

- Added regression test cases to `tests/data/cases/fmtskip10.py` for `async def` and `async with` with semicolon bodies and `# fmt: skip`.
- All 398 existing tests pass.