### PR TITLE
`ruff:ignore` should be processed as a pragma in `contains_pragma_comment` (#5260)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 
 <!-- Changes that affect Black's preview style -->
 
+- `ruff:ignore` should be processed as a pragma in `contains_pragma_comment` (#5260)
 - Remove redundant parentheses around generator expressions (#5304)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)

--- a/src/black/lines.py
+++ b/src/black/lines.py
@@ -343,8 +343,24 @@ class Line:
                 for comment in self.comments.get(id(node), []):
                     if is_type_ignore_comment(comment, mode=self.mode):
                         return True
+                    if self._is_ruff_ignore_comment(comment):
+                        return True
 
         return False
+
+    @staticmethod
+    def _is_ruff_ignore_comment(comment: Leaf) -> bool:
+        """Return True if the comment is a ruff per-line ignore pragma.
+
+        Black normalizes the whitespace after the leading ``#`` to exactly one
+        space, but does not normalize whitespace after any subsequent ``:``.
+        Both ``# ruff:ignore[...]`` and ``# ruff: ignore[...]`` are recognized.
+        """
+        value = comment.value
+        if not value.startswith("# ruff:"):
+            return False
+        remainder = value[len("# ruff:") :]
+        return remainder.lstrip().startswith("ignore")
 
     def contains_multiline_strings(self) -> bool:
         return any(is_multiline_string(leaf) for leaf in self.leaves)

--- a/tests/data/cases/ruff_ignore_pragma.py
+++ b/tests/data/cases/ruff_ignore_pragma.py
@@ -1,0 +1,7 @@
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]
+yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy = 6  # ruff: ignore[bweh]
+
+# output
+
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]
+yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy = 6  # ruff: ignore[bweh]


### PR DESCRIPTION
Closes #5260

This patch was produced with the help of an autonomous coding system I build and supervise. I review and test every change before submitting and follow up on review feedback personally. If automated contributions are unwelcome in this project, please say so and I will stop submitting them.