### PR TITLE
Handle UTF-8 offsets when masking notebook magics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 <!-- Changes that affect Black's stable style -->
 
+- Fix parsing Jupyter notebook assignment magics when non-ASCII characters appear
+  earlier on the line (#5381)
 - Preserve blank lines that come immediately before a `# fmt: on` comment (#5300)
 - Keep the parentheses around the target of an annotated assignment (for example
   `(x): int = 5`). They make the target non-simple, so CPython leaves the name out of

--- a/src/black/handle_ipynb_magics.py
+++ b/src/black/handle_ipynb_magics.py
@@ -299,7 +299,9 @@ def replace_magics(src: str) -> tuple[str, list[Replacement]]:
             mask = get_token(src, magic, existing_tokens)
             replacements.append(Replacement(mask=mask, src=magic))
             existing_tokens.add(mask)
-            line = line[:col_offset] + mask
+            # AST column offsets are UTF-8 byte offsets, not character indices.
+            prefix = line.encode("utf-8")[:col_offset].decode("utf-8")
+            line = prefix + mask
         new_srcs.append(line)
     return "\n".join(new_srcs), replacements
 

--- a/tests/test_ipynb.py
+++ b/tests/test_ipynb.py
@@ -138,6 +138,11 @@ def test_cell_magic_noop() -> None:
         pytest.param(
             "env =  %env var", "env = %env var", id="Assignment to environment variable"
         ),
+        pytest.param(
+            "变量 =  %env var",
+            "变量 = %env var",
+            id="Assignment after non-ASCII characters",
+        ),
         pytest.param("env =  %env", "env = %env", id="Assignment to magic"),
     ),
 )


### PR DESCRIPTION
### Description

Fixes #5378.

`ast.col_offset` counts UTF-8 bytes, but `replace_magics()` used the value as a Python string index. When non-ASCII characters appeared before an assignment magic, Black kept part of the transformed `get_ipython()` call and produced source that could not be parsed.

Build the preserved prefix from the UTF-8 bytes before replacing the magic with its mask. The regression test covers a CJK identifier in both the default and custom cell-magic modes.

### Validation

- `tox -e py`
- `pre-commit run -a`
- Black self-format check

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?