### PR TITLE
Long string in return annotation does not get split if there's parameters (#3926)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Long string in return annotation does not get split if there's parameters (#3926)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1172,6 +1172,16 @@ def _maybe_split_omitting_optional_parens(
                     and rhs.opening_bracket.parent.parent
                     and rhs.opening_bracket.parent.parent.type == syms.case_block
                 )
+                and not (
+                    Preview.string_processing in mode
+                    and len(rhs.body.leaves) == 1
+                    and rhs.body.leaves[0].type == token.STRING
+                    and rhs.opening_bracket.parent
+                    and rhs.opening_bracket.parent.parent
+                    and rhs.opening_bracket.parent.parent.type == syms.funcdef
+                    and rhs.opening_bracket.parent.prev_sibling
+                    and rhs.opening_bracket.parent.prev_sibling.type == token.RARROW
+                )
             ):
                 raise CannotSplit(
                     "Splitting failed, body is still too long and can't be split."
@@ -1376,7 +1386,7 @@ def bracket_split_build_line(
                 break
 
     leaves_to_track: set[LeafID] = set()
-    if component is _BracketSplitComponent.head:
+    if component in (_BracketSplitComponent.head, _BracketSplitComponent.tail):
         leaves_to_track = get_leaves_inside_matching_brackets(leaves)
     # Populate the line
     for leaf in leaves:

--- a/tests/data/cases/preview_return_annotation_brackets_string.py
+++ b/tests/data/cases/preview_return_annotation_brackets_string.py
@@ -20,5 +20,8 @@ def frobnicate() -> (
 # splitting the string breaks if there's any parameters
 def frobnicate(
     a,
-) -> "ThisIsTrulyUnreasonablyExtremelyLongClassName | list[ThisIsTrulyUnreasonablyExtremelyLongClassName]":
+) -> (
+    "ThisIsTrulyUnreasonablyExtremelyLongClassName |"
+    " list[ThisIsTrulyUnreasonablyExtremelyLongClassName]"
+):
     pass


### PR DESCRIPTION
Closes #3926

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.