### PR TITLE
fix(issue #5260): `ruff:ignore` should be processed as a pragma in `contains_pragma_comment`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ venv/
 .ipynb_checkpoints/
 node_modules/
 *.pyd
+.cie/
+.venv/
+.forge/

--- a/src/black/comments.py
+++ b/src/black/comments.py
@@ -918,7 +918,7 @@ def contains_pragma_comment(comment_list: list[Leaf]) -> bool:
         pylint).
     """
     for comment in comment_list:
-        if comment.value.startswith(("# type:", "# noqa", "# pylint:")):
+        if comment.value.startswith(("# type:", "# noqa", "# pylint:", "# ruff:")):
             return True
 
     return False

--- a/tests/test_forge_5260.py
+++ b/tests/test_forge_5260.py
@@ -1,0 +1,20 @@
+import pytest
+from blib2to3.pgen2.token import COMMENT
+from blib2to3.pytree import Leaf
+from black.comments import contains_pragma_comment
+
+
+def _comment_leaf(value: str) -> Leaf:
+    return Leaf(COMMENT, value)
+
+
+def test_ruff_ignore_is_pragma():
+    """`# ruff: ignore[...]` should be treated as a pragma comment."""
+    leaf = _comment_leaf("# ruff: ignore[bweh]")
+    assert contains_pragma_comment([leaf]) is True
+
+
+def test_ruff_ignore_no_space_is_pragma():
+    """`# ruff:ignore[...]` (no space) should also be treated as a pragma."""
+    leaf = _comment_leaf("# ruff:ignore[bweh]")
+    assert contains_pragma_comment([leaf]) is True

--- a/tests/test_forge_5260.py
+++ b/tests/test_forge_5260.py
@@ -1,7 +1,8 @@
 import pytest
+
+from black.comments import contains_pragma_comment
 from blib2to3.pgen2.token import COMMENT
 from blib2to3.pytree import Leaf
-from black.comments import contains_pragma_comment
 
 
 def _comment_leaf(value: str) -> Leaf:


### PR DESCRIPTION
Fixes https://github.com/psf/black/issues/5260

## What
autonomous fix via `atomic-forge fix` — CIE (code graph over MCP) localized the bug, generated a failing regression test, and forge's repair loop fixed the source against it.

## Issue
> **`ruff:ignore` should be processed as a pragma in `contains_pragma_comment`**

<!--
Please make sure that the bug is not already fixed either in newer versions or the
current development version. To confirm this, you have three options:

1. Update Black's version if a newer release exists: `pip install -U black`
2. Install the latest `main` branch directly:
   `pip install "black @ git+https://github.com/psf/black.git"`
3. Or run _Black_ from source on your machine:
   - create a new virtualenv (make sure it's the same Python version);
   - clone this repository;
   - run `pip install -e .[d]`;
   - run `pip install --group tests`
   - make sure it's sane by running `python -m pytest -n auto`; and
   - run `black` like you did last time.
-->

**Describe the bug**

`ruff:ignore` is not processed as a pragma.

**To Reproduce**

<!--
Minimal steps to reproduce the behavior with source code and Black's configuration.
-->

For example, take this code:

```python
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff:ignore[bweh]
```

And run it with these arguments:

```sh
$ black x.py
```

The resulting output is:

```diff
--- x.py        2026-07-26 00:36:44.849442+00:00
+++ x.py        2026-07-26 00:36:45.724865+00:00
@@ -1 +1,3 @@
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = 5  # ruff: ignore[bweh]
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = (
+    5  # ruff: ignore[bweh]
+)
```

**Expected behavior**

No reformatting (which is what happens if you replace this with `type: ignore`).

**Environment**

<!-- Please complete the following information: -->

- Black's version: <!-- e.g. [main] --> 26.5.1
- OS and Python version: <!-- e.g. [Linux/Python 3.7.4rc1] --> macOS CPython 3.14.2

**Additional context**

<!-- Add any other context about the problem here. -->

This is probably going to become more popular as ruff has a rule in preview that converts all `noqa` to `ruff:ignore`. See https://docs.astral.sh/ruff/rules/noqa-comments/

## How it was verified
- regression test: `tests/test_forge_5260.py` (CIE-generated; fails on the pre-fix code, passes on the fix)
- repair rounds: 1  failures: 2 -> 0
- repaired file(s): src/black/comments.py

---
<!-- atomic-forge:pr -->
[![Fixed by Forge](https://img.shields.io/badge/fixed_by-atomic--forge-6f42c1?logo=github)](https://github.com/kannamma-labs/atomic-forge)

🔨 Fixed by [Forge](https://github.com/kannamma-labs/atomic-forge) — an autonomous, test-driven issue→PR repair engine (`atomic-forge fix <issue-url>`).

⭐ If you found this useful, a star on [atomic-forge](https://github.com/kannamma-labs/atomic-forge) helps other maintainers find the tool that fixed your bug.
