### PR TITLE
docs: fix magic trailing comma documentation link

### DIFF
--- a/docs/contributing/issue_triage.md
+++ b/docs/contributing/issue_triage.md
@@ -153,7 +153,7 @@ Here's some of the most common issues and also pre-made responses you can use:
 ```text
 Black used to remove the trailing comma if the expression fits in a single line, but this was changed by #826 and #1288. Now a trailing comma tells Black to always explode the expression. This change was made mostly for the cases where you _know_ a collection or whatever will grow in the future. Having it always exploded as one element per line reduces diff noise when adding elements. Before the "magic trailing comma" feature, you couldn't anticipate a collection's growth reliably since collections that fitted in one line were ruthlessly collapsed regardless of your intentions. One of Black's goals is reducing diff noise, so this was a good pragmatic change.
 
-So no, this is not a bug, but an intended feature. Anyway, [here's the documentation](https://github.com/psf/black/blob/master/docs/the_black_code_style.md#the-magic-trailing-comma) on the "magic trailing comma", including the ability to skip this functionality with the `--skip-magic-trailing-comma` option. Hopefully that helps solve the possible confusion.
+So no, this is not a bug, but an intended feature. Anyway, [here's the documentation](https://github.com/psf/black/blob/main/docs/the_black_code_style/current_style.md#the-magic-trailing-comma) on the "magic trailing comma", including the ability to skip this functionality with the `--skip-magic-trailing-comma` option. Hopefully that helps solve the possible confusion.
 ```
 
 ### "Black formatted code is violating Flake8's E203!"


### PR DESCRIPTION
## Problem

The canned triage reply linked to
`https://github.com/psf/black/blob/master/docs/the_black_code_style.md#the-magic-trailing-comma`.
That path no longer exists. The style guide lives under
`docs/the_black_code_style/current_style.md`, and the default branch is `main`.

Verified:

    GET https://github.com/psf/black/blob/master/docs/the_black_code_style.md#the-magic-trailing-comma -> 404
    GET https://github.com/psf/black/blob/main/docs/the_black_code_style.md#the-magic-trailing-comma -> 404
    GET https://github.com/psf/black/blob/main/docs/the_black_code_style/current_style.md#the-magic-trailing-comma -> 200

## Solution

Update the canned reply to the current file on `main`.

## Verification

GET of the replacement GitHub blob URL returns 200.
The heading `The magic trailing comma` is present in
`docs/the_black_code_style/current_style.md`.

Small documentation change; no CHANGES.md entry.
