### PR TITLE
A comment before a multiplication line inside a func call makes the line unnecessarily explode (#3713)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
-- A comment before a multiplication line inside a func call makes the line unnecessarily explode (#3713)
+- A comment before a multiplication line inside a func call makes the line unnecessarily
+  explode (#3713)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- A comment before a multiplication line inside a func call makes the line unnecessarily explode (#3713)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -14,6 +14,7 @@ from black.brackets import (
     COMMA_PRIORITY,
     COMPARATOR_PRIORITY,
     DOT_PRIORITY,
+    MATH_PRIORITIES,
     STRING_PRIORITY,
     get_leaves_inside_matching_brackets,
     max_delimiter_priority_in_atom,
@@ -1502,6 +1503,17 @@ def delimiter_split(
         and _can_defer_lone_comparator_to_rhs(line, mode)
     ):
         raise CannotSplit("Bracketed RHS will explode via right_hand_split")
+
+    if (
+        delimiter_priority in MATH_PRIORITIES.values()
+        and bt.delimiter_count_with_priority(delimiter_priority) == 1
+        and not line.magic_trailing_comma
+        and line.contains_standalone_comments()
+    ):
+        raise CannotSplit(
+            "Standalone comment should be split first; expression may fit on one"
+            " line"
+        )
 
     current_line = Line(
         mode=line.mode, depth=line.depth, inside_brackets=line.inside_brackets

--- a/tests/data/cases/comment_before_multiplication_in_call.py
+++ b/tests/data/cases/comment_before_multiplication_in_call.py
@@ -1,0 +1,50 @@
+# Regression test for https://github.com/psf/black/issues/3713.
+my_func(
+    arg1=1,
+    arg2=[
+        func_call(
+            # Comment.
+            [MyClass(arg1, arg2)] * 10000
+        ),
+    ],
+)
+
+# A single arithmetic/bitwise operator should stay collapsed too.
+func_call(
+    # Comment.
+    a + b
+)
+
+# But if the result still doesn't fit, it still needs to split around the
+# operator (just without the comment forcing it unnecessarily).
+func_call(
+    # Comment.
+    [MyClass(arg1, arg2)] * some_extremely_long_multiplier_that_certainly_does_not_fit_at_all_here
+)
+
+# output
+
+# Regression test for https://github.com/psf/black/issues/3713.
+my_func(
+    arg1=1,
+    arg2=[
+        func_call(
+            # Comment.
+            [MyClass(arg1, arg2)] * 10000
+        ),
+    ],
+)
+
+# A single arithmetic/bitwise operator should stay collapsed too.
+func_call(
+    # Comment.
+    a + b
+)
+
+# But if the result still doesn't fit, it still needs to split around the
+# operator (just without the comment forcing it unnecessarily).
+func_call(
+    # Comment.
+    [MyClass(arg1, arg2)]
+    * some_extremely_long_multiplier_that_certainly_does_not_fit_at_all_here
+)


### PR DESCRIPTION
Closes #3713

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.