### PR TITLE
keep inline comments in _force_standalone_comment_split

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@
   operator (#5272)
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
+- Fix inline comments being dropped on the lines produced by that forced split, so a
+  trailing `# comment` or `# type: ignore` on a bracket inside such a comprehension is
+  kept instead of silently removed (#5330)
 - Respect the magic trailing comma in a PEP 695 type parameter list containing a
   `*TypeVarTuple` or `**ParamSpec`, which previously collapsed back onto one line
   (#5244)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1617,6 +1617,8 @@ def _force_standalone_comment_split(line: Line) -> Iterator[Line]:
                 mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
             )
         current_line.append(leaf, preformatted=True)
+        for comment_after in line.comments_after(leaf):
+            current_line.append(comment_after, preformatted=True)
     if current_line:
         yield current_line
 

--- a/tests/data/cases/comments_in_comprehensions.py
+++ b/tests/data/cases/comments_in_comprehensions.py
@@ -43,6 +43,31 @@ for (a, b), c in [
 ]:
     pass
 
+# Inline comments on the forced split must not be dropped.
+[
+    [
+        x
+        for x
+        # comment
+        in [  # trailing comment
+            # comment
+            "ABC"
+        ]
+    ]
+]
+
+[
+    [
+        x
+        for x
+        # comment
+        in [  # type: ignore[attr-defined]
+            # comment
+            "ABC"
+        ]
+    ]
+]
+
 # output
 
 # Regression tests for https://github.com/psf/black/issues/4296.
@@ -89,3 +114,20 @@ for (a, b), c in [
     z,
 ]:
     pass
+
+# Inline comments on the forced split must not be dropped.
+[
+    [x for x
+    # comment
+    in [  # trailing comment
+    # comment
+    "ABC"]]
+]
+
+[
+    [x for x
+    # comment
+    in [  # type: ignore[attr-defined]
+    # comment
+    "ABC"]]
+]


### PR DESCRIPTION
### Description

While running a mutation pass over the fixtures (appending `# type: ignore` and other pragmas to random lines, then formatting under `--safe`) the `comments_in_comprehensions.py` case from #4296 started failing the AST check: `INTERNAL ERROR: ... produced code that is not equivalent to the source`, with the safety diff showing only a missing `TypeIgnore` node. Swapping the pragma for a plain `# comment` does not raise anything but the comment is gone from the output all the same, so under `--fast`, `blackd` or a direct `format_str` the file is written with the comment silently removed. Tracing `transform_line` showed the line `in [# comment3 "ABC"]]  # comment2` reaching the fall-through branch with `# comment2` still attached to the inner `[` in `line.comments`, and coming out of `_force_standalone_comment_split` as three lines with no trace of it.

The root cause is that `_force_standalone_comment_split`, added in #5144 as the last-resort split for a line that still carries standalone comments, rebuilds the new lines from `line.leaves` alone and never copies `line.comments`, so every inline comment on that line is lost, including `# noqa` and `# type: ignore`. The other line builders (`standalone_comment_split`, `bracket_split_build_line`) append `comments_after(leaf)` after each leaf, so this does the same. The risk if left is that the one path whose whole purpose is to emit valid code for a comprehension with a comment between the target and `in` now quietly deletes the user's pragmas, and a `# type: ignore` there makes the file unformattable under the default `--safe`. Output for the existing #4296 cases is unchanged; two regression cases are added to the same fixture and the full suite passes on 3.14.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
