### PR TITLE
Improve `adjusted_lines`'s diff algorithm used in `--line-ranges`. (#4052)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Improve `adjusted_lines`'s diff algorithm used in `--line-ranges`. (#4052)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -3,6 +3,7 @@
 import difflib
 from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from black.nodes import (
     LN,
@@ -543,6 +544,102 @@ class _LinesMapping:
     is_changed_block: bool
 
 
+class _DiagonalTieBreakSequenceMatcher(difflib.SequenceMatcher):
+    """A SequenceMatcher that prefers matches closest to the diagonal.
+
+    When multiple matching blocks of equal length exist, the default
+    SequenceMatcher picks the one that starts earliest in the original text,
+    then earliest in the modified text. This can misalign duplicate lines.
+    Instead, we prefer the match whose start position in the original text is
+    closest to its start position in the modified text (i.e. closest to the
+    diagonal), which keeps each line aligned with its nearest counterpart.
+    """
+
+    def find_longest_match(
+        self,
+        alo: int,
+        ahi: int,
+        blo: int,
+        bhi: int,
+    ) -> difflib.Match:
+        """Find longest matching block in a[alo:ahi] and b[blo:bhi].
+
+        This is a copy of difflib.SequenceMatcher.find_longest_match with the
+        tie-breaking changed to prefer matches closest to the diagonal.
+        """
+        a, b, b2j, isbjunk = self.a, self.b, self.b2j, self.bjunk.__contains__
+        besti, bestj, bestsize = alo, blo, 0
+        # find longest junk-free match
+        # during an iteration of the loop, j2len[j] = length of longest
+        # junk-free match ending with a[i-1] and b[j]
+        j2len: dict[int, int] = {}
+        nothing: list[Any] = []
+        for i in range(alo, ahi):
+            # look at all instances of a[i] in b; note that because
+            # b2j has no junk keys, the loop is skipped if a[i] is junk
+            j2lenget = j2len.get
+            newj2len: dict[int, int] = {}
+            for j in b2j.get(a[i], nothing):
+                # a[i] matches b[j]
+                if j < blo:
+                    continue
+                if j >= bhi:
+                    break
+                k = newj2len[j] = j2lenget(j - 1, 0) + 1
+                if k > bestsize:
+                    besti, bestj, bestsize = i - k + 1, j - k + 1, k
+                elif k == bestsize:
+                    # Tie-break: prefer the match closest to the diagonal.
+                    current_distance = abs((i - k + 1) - (j - k + 1))
+                    best_distance = abs(besti - bestj)
+                    if current_distance < best_distance:
+                        besti, bestj, bestsize = i - k + 1, j - k + 1, k
+            j2len = newj2len
+
+        # Extend the best by non-junk elements on each end. In particular,
+        # "popular" non-junk elements aren't in b2j, which greatly speeds
+        # the inner loop above, but also means "the best" match so far
+        # doesn't contain any junk *or* popular non-junk elements.
+        while (
+            besti > alo
+            and bestj > blo
+            and not isbjunk(b[bestj - 1])
+            and a[besti - 1] == b[bestj - 1]
+        ):
+            besti, bestj, bestsize = besti - 1, bestj - 1, bestsize + 1
+        while (
+            besti + bestsize < ahi
+            and bestj + bestsize < bhi
+            and not isbjunk(b[bestj + bestsize])
+            and a[besti + bestsize] == b[bestj + bestsize]
+        ):
+            bestsize += 1
+
+        # Now that we have a wholly interesting match (albeit possibly
+        # empty!), we may as well suck up the matching junk on each
+        # side of it too. Can't think of a good reason not to, and it
+        # saves post-processing the (possibly considerable) expense of
+        # figuring out what to do with it. In the case of an empty
+        # interesting match, this is clearly the right thing to do,
+        # because no other kind of match is possible in the regions.
+        while (
+            besti > alo
+            and bestj > blo
+            and isbjunk(b[bestj - 1])
+            and a[besti - 1] == b[bestj - 1]
+        ):
+            besti, bestj, bestsize = besti - 1, bestj - 1, bestsize + 1
+        while (
+            besti + bestsize < ahi
+            and bestj + bestsize < bhi
+            and isbjunk(b[bestj + bestsize])
+            and a[besti + bestsize] == b[bestj + bestsize]
+        ):
+            bestsize += 1
+
+        return difflib.Match(besti, bestj, bestsize)
+
+
 def _calculate_lines_mappings(
     original_source: str,
     modified_source: str,
@@ -573,7 +670,7 @@ def _calculate_lines_mappings(
       original_source: the original source.
       modified_source: the modified source.
     """
-    matcher = difflib.SequenceMatcher(
+    matcher = _DiagonalTieBreakSequenceMatcher(
         None,
         original_source.splitlines(keepends=True),
         modified_source.splitlines(keepends=True),

--- a/tests/data/cases/line_ranges_diff_edge_case.py
+++ b/tests/data/cases/line_ranges_diff_edge_case.py
@@ -2,9 +2,9 @@
 # NOTE: If you need to modify this file, pay special attention to the --line-ranges=
 # flag above as it's formatting specifically these lines.
 
-# Reproducible example for https://github.com/psf/black/issues/4033.
-# This can be fixed in the future if we use a better diffing algorithm, or make Black
-# perform formatting in a single pass.
+# Reproducible example for https://github.com/psf/black/issues/4033, fixed here by a
+# diagonal-preferring diff (https://github.com/psf/black/issues/4052): only the lines
+# within --line-ranges should be reformatted, even though the surrounding lines match.
 
 print ( "format me" )
 print ( "format me" )
@@ -17,12 +17,12 @@ print ( "format me" )
 # NOTE: If you need to modify this file, pay special attention to the --line-ranges=
 # flag above as it's formatting specifically these lines.
 
-# Reproducible example for https://github.com/psf/black/issues/4033.
-# This can be fixed in the future if we use a better diffing algorithm, or make Black
-# perform formatting in a single pass.
+# Reproducible example for https://github.com/psf/black/issues/4033, fixed here by a
+# diagonal-preferring diff (https://github.com/psf/black/issues/4052): only the lines
+# within --line-ranges should be reformatted, even though the surrounding lines match.
 
 print ( "format me" )
 print("format me")
 print("format me")
-print("format me")
-print("format me")
+print ( "format me" )
+print ( "format me" )

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -212,6 +212,37 @@ def test_diffs(lines: list[tuple[int, int]], adjusted: list[tuple[int, int]]) ->
 
 
 @pytest.mark.parametrize(
+    "lines,adjusted",
+    [
+        # The exact case from https://github.com/psf/black/issues/4052: only
+        # lines 2-3 were reformatted, but every original line is identical
+        # text, so a diff that isn't position-aware can match the unchanged
+        # original lines 1-2 against the unchanged modified lines 4-5.
+        ([(2, 3)], [(2, 3)]),
+        # Lines fully outside the changed block, on either side of it,
+        # should map straight through despite being textually identical to
+        # lines inside the changed block.
+        ([(1, 1)], [(1, 1)]),
+        ([(4, 4)], [(4, 4)]),
+        ([(4, 5)], [(4, 5)]),
+        ([(1, 5)], [(1, 5)]),
+    ],
+)
+def test_diffs_with_duplicate_lines(
+    lines: list[tuple[int, int]], adjusted: list[tuple[int, int]]
+) -> None:
+    original_source = 'print ( "format me" )\n' * 5
+    modified_source = (
+        'print ( "format me" )\n'
+        'print("format me")\n'
+        'print("format me")\n'
+        'print ( "format me" )\n'
+        'print ( "format me" )\n'
+    )
+    assert adjusted == adjusted_lines(lines, original_source, modified_source)
+
+
+@pytest.mark.parametrize(
     "lines,sanitized",
     [
         (


### PR DESCRIPTION
Closes #4052

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.