### PR TITLE
Warn before formatting the filesystem root

### DIFF
--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -42,6 +42,7 @@ from black.files import (
     find_user_pyproject_toml,
     gen_python_files,
     get_gitignore,
+    is_filesystem_root,
     parse_pyproject_toml,
     path_is_excluded,
     resolves_outside_root_or_cannot_stat,
@@ -617,6 +618,14 @@ def main(
         find_project_root(src, stdin_filename) if code is None else (None, None)
     )
     ctx.obj["root"] = root
+
+    if code is None:
+        for source in src:
+            if source != "-" and is_filesystem_root(Path(source)):
+                err(
+                    "Warning: formatting the filesystem root can affect files "
+                    "outside your project."
+                )
 
     if verbose:
         if root:

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -74,6 +74,15 @@ def find_project_root(
     return _find_project_root_cached(resolved_srcs)
 
 
+def is_filesystem_root(path: Path) -> bool:
+    """Return whether ``path`` resolves to the root of its filesystem."""
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):
+        return False
+    return resolved == resolved.parent
+
+
 @lru_cache
 def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
     path_srcs = [Path(src) for src in srcs]

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1858,6 +1858,10 @@ class BlackTestCase(BlackBaseTestCase):
                 (src_dir.resolve(), "pyproject.toml"),
             )
 
+    def test_is_filesystem_root(self, tmp_path: Path) -> None:
+        assert black.files.is_filesystem_root(Path("/"))
+        assert not black.files.is_filesystem_root(tmp_path)
+
     @patch(
         "black.files.find_user_pyproject_toml",
     )


### PR DESCRIPTION
## Summary

- warn when an explicitly supplied source resolves to the filesystem root
- keep formatting behavior and exit status unchanged
- ignore stdin and avoid crashing when path resolution fails
- add focused coverage for root detection

Closes #2424

## Validation

- `python3 -m compileall -q src/black`
- `git diff --check`
- Runtime tests require the project dependencies (not installed in this environment).

Drafted by @airbate; please review the warning wording and whether it should remain visible under `--quiet`.