### PR TITLE
avoid quadratic child rescan in normalize_invisible_parens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,11 +179,8 @@
   `"%s ..." % (a, b, c, ...)` by copying the leaves that surround the merged string in
   one `append_leaves` call instead of one call per leaf, which rescanned the shared
   parent's child list from the start every time (#5220)
-- Improve performance on long `if`/`elif` chains (and other compound statements with
-  many clauses) by passing the known child index when wrapping each clause's test in
-  invisible parentheses in `normalize_invisible_parens`, so the child is swapped in
-  place instead of being located with a full rescan of the statement's child list
-  (#5322)
+- Improve performance on long `if`/`elif` chains and other compound statements with
+  many clauses (#5322)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,8 +179,8 @@
   `"%s ..." % (a, b, c, ...)` by copying the leaves that surround the merged string in
   one `append_leaves` call instead of one call per leaf, which rescanned the shared
   parent's child list from the start every time (#5220)
-- Improve performance on long `if`/`elif` chains and other compound statements with
-  many clauses (#5322)
+- Improve performance on long `if`/`elif` chains and other compound statements with many
+  clauses (#5322)
 
 ### Output
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,11 @@
   `"%s ..." % (a, b, c, ...)` by copying the leaves that surround the merged string in
   one `append_leaves` call instead of one call per leaf, which rescanned the shared
   parent's child list from the start every time (#5220)
+- Improve performance on long `if`/`elif` chains (and other compound statements with
+  many clauses) by passing the known child index when wrapping each clause's test in
+  invisible parentheses in `normalize_invisible_parens`, so the child is swapped in
+  place instead of being located with a full rescan of the statement's child list
+  (#5322)
 
 ### Output
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1724,7 +1724,7 @@ def normalize_invisible_parens(
                 remove_brackets_around_comma=True,
                 allow_star_expr=True,
             ):
-                wrap_in_parentheses(node, child, visible=False)
+                wrap_in_parentheses(node, child, visible=False, index=index)
 
         if check_lpar:
             if (
@@ -1741,7 +1741,7 @@ def normalize_invisible_parens(
                     features=features,
                     remove_brackets_around_comma=True,
                 ):
-                    wrap_in_parentheses(node, child, visible=False)
+                    wrap_in_parentheses(node, child, visible=False, index=index)
             elif isinstance(child, Node) and node.type == syms.with_stmt:
                 remove_with_parens(child, node, mode=mode, features=features)
             elif (
@@ -1755,7 +1755,7 @@ def normalize_invisible_parens(
                     and child.children[0].type != syms.atom
                     and is_one_tuple(child.children[0])
                 ):
-                    wrap_in_parentheses(node, child, visible=True)
+                    wrap_in_parentheses(node, child, visible=True, index=index)
             elif child.type == syms.atom:
                 if "in" in parens_after and _is_parenthesized_lambda_or_ternary(child):
                     # A lambda or conditional expression used as a comprehension's
@@ -1774,9 +1774,9 @@ def normalize_invisible_parens(
                 elif maybe_make_parens_invisible_in_atom(
                     child, parent=node, mode=mode, features=features
                 ):
-                    wrap_in_parentheses(node, child, visible=False)
+                    wrap_in_parentheses(node, child, visible=False, index=index)
             elif is_one_tuple(child):
-                wrap_in_parentheses(node, child, visible=True)
+                wrap_in_parentheses(node, child, visible=True, index=index)
             elif node.type == syms.import_from:
                 _normalize_import_from(node, child, index)
                 break
@@ -1815,9 +1815,9 @@ def normalize_invisible_parens(
                         mock_line.append(leaf)
                     # If it's a guard AND it's short, we DON'T wrap
                     if not is_line_short_enough(mock_line, mode=mode):
-                        wrap_in_parentheses(node, child, visible=False)
+                        wrap_in_parentheses(node, child, visible=False, index=index)
                 else:
-                    wrap_in_parentheses(node, child, visible=False)
+                    wrap_in_parentheses(node, child, visible=False, index=index)
 
         comma_check = child.type == token.COMMA
 


### PR DESCRIPTION
Formatting a long `if`/`elif` chain scales quadratically. Profiling a chain of a few thousand `elif` clauses put nearly all the time in `blib2to3`'s `Base.remove`, reached from `normalize_invisible_parens`: after each `if`/`elif`/`while`/`for`/`return` keyword it wraps the following test expression in invisible parentheses via `wrap_in_parentheses(node, child)`, which locates the child with `child.remove()`. The whole chain is a single `if_stmt` node, so its child list grows with the number of clauses and every `remove()` rescans it from the start, so wrapping n clauses is O(n^2). This runs in the default stable style and before any line splitting, so it is reachable pre-auth through `blackd`.

The enclosing `enumerate` loop already holds each child's position, so I pass it as the `index` that `wrap_in_parentheses` gained in #5184 and let it swap the atom in place with `set_child` instead of remove plus re-insert. Keeping the change in the wrapper call means every clause type flowing through this loop benefits without its own bookkeeping. Output is byte-identical across the test suite and the black plus stdlib sources in stable, preview and skip-string-normalisation modes; a 4000-clause chain drops from ~3.1s to ~1.0s and the curve flattens to linear.
