### PR TITLE
`--line-ranges` formats lines outside of range (#4430)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- `--line-ranges` formats lines outside of range (#4430)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/ranges.py
+++ b/src/black/ranges.py
@@ -441,6 +441,19 @@ def _convert_node_to_standalone_comment(
     # This also means the indentation will be changed on the unchanged lines, and
     # this is actually required to not break incremental reformatting.
     prefix = replacements.take_prefix(first)
+    # Preserve the original indentation of leading comments outside the
+    # requested line ranges. The prefix may contain blank lines and/or
+    # comment lines. Only the portion from the first comment line onward is
+    # folded into the STANDALONE_COMMENT value, so that the comment's own
+    # leading whitespace is kept verbatim. Any purely-whitespace remainder
+    # stays in the prefix and continues through the normal blank-line and
+    # indentation machinery.
+    comment_start = _find_comment_start(prefix)
+    if comment_start != -1:
+        value = prefix[comment_start:] + str(node)[:-1]
+        prefix = prefix[:comment_start]
+    else:
+        value = str(node)[:-1]
     # For a single-line decorated item the decorator and the item need a newline
     # between them. The conversions are recorded and applied in a single pass
     # instead of mutating the tree per node, so the decorator here is still its
@@ -450,7 +463,6 @@ def _convert_node_to_standalone_comment(
     # _convert_unchanged_line_by_line, which manages the newlines itself.)
     # Remove the '\n', as STANDALONE_COMMENT will have '\n' appended when
     # generating the formatted code.
-    value = str(node)[:-1]
     replacements.record(
         [node],
         Leaf(
@@ -460,6 +472,21 @@ def _convert_node_to_standalone_comment(
             fmt_pass_converted_first_leaf=first,
         ),
     )
+
+
+def _find_comment_start(prefix: str) -> int:
+    """Return the index in prefix where the first comment line starts.
+
+    A comment line is a line whose first non-whitespace character is '#'.
+    Returns -1 if there is no such line.
+    """
+    lines = prefix.splitlines(keepends=True)
+    offset = 0
+    for line in lines:
+        if line.lstrip().startswith("#"):
+            return offset
+        offset += len(line)
+    return -1
 
 
 def _convert_nodes_to_standalone_comment(

--- a/tests/data/cases/line_ranges_preserve_comment_indentation.py
+++ b/tests/data/cases/line_ranges_preserve_comment_indentation.py
@@ -1,0 +1,49 @@
+# flags: --line-ranges=4-12
+# NOTE: If you need to modify this file, pay special attention to the --line-ranges=
+# flag above as it's formatting specifically these lines.
+print("format me"  )
+ # format whitespace
+  # format whitespace
+   # format whitespace
+print( "format me" )
+   # format whitespace
+  # format whitespace
+ # format whitespace
+print(  "format me")
+
+
+
+print("don't format me"  )
+ # don't format whitespace
+  # don't format whitespace
+   # don't format whitespace
+print( "don't format me" )
+   # don't format whitespace
+  # don't format whitespace
+ # don't format whitespace
+print(  "don't format me")
+
+# output
+# flags: --line-ranges=4-12
+# NOTE: If you need to modify this file, pay special attention to the --line-ranges=
+# flag above as it's formatting specifically these lines.
+print("format me")
+# format whitespace
+# format whitespace
+# format whitespace
+print("format me")
+# format whitespace
+# format whitespace
+# format whitespace
+print("format me")
+
+
+print("don't format me"  )
+ # don't format whitespace
+  # don't format whitespace
+   # don't format whitespace
+print( "don't format me" )
+   # don't format whitespace
+  # don't format whitespace
+ # don't format whitespace
+print(  "don't format me")


### PR DESCRIPTION
Closes #4430

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.