### PR TITLE
Keep inline comments with the string when wrapping it in parentheses (#3802)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,11 +68,10 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Keep an inline comment that follows a string on the same line as that string
-  when the string is wrapped in parentheses, instead of moving the comment up to
-  the opening parenthesis. This lets suppression comments such as
-  `# pyright: ignore[...]` keep applying to the expression they were written for
-  (#3802)
+- Keep an inline comment that follows a string on the same line as that string when the
+  string is wrapped in parentheses, instead of moving the comment up to the opening
+  parenthesis. This lets suppression comments such as `# pyright: ignore[...]` keep
+  applying to the expression they were written for (#3802)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,11 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Keep an inline comment that follows a string on the same line as that string
+  when the string is wrapped in parentheses, instead of moving the comment up to
+  the opening parenthesis. This lets suppression comments such as
+  `# pyright: ignore[...]` keep applying to the expression they were written for
+  (#3802)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2280,7 +2280,7 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
         if LL[comma_idx].type == token.COMMA:
             ends_with_comma = True
 
-        leaves_to_steal_comments_from = [LL[string_idx]]
+        leaves_to_steal_comments_from = []
         if ends_with_comma:
             leaves_to_steal_comments_from.append(LL[comma_idx])
 
@@ -2306,9 +2306,10 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
             insert_str_child(lpar_leaf)
         first_line.append(lpar_leaf)
 
-        # We throw inline comments that were originally to the right of the
-        # target string to the top line. They will now be shown to the right of
-        # the LPAR.
+        # We throw inline comments that were originally to the right of a
+        # trailing comma or of a pre-existing LPAR to the top line. They will
+        # now be shown to the right of the LPAR. Comments attached directly to
+        # the target string are not touched here; they stay with the string.
         for leaf in leaves_to_steal_comments_from:
             for comment_leaf in line.comments_after(leaf):
                 first_line.append(comment_leaf, preformatted=True)
@@ -2329,6 +2330,14 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
         string_leaf = Leaf(token.STRING, string_value)
         insert_str_child(string_leaf)
         string_line.append(string_leaf)
+
+        # Comments attached directly to the target string stay attached to it:
+        # they are rendered on the same output line as the string itself
+        # (inside the parentheses) instead of being moved to the opening-paren
+        # line. This preserves the semantics of inline suppression comments
+        # such as `# pyright: ignore[...]`.
+        for comment_leaf in line.comments_after(LL[string_idx]):
+            string_line.append(comment_leaf, preformatted=True)
 
         old_rpar_leaf = None
         if is_valid_index(string_idx + 1):

--- a/tests/data/cases/preview_comment_after_wrapped_string.py
+++ b/tests/data/cases/preview_comment_after_wrapped_string.py
@@ -1,0 +1,14 @@
+# flags: --unstable
+# Regression test for https://github.com/psf/black/issues/3802
+def __str__(self):
+    return "foo bar baz qux" # pyright: ignore[reportGeneralTypeIssues] -- This is some special Django magic that we can't easily tell Pyright about
+
+
+# output
+
+
+# Regression test for https://github.com/psf/black/issues/3802
+def __str__(self):
+    return (
+        "foo bar baz qux"  # pyright: ignore[reportGeneralTypeIssues] -- This is some special Django magic that we can't easily tell Pyright about
+    )

--- a/tests/data/cases/preview_comments7.py
+++ b/tests/data/cases/preview_comments7.py
@@ -181,12 +181,12 @@ result = 1  # look ma, no comment migration xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 result = 1  # look ma, no comment migration xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-result = (  # aaa
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+result = (
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
 )
 
-result = (  # aaa
-    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+result = (
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # aaa
 )
 
 
@@ -297,8 +297,8 @@ square = Square(4)  # type: Optional[Square]
 
 # Regression test for https://github.com/psf/black/issues/3756.
 [
-    (  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     ),
 ]
 [

--- a/tests/data/cases/preview_long_strings.py
+++ b/tests/data/cases/preview_long_strings.py
@@ -650,9 +650,9 @@ fstring_with_no_fexprs = (
     f" any means whatsoever."
 )
 
-comment_string = (  # This comment gets thrown to the top.
+comment_string = (
     "Long lines with inline comments should have their comments appended to the"
-    " reformatted string's enclosing right parentheses."
+    " reformatted string's enclosing right parentheses."  # This comment gets thrown to the top.
 )
 
 arg_comment_string = print(

--- a/tests/data/cases/preview_long_strings__regression.py
+++ b/tests/data/cases/preview_long_strings__regression.py
@@ -835,8 +835,9 @@ some_dictionary = {
 
 
 def foo():
-    xxx_xxx = (  # xxxx xxxxxxxxxx xxxx xx xxxx xx xxx xxxxxxxx xxxxxx xxxxx.
-        'xxxx xxx xxxxxxxx_xxxx xx "xxxxxxxxxx".\n xxx: xxxxxx xxxxxxxx_xxxx=xxxxxxxxxx'
+    xxx_xxx = (
+        'xxxx xxx xxxxxxxx_xxxx xx "xxxxxxxxxx".'
+        "\n xxx: xxxxxx xxxxxxxx_xxxx=xxxxxxxxxx"  # xxxx xxxxxxxxxx xxxx xx xxxx xx xxx xxxxxxxx xxxxxx xxxxx.
     )
 
 


### PR DESCRIPTION
Closes #3802

When `StringParenWrapper` wraps a return/assign/assert value in parentheses so
the string can go on its own line, it moved any inline comment that followed the
string up to the opening-paren line. That silently changed which expression a
suppression comment applied to, so `# pyright: ignore[...]` (and similar) stopped
working — and there was no place the comment could be written that survived
formatting.

The comment now stays on the same line as the string it was written after.
Comments after a trailing comma or a pre-existing `(` are still moved up, as
before.

This changes the expected output of three existing unstable-style cases, updated
here: `preview_comments7`, `preview_long_strings` and
`preview_long_strings__regression`. A regression case for this issue is added as
`preview_comment_after_wrapped_string`.

Verified on this base: `tests/test_format.py` + `tests/test_black.py` go from 3
failures to 403 passed, with no newly failing test; re-running Black on the
formatted output is idempotent.

This patch was produced with the help of an autonomous coding system I build and
supervise. I review and test every change before submitting and follow up on
review feedback personally. If automated contributions are unwelcome in this
project, please say so and I will stop submitting them.
