### PR TITLE
Fix a crash when `# type: ignore` is lost during formatting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@
   previously crashing) (#5161)
 - Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
   `async for` statements containing a semicolon (#5311)
+- Fix crash when `# type: ignore` is lost during formatting (#5328)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@
   previously crashing) (#5161)
 - Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
   `async for` statements containing a semicolon (#5311)
-- Fix a crash when `# type: ignore` is lost during formatting (#5328)
+- Fix a crash when `# type: ignore` is lost during formatting (#5329)
 
 ### Preview style
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,6 @@
   previously crashing) (#5161)
 - Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
   `async for` statements containing a semicolon (#5311)
-- Fix a crash when `# type: ignore` is lost during formatting (#5329)
 
 ### Preview style
 
@@ -93,6 +92,8 @@
 - Don't hug brackets when doing so would join two `type: ignore` comments onto one line.
   The AST records `type: ignore` per line, so merging them dropped a `TypeIgnore` entry
   and Black failed its own equivalence check (#5271)
+- Fix a crash when `# type: ignore` is lost during formatting of a long parenthesized
+  string (#5329)
 
 ### Configuration
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@
   previously crashing) (#5161)
 - Fix crash when `# fmt: skip` is used on one-line `async def`, `async with`, and
   `async for` statements containing a semicolon (#5311)
-- Fix crash when `# type: ignore` is lost during formatting (#5328)
+- Fix a crash when `# type: ignore` is lost during formatting (#5328)
 
 ### Preview style
 

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2383,6 +2383,10 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
             replace_child(LL[comma_idx], comma_leaf)
             last_line.append(comma_leaf)
 
+        if old_rpar_leaf is not None:
+            for comment_leaf in line.comments_after(old_rpar_leaf):
+                last_line.append(comment_leaf, preformatted=True)
+
         yield Ok(last_line)
 
 

--- a/tests/data/cases/comments6.py
+++ b/tests/data/cases/comments6.py
@@ -116,3 +116,9 @@ call_to_some_function_asdf(
 )
 
 aaaaaaaaaaaaa, bbbbbbbbb = map(list, map(itertools.chain.from_iterable, zip(*items)))  # type: ignore[arg-type]
+
+my_dict = {
+    "key": (
+        "A very very very very very very very very very very very very very very very very long string literal"
+    )  # type: ignore
+}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit smoother
     we would appreciate that you go through this template. -->

### Description

In the transformation process of formatting a complicated expression with a `# type: ignore` comment at the end, the comment was getting lost. This was in turn crashing Black on the `--unstable` style.

Fix the issue by moving comments from `old_rpar_leaf` to the new last line of the transformed code after a transformation.  It seems this was missed in the initial implementation.

This PR is a direct fix for #5328.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] ~Add new / update outdated documentation?~

FIXES: #5328