### PR TITLE
global config not possible if project contains a `pyproject.toml` (#4411)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- global config not possible if project contains a `pyproject.toml` (#4411)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -111,7 +111,9 @@ def find_pyproject_toml(
     path_project_root, _ = find_project_root(path_search_start, stdin_filename)
     path_pyproject_toml = path_project_root / "pyproject.toml"
     if path_pyproject_toml.is_file():
-        return str(path_pyproject_toml)
+        pyproject_toml = _load_toml(path_pyproject_toml)
+        if "black" in pyproject_toml.get("tool", {}):
+            return str(path_pyproject_toml)
 
     try:
         path_user_pyproject_toml = find_user_pyproject_toml()

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1873,6 +1873,36 @@ class BlackTestCase(BlackBaseTestCase):
         err = stderr.getvalue()
         assert "Ignoring user configuration" in err
 
+    def test_find_pyproject_toml_ignores_pyproject_toml_without_tool_black(
+        self,
+    ) -> None:
+        # A project root can be identified by a `.git` directory even though
+        # the `pyproject.toml` living right next to it has no [tool.black]
+        # section (e.g. it only configures other tools). In that case Black
+        # must keep looking and fall back to the user-level configuration
+        # file, instead of treating the project's pyproject.toml as if it
+        # were a (empty) Black config.
+        with TemporaryDirectory() as workspace:
+            root = Path(workspace)
+            (root / ".git").mkdir()
+            (root / "pyproject.toml").write_text(
+                "[tool.other]\nx = 1\n", encoding="utf-8"
+            )
+            src = root / "foo.py"
+            src.touch()
+
+            user_pyproject_toml = root / "user_pyproject.toml"
+            user_pyproject_toml.write_text("[tool.black]\n", encoding="utf-8")
+
+            with patch(
+                "black.files.find_user_pyproject_toml",
+                return_value=user_pyproject_toml,
+            ):
+                self.assertEqual(
+                    black.files.find_pyproject_toml((str(src),)),
+                    str(user_pyproject_toml),
+                )
+
     @patch(
         "black.files.find_user_pyproject_toml",
         black.files.find_user_pyproject_toml.__wrapped__,


### PR DESCRIPTION
Closes #4411

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.