### PR TITLE
Fix long keyword argument values exceeding line length

### DIFF
--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -243,7 +243,9 @@ class LineGenerator(Visitor[Line]):
                 leaf.prefix + leaf.value for leaf in value_leaves
             ).strip()
             continuation_indent = 4 * (self.current_line.depth + 1)
-            key_width = str_width(node.children[0].value) + 1
+            key = node.children[0]
+            assert isinstance(key, Leaf)
+            key_width = str_width(key.value) + 1
             value_width = str_width(value_text)
             if (
                 value_text

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -234,6 +234,34 @@ class LineGenerator(Visitor[Line]):
 
             yield from self.visit(child)
 
+    def visit_argument(self, node: Node) -> Iterator[Line]:
+        """Add potential parentheses around long keyword argument values."""
+        if len(node.children) == 3 and node.children[1].type == token.EQUAL:
+            value = node.children[2]
+            value_leaves = list(value.leaves())
+            value_text = "".join(
+                leaf.prefix + leaf.value for leaf in value_leaves
+            ).strip()
+            continuation_indent = 4 * (self.current_line.depth + 1)
+            key_width = str_width(node.children[0].value) + 1
+            value_width = str_width(value_text)
+            if (
+                value_text
+                and not any(
+                    leaf.type == token.STRING or leaf.type in OPENING_BRACKETS
+                    for leaf in value_leaves
+                )
+                and continuation_indent + key_width <= self.mode.line_length
+                and continuation_indent + key_width + value_width
+                > self.mode.line_length
+                and value_width
+                > self.mode.line_length - continuation_indent - key_width
+            ):
+                normalize_invisible_parens(
+                    node, parens_after={"="}, mode=self.mode, features=self.features
+                )
+        yield from self.visit_default(node)
+
     def visit_typeparams(self, node: Node) -> Iterator[Line]:
         yield from self.visit_default(node)
         node.children[0].prefix = ""

--- a/tests/data/cases/long_keyword_argument_value.py
+++ b/tests/data/cases/long_keyword_argument_value.py
@@ -1,0 +1,11 @@
+foo(
+    this_is_a_very_looooooooooooooong_parameter_name=some_very_loooooooooooooooooong_variable_name
+)
+
+# output
+
+foo(
+    this_is_a_very_looooooooooooooong_parameter_name=(
+        some_very_loooooooooooooooooong_variable_name
+    )
+)


### PR DESCRIPTION
## Summary

Fix formatting of long keyword argument values so the value can be parenthesized and split when the complete call would otherwise exceed the configured line length.

## Changes

- Add invisible parentheses around eligible long keyword argument values.
- Add a regression case covering a long keyword argument value.
- Keep strings and values that already contain opening brackets on the existing path.

## Testing

- `pytest tests/test_format.py` — 237 passed
- `pytest tests/test_black.py` — 166 passed, 8 subtests passed
- Focused regression case — passed
- Source self-formatting check — passed
- `git diff --check` — passed

Resolves #4040.
