### PR TITLE
Honor negations in nested .gitignore files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,8 @@
 
 <!-- Changes to how Black can be configured -->
 
+- Honor negations in nested `.gitignore` files when an ancestor rule also matches
+  (#5382)
 - Fix `find_project_root` returning a stale cached result when `--code` is used from
   different working directories in the same process. The CWD fallback (used when no
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -304,6 +304,7 @@ def _path_is_ignored(
     gitignore_dict: dict[Path, GitIgnoreSpec],
 ) -> bool:
     path = root / root_relative_path
+    ignored = False
     # Note that this logic is sensitive to the ordering of gitignore_dict. Callers must
     # ensure that gitignore_dict is ordered from least specific to most specific.
     for gitignore_path, pattern in gitignore_dict.items():
@@ -313,9 +314,12 @@ def _path_is_ignored(
                 relative_path = relative_path + "/"
         except ValueError:
             break
-        if pattern.match_file(relative_path):
-            return True
-    return False
+        # A matching rule in a deeper .gitignore overrides an earlier match. A
+        # None result means this file had no applicable rule and leaves the state alone.
+        match = pattern.check_file(relative_path).include
+        if match is not None:
+            ignored = match
+    return ignored
 
 
 def path_is_excluded(

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2844,6 +2844,18 @@ class TestFileCollection:
         )
         assert sorted(expected) == sorted(sources)
 
+    def test_nested_gitignore_reincludes_parent_match(self, tmp_path: Path) -> None:
+        packages = tmp_path / "packages"
+        source = packages / "playground" / "generated" / "settings.py"
+        source.parent.mkdir(parents=True)
+        source.write_text("x=1\n", encoding="utf-8")
+        (tmp_path / ".gitignore").write_text("generated\n", encoding="utf-8")
+        (packages / ".gitignore").write_text(
+            "!playground/generated\n", encoding="utf-8"
+        )
+
+        assert_collected_sources([tmp_path], [source], root=tmp_path)
+
     def test_nested_gitignore_directly_in_source_directory(self) -> None:
         # https://github.com/psf/black/issues/2598
         path = Path(DATA_DIR / "nested_gitignore_tests")


### PR DESCRIPTION
### Description

Fixes #5376.

Black stopped checking `.gitignore` files as soon as an ancestor rule matched. That meant a more specific negation in a nested `.gitignore` could never re-include the path. This keeps the last explicit match while walking from the repository root toward the file, so a deeper rule can override an earlier one and a non-match leaves the current state alone.

The regression test uses a `generated` directory rather than the issue's `.vscode` example because `.vscode` is also covered by Black's default exclusions.

### Validation

- The regression test fails on the previous implementation and passes with this change.
- All 24 applicable file-collection tests pass. Three other cases require Windows symlink privileges that are unavailable in this environment.
- The remaining test suite passes when five environment-specific Windows cases (three symlink privilege checks and two ANSI color expectations) are excluded: 476 regular tests and 73 Jupyter tests, with 93% coverage.
- Full pre-commit suite passes.
- The self-format check leaves all 68 files unchanged. The `tox -e run_self` wrapper itself splits a Windows workspace path containing spaces, so I ran its installed Black command with `.` instead.
- `git check-ignore` and `git add --dry-run` both confirm the nested negation re-includes the fixture path.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy? (No formatting style change.)
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation? (No documentation change needed.)
