### PR TITLE
Keep parentheses around the target of an annotated assignment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,8 +22,9 @@
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of
-  `__annotations__`; removing them changed that and tripped Black's AST safety check
-  (#5321)
+  `__annotations__`; removing them changed that and tripped Black's AST safety check.
+  Nesting beyond the first pair is redundant and is still removed, so `((x)): int = 5`
+  becomes `(x): int = 5` (#5321)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@
 <!-- Changes that affect Black's stable style -->
 
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
+- Keep the parentheses around the target of an annotated assignment (for example
+  `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of
+  `__annotations__`; removing them changed that and tripped Black's AST safety check
+  (#5321)
 - Stop treating a t-string in docstring position as a docstring (for example
   `t"  spam  "` as the first statement of a module, class or function). t-strings
   evaluate to `Template`, never `str`, so stripping and reindenting one changed the

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1715,6 +1715,7 @@ def normalize_invisible_parens(
             and node.type == syms.expr_stmt
             and not _atom_has_magic_trailing_comma(child, mode)
             and not _is_atom_multiline(child)
+            and not _is_parenthesized_annotation_target(node, child)
         ):
             if maybe_make_parens_invisible_in_atom(
                 child,
@@ -1977,6 +1978,34 @@ def _atom_has_magic_trailing_comma(node: LN, mode: Mode) -> bool:
         return False
 
     return is_one_tuple(node)
+
+
+def _is_parenthesized_annotation_target(node: Node, child: Node) -> bool:
+    """Is `child` a parenthesized plain name that `node` annotates?
+
+    `(x): int = 5` and `x: int = 5` do not do the same thing: only the second one
+    records `x` in `__annotations__`, because the parentheses make the target
+    non-simple (`AnnAssign.simple` is 0). Dropping them changes what the module
+    does at runtime, so they have to stay. Attribute and subscript targets are
+    non-simple either way, so those are left alone here.
+    """
+    if len(node.children) < 2:
+        return False
+
+    annassign = node.children[1]
+    if not isinstance(annassign, Node) or annassign.type != syms.annassign:
+        return False
+
+    # `((x)): int = 5` is non-simple too, so look through any nesting.
+    target: LN = child
+    while (
+        isinstance(target, Node)
+        and target.type == syms.atom
+        and len(target.children) == 3
+    ):
+        target = target.children[1]
+
+    return isinstance(target, Leaf) and target.type == token.NAME
 
 
 def _is_atom_multiline(node: LN) -> bool:

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1715,9 +1715,19 @@ def normalize_invisible_parens(
             and node.type == syms.expr_stmt
             and not _atom_has_magic_trailing_comma(child, mode)
             and not _is_atom_multiline(child)
-            and not _is_parenthesized_annotation_target(node, child)
         ):
-            if maybe_make_parens_invisible_in_atom(
+            if _is_parenthesized_annotation_target(node, child):
+                # One pair is what makes the target non-simple, so any nesting
+                # inside it is redundant and goes.
+                inner = child.children[1]
+                if isinstance(inner, Node) and inner.type == syms.atom:
+                    maybe_make_parens_invisible_in_atom(
+                        inner,
+                        parent=child,
+                        mode=mode,
+                        features=features,
+                    )
+            elif maybe_make_parens_invisible_in_atom(
                 child,
                 parent=node,
                 mode=mode,

--- a/tests/data/cases/annotated_assignment_target_parens.py
+++ b/tests/data/cases/annotated_assignment_target_parens.py
@@ -3,7 +3,11 @@
 # there. Removing them changes what the module does at runtime.
 (x): int = 5
 (y): int
+
+# One pair is what makes the target non-simple, so the nesting above it is
+# redundant and gets removed.
 ((z)): int = 5
+(((q))): int = 5
 
 
 class C:
@@ -29,7 +33,11 @@ def f():
 # there. Removing them changes what the module does at runtime.
 (x): int = 5
 (y): int
-((z)): int = 5
+
+# One pair is what makes the target non-simple, so the nesting above it is
+# redundant and gets removed.
+(z): int = 5
+(q): int = 5
 
 
 class C:

--- a/tests/data/cases/annotated_assignment_target_parens.py
+++ b/tests/data/cases/annotated_assignment_target_parens.py
@@ -1,0 +1,49 @@
+# Parentheses around the target of an annotated assignment are load bearing:
+# `(x): int = 5` leaves `x` out of `__annotations__`, while `x: int = 5` puts it
+# there. Removing them changes what the module does at runtime.
+(x): int = 5
+(y): int
+((z)): int = 5
+
+
+class C:
+    (attr): int = 5
+
+
+def f():
+    (local): int = 5
+
+
+# Attribute and subscript targets are non-simple with or without the parentheses,
+# so those are still stripped.
+(obj.attr): int = 5
+(obj[0]): int = 5
+
+# And a plain assignment carries no annotation, so its parentheses go too.
+(w) = 5
+
+# output
+
+# Parentheses around the target of an annotated assignment are load bearing:
+# `(x): int = 5` leaves `x` out of `__annotations__`, while `x: int = 5` puts it
+# there. Removing them changes what the module does at runtime.
+(x): int = 5
+(y): int
+((z)): int = 5
+
+
+class C:
+    (attr): int = 5
+
+
+def f():
+    (local): int = 5
+
+
+# Attribute and subscript targets are non-simple with or without the parentheses,
+# so those are still stripped.
+obj.attr: int = 5
+obj[0]: int = 5
+
+# And a plain assignment carries no annotation, so its parentheses go too.
+w = 5


### PR DESCRIPTION
### Description

Black removes the parentheses around the target of an annotated assignment, which is not a formatting-only change:

```python
(x): int = 5   # __annotations__ stays empty
x: int = 5     # __annotations__ gets {'x': int}
```

The parentheses make the target non-simple (`AnnAssign.simple` goes from 0 to 1), and CPython only records an annotation for simple targets. Same in a class body, which is where `dataclasses`, `attrs`, `pydantic` and `typing.get_type_hints` read from.

The AST safety check catches it, so today the visible symptom is a crash rather than silent damage:

```
$ printf '(x): int = 5\n' | black -
error: cannot format -: INTERNAL ERROR: Black produced code that is not equivalent to the source.
```

With `--fast` it goes through and the annotation is gone. I ran into it formatting `Lib/test/test_grammar.py` from CPython 3.13, which is where the case is in the wild.

The fix keeps the parentheses only when the target is a plain name. Attribute and subscript targets (`(obj.attr): int`, `(obj[0]): int`) are non-simple either way, so those keep being stripped, and a plain `(w) = 5` is untouched by this.

### Checklist - did you ...

- [ ] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?

Not put behind preview because the current output either fails the safety check or changes runtime behaviour, so there is no stable formatting being changed here. Happy to move it if you disagree.

Tests: `tests/data/cases/annotated_assignment_target_parens.py`, which fails on `main`. Full suite passes here, other than three `TestFileCollection` symlink tests that also fail on a clean checkout on this machine (Windows symlink privilege).
