### PR TITLE
Keep a trailing comment when wrapping a long string in parens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,9 +70,9 @@
 
 - Remove redundant parentheses around generator expressions (#5304)
 - Keep a trailing comment when wrapping a long string in parentheses, instead of
-  dropping it. `# type: ignore` was the visible case: it kept the parentheses, so
-  it stayed attached to the closing paren that the wrap replaces, and Black then
-  failed its own AST safety check (#5331)
+  dropping it. `# type: ignore` was the visible case: it kept the parentheses, so it
+  stayed attached to the closing paren that the wrap replaces, and Black then failed its
+  own AST safety check (#5331)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,10 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
+- Keep a trailing comment when wrapping a long string in parentheses, instead of
+  dropping it. `# type: ignore` was the visible case: it kept the parentheses, so
+  it stayed attached to the closing paren that the wrap replaces, and Black then
+  failed its own AST safety check (#5331)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2296,6 +2296,14 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
             old_parens_exist = True
             leaves_to_steal_comments_from.append(left_leaves[-1])
             left_leaves.pop()
+            # The closing paren is replaced by a new leaf further down, so a
+            # comment attached to it has to be taken along or it is dropped.
+            # `# type: ignore` is the case that shows up: it is the one comment
+            # that keeps the parentheses visible, so it is still attached to a
+            # real RPAR here rather than to the string.
+            old_rpar = LL[comma_idx - 1] if ends_with_comma else LL[-1]
+            if old_rpar.type == token.RPAR:
+                leaves_to_steal_comments_from.append(old_rpar)
 
         append_leaves(first_line, line, left_leaves)
 

--- a/tests/data/cases/preview_long_strings__regression.py
+++ b/tests/data/cases/preview_long_strings__regression.py
@@ -570,6 +570,11 @@ s = f'Lorem Ipsum is simply dummy text of the printing and typesetting industry:
     "which is against the line length rule."
 )  # type: ignore
 
+# Don't drop a trailing type ignore when wrapping a long string in parentheses.
+x = (
+    "A very very very very very very very very very very very very very very very very long string literal"
+)  # type: ignore
+
 
 # output
 
@@ -1268,3 +1273,9 @@ s = (
     "annotated with a type ignore pragma gets merged into a single very long line "
     "which is against the line length rule."
 )  # type: ignore
+
+# Don't drop a trailing type ignore when wrapping a long string in parentheses.
+x = (  # type: ignore
+    "A very very very very very very very very very very very very very very very very"
+    " long string literal"
+)


### PR DESCRIPTION
Fixes #5328.

## What is happening

`StringParenWrapper` replaces the parentheses around the string it wraps. It collects comments off the old **opening** paren, the string and a trailing comma — but never off the old **closing** paren, so a comment attached there is dropped.

That closing paren is normally invisible, and the comment sits on the string instead, which is why other trailing comments survive and get moved next to the new opening paren:

```python
x = (
    "A very very ... long string literal"
)  # note
```
```python
x = (  # note
    "A very very very very very very very very very very very very very very very very"
    " long string literal"
)
```

`# type: ignore` is the exception. `maybe_make_parens_invisible_in_atom` deliberately keeps the parentheses for it, so it stays attached to a real `RPAR` — and is the one comment that disappears. Losing it changes the AST, so Black fails its own safety check.

## Smaller reproducer

The dict in the issue is not needed:

```python
x = (
    "A very very very very very very very very very very very very very very very very long string literal"
)  # type: ignore
```

```console
$ black x.py --unstable
error: cannot format x.py: INTERNAL ERROR: ... produced code that is not equivalent to the source.
```

The diff Black writes out is just the missing `TypeIgnore` node:

```
     type_ignores=
-    TypeIgnore(
-    )  # /TypeIgnore
 )  # /Module
```

Confirmed it is `string_processing` alone — `--preview` is fine, and `--enable-unstable-feature hug_parens_with_braces_and_square_brackets` is fine. Also confirmed the comment is really deleted rather than merely relocated: with `--fast` to skip the check, the output has no `# type: ignore` anywhere, and `ast.parse(..., type_comments=True).type_ignores` goes from 1 to 0.

## The change

Add the old closing paren to `leaves_to_steal_comments_from`, next to the opening one. `# type: ignore` then lands beside the new `(`, the same place every other trailing comment already goes:

```python
x = (  # type: ignore
    "A very very very very very very very very very very very very very very very very"
    " long string literal"
)
```

## Tests

A case in `preview_long_strings__regression.py`, next to the existing "Don't merge multi-line strings when a pragma comment follows" case — that one covers the merge path, this one the wrap path. It fails on `main`:

```
E       AssertionError
- '  # type: ignore\n    '
-x = (  # type: ignore
```

`tests/` (excluding `test_blackd.py`, which needs the `d` extra): **446 passed, 3 skipped** — identical to `main`. `black --check .` with the repo's own config is clean.
