### PR TITLE
fix(files): handle project roots across Windows drives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,6 +104,8 @@
 - Add validation for --line-ranges values (#5107)
 - Ignore empty cache files like other malformed cache files instead of raising an
   `EOFError` (#5192)
+- Handle source files on different Windows drives without raising an internal
+  `ValueError` during project-root discovery (#5379)
 - Reject non-string `include` and `force-exclude` values in `pyproject.toml` (#5193)
 - Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors instead
   of crashing (#5211)

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -84,10 +84,14 @@ def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
         list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
     ]
 
-    common_base = max(
-        set.intersection(*(set(parents) for parents in src_parents)),
-        key=lambda path: path.parts,
-    )
+    common = set.intersection(*(set(parents) for parents in src_parents))
+    if common:
+        common_base = max(common, key=lambda path: path.parts)
+    else:
+        # Paths on different Windows drives have no common parent. Use the
+        # first path's filesystem root so project-root discovery can continue
+        # without exposing the implementation's empty-intersection error.
+        common_base = Path(path_srcs[0].anchor)
 
     for directory in (common_base, *common_base.parents):
         if (directory / ".git").exists():

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1858,6 +1858,19 @@ class BlackTestCase(BlackBaseTestCase):
                 (src_dir.resolve(), "pyproject.toml"),
             )
 
+    @pytest.mark.incompatible_with_mypyc
+    def test_find_project_root_different_windows_drives(self) -> None:
+        if system() != "Windows":
+            return
+
+        black.files._find_project_root_cached.cache_clear()
+        self.addCleanup(black.files._find_project_root_cached.cache_clear)
+
+        self.assertEqual(
+            black.find_project_root((r"C:\work\app\a.py", r"D:\tmp\b.py")),
+            (Path("C:\\"), "file system root"),
+        )
+
     @patch(
         "black.files.find_user_pyproject_toml",
     )


### PR DESCRIPTION
### Description

When Black receives source files on different Windows drives, their parent paths have no common entry and project-root discovery raised an internal `ValueError`. Fall back to the first source's filesystem root so formatting continues without exposing the empty-intersection failure. Inputs that share a drive keep the existing project-root behavior.

Fixes #5379

### Checklist

- [x] No code style changes
- [x] Added an entry to `CHANGES.md`
- [x] Added a regression test for paths on different Windows drives
- [x] No additional documentation changes are needed