### PR TITLE
Failure to consistently format inline type comments on a multi-line attribute access (#3869)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,8 @@
 
 <!-- Changes that affect Black's preview style -->
 
-- Failure to consistently format inline type comments on a multi-line attribute access (#3869)
+- Failure to consistently format inline type comments on a multi-line attribute access
+  (#3869)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Failure to consistently format inline type comments on a multi-line attribute access (#3869)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -881,6 +881,8 @@ def transform_line(
         # output is at least valid Python.
         if line.contains_standalone_comments():
             yield from _force_standalone_comment_split(line)
+        elif line.contains_uncollapsable_type_comments():
+            yield from _force_uncollapsable_type_comment_split(line)
         else:
             yield line
 
@@ -1209,6 +1211,12 @@ def _prefer_split_rhs_oop_over_rhs(
         or rhs_oop.tail.contains_unsplittable_type_ignore()
     ):
         return True
+
+    # contains uncollapsable type comments in the head: the head has no
+    # delimiter to safely split on, so keep the (now-forced-visible) optional
+    # parens instead, giving the fallback split a real bracket to work with.
+    if rhs_oop.head.contains_uncollapsable_type_comments():
+        return False
 
     # Retain optional parens around dictionary values
     if (
@@ -1617,6 +1625,25 @@ def _force_standalone_comment_split(line: Line) -> Iterator[Line]:
                 mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
             )
         current_line.append(leaf, preformatted=True)
+    if current_line:
+        yield current_line
+
+
+def _force_uncollapsable_type_comment_split(line: Line) -> Iterator[Line]:
+    """Last-resort split so each uncollapsable type comment gets its own line."""
+    current_line = Line(
+        mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+    )
+    last_leaf = line.leaves[-1] if line.leaves else None
+    for leaf in line.leaves:
+        current_line.append(leaf, preformatted=True)
+        for comment_after in line.comments_after(leaf):
+            current_line.append(comment_after, preformatted=True)
+        if leaf is not last_leaf and line.comments_after(leaf):
+            yield current_line
+            current_line = Line(
+                mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets
+            )
     if current_line:
         yield current_line
 

--- a/tests/data/cases/comments_on_multiline_attribute_chain.py
+++ b/tests/data/cases/comments_on_multiline_attribute_chain.py
@@ -1,0 +1,28 @@
+# Regression test for https://github.com/psf/black/issues/3869: inline comments
+# (including `# type: ignore`) attached to different leaves of a multi-line
+# attribute-access chain must never be merged onto the same output line. The AST
+# records a `# type: ignore` once per physical line, so merging two of them
+# together drops one and used to fail Black's own equivalence check.
+def _get_light_style(app: sphinx.application.Sphinx) -> Style:
+    return (
+        app  # type: ignore[no-any-return]
+            .builder
+            .highlighter # type: ignore[attr-defined]
+            .formatter_args["style"]
+        )
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/3869: inline comments
+# (including `# type: ignore`) attached to different leaves of a multi-line
+# attribute-access chain must never be merged onto the same output line. The AST
+# records a `# type: ignore` once per physical line, so merging two of them
+# together drops one and used to fail Black's own equivalence check.
+def _get_light_style(app: sphinx.application.Sphinx) -> Style:
+    return (
+        app  # type: ignore[no-any-return]
+        .builder.highlighter  # type: ignore[attr-defined]
+        .formatter_args[
+            "style"
+        ]
+    )


### PR DESCRIPTION
Closes #3869

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.