### PR TITLE
Avoid parentheszing non-fluent attribute chain exceeding the line-length (#4001)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Avoid parentheszing non-fluent attribute chain exceeding the line-length (#4001)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -1498,6 +1498,13 @@ def can_be_split(line: Line) -> bool:
             if dot_count > 1 and call_count > 1:
                 return False
 
+    # A pure attribute-access chain (all NAME/DOT leaves, no brackets anywhere)
+    # has no bracket pair of its own to split on, so it can never be made to fit
+    # by further splitting. Treat it like a lone atom: don't wrap it in optional
+    # parentheses that won't help.
+    if all(leaf.type in (token.NAME, token.DOT) for leaf in leaves):
+        return False
+
     return True
 
 

--- a/tests/data/cases/nonfluent_attribute_chain_parens.py
+++ b/tests/data/cases/nonfluent_attribute_chain_parens.py
@@ -1,0 +1,75 @@
+# fits parenthesized
+first = (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvv"
+)
+second = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvv
+)
+third = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvv
+)
+
+# exceeds parenthesized
+fourth = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvv"
+fifth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvv
+sixth = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvv
+)
+
+
+def doesnt_exceed_line_length_when_parenthesizing():
+    first = (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvv"
+    )
+    second = (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvv
+    )
+    third = (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvv
+    )
+
+
+def exceeds_line_length_parenthesized():
+    fourth = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvv"
+    fifth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvvv
+    sixth = (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvvv
+    )
+
+
+# output
+
+
+# fits parenthesized
+first = (
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvv"
+)
+second = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvv
+)
+third = (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvv
+)
+
+# exceeds parenthesized
+fourth = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvv"
+fifth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvv
+sixth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvv
+
+
+def doesnt_exceed_line_length_when_parenthesizing():
+    first = (
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvv"
+    )
+    second = (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvv
+    )
+    third = (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvv
+    )
+
+
+def exceeds_line_length_parenthesized():
+    fourth = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvv"
+    fifth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvvv
+    sixth = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbvvvvvvvvvvvvvvvvvvvv

--- a/tests/data/cases/remove_except_parens.py
+++ b/tests/data/cases/remove_except_parens.py
@@ -58,9 +58,7 @@ except (AttributeError, ValueError) as err:
 # Test long variants.
 try:
     a.something
-except (
-    some.really.really.really.looooooooooooooooooooooooooooooooong.module.over89.chars.Error
-) as err:
+except some.really.really.really.looooooooooooooooooooooooooooooooong.module.over89.chars.Error as err:
     raise err
 
 try:


### PR DESCRIPTION
Closes #4001

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.