### PR TITLE
docs: fix PyCharm File Watchers help link

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -30,4 +30,4 @@ The formatted code will be returned on stdout (unless `--check` was passed). _Bl
 will still emit messages on stderr but that shouldn't affect your use case.
 
 This can be used for example with PyCharm's or IntelliJ's
-[File Watchers](https://www.jetbrains.com/help/pycharm/file-watchers.html).
+[File Watchers](https://www.jetbrains.com/help/pycharm/using-file-watchers.html).


### PR DESCRIPTION
## Problem

The integrations overview linked to
`https://www.jetbrains.com/help/pycharm/file-watchers.html`,
which returns 404.

Verified:

    GET https://www.jetbrains.com/help/pycharm/file-watchers.html -> 404
    GET https://www.jetbrains.com/help/pycharm/using-file-watchers.html -> 200

## Solution

Point the File Watchers mention at the current JetBrains help page.

## Verification

GET `https://www.jetbrains.com/help/pycharm/using-file-watchers.html` returns 200.

Small documentation change; no CHANGES.md entry.
