### PR TITLE
Formatting a dictionary with a long string and type ignore fails on --unstable (#5328)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- Formatting a dictionary with a long string and type ignore fails on --unstable (#5328)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/trans.py
+++ b/src/black/trans.py
@@ -2383,6 +2383,14 @@ class StringParenWrapper(BaseStringSplitter, CustomSplitMapMixin):
             replace_child(LL[comma_idx], comma_leaf)
             last_line.append(comma_leaf)
 
+        # When the original closing paren is replaced, any comments that were
+        # attached to it (e.g. `# type: ignore`) are not carried over by
+        # `replace_child`. Recover them and append them to the last line so
+        # they are not silently dropped.
+        if old_rpar_leaf is not None:
+            for comment_leaf in line.comments_after(old_rpar_leaf):
+                last_line.append(comment_leaf, preformatted=True)
+
         yield Ok(last_line)
 
 

--- a/tests/data/cases/type_ignore_wrapped_string_in_dict.py
+++ b/tests/data/cases/type_ignore_wrapped_string_in_dict.py
@@ -1,0 +1,15 @@
+# flags: --unstable
+my_dict = {
+    "key": (
+        "A very very very very very very very very very very very very very very very very long string literal"
+    )  # type: ignore
+}
+
+# output
+
+my_dict = {
+    "key": (
+        "A very very very very very very very very very very very very very very very"
+        " very long string literal"
+    )  # type: ignore
+}


### PR DESCRIPTION
Closes #5328

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.