### PR TITLE
Treat ruff:ignore as a pragma comment

### DIFF
--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -152,7 +152,7 @@ def normalize_trailing_prefix(leaf: LN, total_consumed: int) -> None:
 def make_comment(content: str, mode: Mode) -> str:
     """Return a consistently formatted comment from the given `content` string.
 
-    All comments (except for "##", "#!", "#:", '#'") should have a single
+    All comments (except for "##", "#!", "#:", '#'"') should have a single
     space between the hash sign and the content.
 
     If `content` didn't start with a hash sign, one is provided.
@@ -907,7 +907,7 @@ def contains_pragma_comment(comment_list: list[Leaf]) -> bool:
         pylint).
     """
     for comment in comment_list:
-        if comment.value.startswith(("# type:", "# noqa", "# pylint:")):
+        if comment.value.startswith(("# type:", "# noqa", "# pylint:", "# ruff:")):
             return True
 
     return False


### PR DESCRIPTION
### Problem

Lines annotated with `# ruff:ignore[...]` or `# ruff: ignore[...]` were reformatted by Black even though those pragmas must stay on the same line as the code they suppress:

```python
# Before formatting — this is already correct and should not change:
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]

# After `black file.py` — incorrectly split:
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = (
    5  # ruff: ignore[bweh]
)
```

`# type: ignore`, `# noqa`, and `# pylint:` are treated as pragma comments that prevent line splitting, but `# ruff:` was not included.

This is becoming more common: Ruff has a preview rule (`RUF101`) that converts all `# noqa` comments to `# ruff: ignore`, so the affected population will grow.

### Fix

Add `"# ruff:"` to the `startswith` check in `contains_pragma_comment` in `src/black/comments.py`. This covers both `# ruff:ignore[...]` and `# ruff: ignore[...]` (with or without a space after the colon).

### Testing

```python
# example.py
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]
```

```bash
black --check example.py
# All done! ✨ 🍰 ✨
# 1 file would be left unchanged.
```

Fixes #5260