### PR TITLE
Format a call whose sole argument is a parenthesized generator under --preview

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,11 @@
 <!-- Changes that affect Black's preview style -->
 
 - Remove redundant parentheses around generator expressions (#5304)
+- Remove every layer of redundant parentheses around a generator passed as the sole
+  argument of a call (e.g. `outer(inner(((x for x in y))))`). Only the outermost pair
+  was removed, and the pair left behind hid the `for` from the line splitter, so a
+  generator long enough to split came out differently on the second pass and Black
+  reported unstable formatting (#5329)
 - Preserve two blank lines before a top-level class starting inside a `# fmt: off` block
   after an import (#5238)
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -383,7 +383,10 @@ class LineGenerator(Visitor[Line]):
                     child.type == syms.trailer
                     and len(child.children) == 3
                     and is_lpar_token(child.children[0])
-                    and is_generator(child.children[1])
+                    and (
+                        is_generator(child.children[1])
+                        or _has_redundant_generator_parentheses(child.children[1])
+                    )
                     and is_rpar_token(child.children[2])
                 ):
                     maybe_make_parens_invisible_in_atom(
@@ -2128,6 +2131,7 @@ def maybe_make_parens_invisible_in_atom(
             mode=mode,
             features=features,
             remove_brackets_around_comma=remove_brackets_around_comma,
+            remove_generator_parens=remove_generator_parens,
         )
 
         if is_atom_with_invisible_parens(middle):

--- a/tests/data/cases/preview_redundant_generator_parentheses.py
+++ b/tests/data/cases/preview_redundant_generator_parentheses.py
@@ -30,6 +30,10 @@ any((
     for obj in this_iterable
 ))
 
+# Every layer of redundant parentheses goes, including when the generator splits.
+outer(inner((((item for item in items)))))
+outer(inner(((item.is_valid_and_ready(runtime_context) for item in the_collection_of_items_to_check))))
+
 # Existing comment handling may keep the generator parentheses visible.
 any((
     long_expression_that_exceeds_the_configured_line_length_limit_value  # inline comment
@@ -73,6 +77,15 @@ consume(*(item for item in items))
 any(
     this_very_long_method_name(obj) or another_long_method_name(obj)
     for obj in this_iterable
+)
+
+# Every layer of redundant parentheses goes, including when the generator splits.
+outer(inner(item for item in items))
+outer(
+    inner(
+        item.is_valid_and_ready(runtime_context)
+        for item in the_collection_of_items_to_check
+    )
 )
 
 # Existing comment handling may keep the generator parentheses visible.


### PR DESCRIPTION
### Description

`black --preview` refuses to format `outer(inner(((x for x in y))))` when the generator is long enough to split:

```
error: cannot format g.py: INTERNAL ERROR: Black produced different code on the second pass of the formatter.
```

`visit_power` only spots a sole-argument generator when the call's argument is the generator atom itself, so with a second redundant pair it does nothing and `visit_atom` removes just the outer pair. The pair left behind keeps the generator inside a bracket, so the `for` never registers as a delimiter and the line breaks inside the element expression instead. Re-parsing that output drops the surviving pair and splits at the `for`, hence the two passes disagree.

`visit_power` now also accepts a nested redundant-paren atom, and `maybe_make_parens_invisible_in_atom` forwards `remove_generator_parens` into its recursion so the inner pair goes too. The result matches what the one-pair spelling already produced.

Preview only. Formatting 2589 files across three modes gives byte-identical output before and after, and the stable style is untouched.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (`future_style.md` already describes the feature; no behavior to add there)