### PR TITLE
Black puts "pyright: ignore" comments on the wrong line (#3946)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Black puts "pyright: ignore" comments on the wrong line (#3946)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/nodes.py
+++ b/src/black/nodes.py
@@ -986,12 +986,34 @@ def is_type_comment_string(value: str, mode: Mode) -> bool:
 
 
 def is_type_ignore_comment(leaf: Leaf, mode: Mode) -> bool:
-    """Return True if the given leaf is a type comment with ignore annotation."""
+    """Return True if the given leaf is a type comment with ignore annotation.
+
+    `# pyright: ignore` comments also count as ignore annotations: like
+    `# type: ignore`, they are positional, so Black must never move one to a
+    line it did not originate on.
+    """
     t = leaf.type
     v = leaf.value
-    return t in {token.COMMENT, STANDALONE_COMMENT} and is_type_ignore_comment_string(
-        v, mode
+    return t in {token.COMMENT, STANDALONE_COMMENT} and (
+        is_type_ignore_comment_string(v, mode) or is_pyright_ignore_comment_string(v)
     )
+
+
+def is_pyright_ignore_comment_string(value: str) -> bool:
+    """Return True if the given string is a `# pyright: ignore` comment.
+
+    This matches both the bare form (`# pyright: ignore`) and the bracketed
+    form (`# pyright: ignore[reportUnknownMemberType]`), with any bracket
+    contents. Other pyright directive comments (e.g. `# pyright: basic`,
+    `# pyright: strict` or `# pyright: reportGeneralTypeIssues=false`) do not
+    match, since they carry no positional suppression semantics.
+    """
+    if not value.startswith("#"):
+        return False
+    directive = value[1:].lstrip()
+    if not directive.startswith("pyright:"):
+        return False
+    return directive[len("pyright:") :].lstrip().startswith("ignore")
 
 
 def is_type_ignore_comment_string(value: str, mode: Mode) -> bool:

--- a/tests/data/cases/probe_pyright_repro.py
+++ b/tests/data/cases/probe_pyright_repro.py
@@ -1,0 +1,17 @@
+asm_client: SecretsManagerClient = boto3.client("secretsmanager")  # pyright: ignore[reportUnknownMemberType]
+asm_client: SecretsManagerClient = boto3.client(  # pyright: ignore[reportUnknownMemberType]
+    "secretsmanager"
+)
+asm_client: SecretsManagerClientTypeAlias = boto3.client("secretsmanager")  # pyright: ignore
+asm_client: SecretsManagerClientTypeAlias = boto3.client("secretsmanager")  # pyright: reportGeneralTypeIssues=false, long comment
+
+# output
+
+asm_client: SecretsManagerClient = boto3.client("secretsmanager")  # pyright: ignore[reportUnknownMemberType]
+asm_client: SecretsManagerClient = boto3.client(  # pyright: ignore[reportUnknownMemberType]
+    "secretsmanager"
+)
+asm_client: SecretsManagerClientTypeAlias = boto3.client("secretsmanager")  # pyright: ignore
+asm_client: SecretsManagerClientTypeAlias = boto3.client(
+    "secretsmanager"
+)  # pyright: reportGeneralTypeIssues=false, long comment

--- a/tests/data/cases/probe_type_ignore_repro.py
+++ b/tests/data/cases/probe_type_ignore_repro.py
@@ -1,0 +1,9 @@
+asm_client: SecretsManagerClient = boto3.client("secretsmanager")  # type: ignore[misc]
+asm_client: SecretsManagerClient = boto3.client(  # type: ignore[misc]
+    "secretsmanager"
+)
+
+# output
+
+asm_client: SecretsManagerClient = boto3.client("secretsmanager")  # type: ignore[misc]
+asm_client: SecretsManagerClient = boto3.client("secretsmanager")  # type: ignore[misc]

--- a/tests/probe_variants_test.py
+++ b/tests/probe_variants_test.py
@@ -1,0 +1,1 @@
+# scratch file, ignore


### PR DESCRIPTION
Closes #3946

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.