### PR TITLE
Report Black's own parse failure as an internal error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -195,6 +195,9 @@
 <!-- Changes to Black's terminal output and error messages -->
 
 - Report parser failures using editor-friendly `path:line:column` locations (#5237)
+- A `# fmt: off` region that keeps a different indent width from the rest of the file
+  can make Black's own output unparseable. That failure is now reported as an internal
+  error naming Black, instead of as a syntax error pointing at the user's file (#5383)
 
 ### _Blackd_
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -1267,7 +1267,19 @@ def format_str(
     if src_contents != dst_contents:
         if lines:
             lines = adjusted_lines(lines, src_contents, dst_contents)
-        return _format_str_once(dst_contents, mode=mode, lines=lines)
+        try:
+            return _format_str_once(dst_contents, mode=mode, lines=lines)
+        except InvalidInput as exc:
+            # The second pass parses Black's own output, so a parse failure
+            # here means Black produced the invalid code, not the user. Without
+            # this the error is reported against the user's file and reads
+            # exactly like a syntax error in their source.
+            log = dump_to_file(dst_contents)
+            raise ASTSafetyError(
+                f"INTERNAL ERROR: {_black_info()} produced invalid code: {exc}. "
+                "Please report a bug on https://github.com/psf/black/issues.  "
+                f"This invalid output might be helpful: {log}"
+            ) from None
     return dst_contents
 
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import ast
 import asyncio
 import inspect
 import io
@@ -132,6 +133,40 @@ def invokeBlack(
         f"exception: {result.exception}"
     )
     assert result.exit_code == exit_code, msg
+
+
+def test_fmt_off_reindent_reports_black_not_the_user(tmp_path: Path) -> None:
+    """Black must own the error when its own output fails to parse.
+
+    Reindenting to 4 spaces stops at a ``# fmt: off`` region, so the result can
+    mix indent widths and fail the forced second pass. That parse failure is
+    Black's, but it used to surface as ``cannot parse: <user file>:<line>``,
+    which is what a genuine syntax error in the user's source looks like.
+    """
+    source = tmp_path / "reindent.py"
+    source.write_text(
+        'if __name__ == "__main__":\n'
+        "  foo = 3\n"
+        "  # fmt: off\n"
+        "  bar = 1\n"
+        "  baz  =  2\n"
+        "  # fmt: on\n"
+        "  qux = 4\n",
+        encoding="utf8",
+    )
+    # the file itself is valid Python; only Black's output is not
+    ast.parse(source.read_text(encoding="utf8"))
+
+    result = BlackRunner().invoke(
+        black.main, ["--config", str(THIS_DIR / "empty.toml"), str(source)]
+    )
+
+    assert result.exit_code == 123
+    assert "INTERNAL ERROR" in result.stderr
+    assert "produced invalid code" in result.stderr
+    assert "https://github.com/psf/black/issues" in result.stderr
+    # must not read as a syntax error in the user's file
+    assert f"cannot parse: {source}:" not in result.stderr
 
 
 def test_invalid_input_error_includes_path_location(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. -->

### Description

Closes #3505.

Black reindents to 4 spaces but leaves `# fmt: off` regions alone, so its output can end up mixing indent widths. @JelleZijlstra said as much on the issue:

> So the reason this happen is that Black (correctly) reindents the code to use 4-space indents, except within the `# fmt: off` part, because the user asked us not to format it. So the code it tries to output then has a syntax error from the remaining 2-space indents.
>
> I still don't think there is a way we can format these cases correctly, but we should give a better error.

This is the better error, rather than an attempt to format those cases.

The forced second pass in `format_str()` parses Black's *own* output, but the `InvalidInput` it raised escaped uncaught, so it surfaced against the user's file:

```console
$ cat reindent.py
if __name__ == "__main__":
  foo = 3
  # fmt: off
  bar = 1
  baz  =  2
  # fmt: on
  qux = 4

$ python -c "import ast; ast.parse(open('reindent.py').read())"   # the file is valid

$ black reindent.py
error: cannot parse: reindent.py:5:0
      baz  =  2
    ^
ParseError: bad input
```

That is byte-for-byte the shape of a genuine syntax error. `def f(:` produces `error: cannot parse: genuine.py:1:6` and the same `ParseError: bad input`, so there is nothing for a user to tell them apart, and it points at a line of their code that is fine.

After:

```console
$ black reindent.py
error: cannot format reindent.py: INTERNAL ERROR: Black 0.1.dev20 on Python (CPython) 3.12.13
produced invalid code: cannot parse: 5:0
      baz  =  2
    ^
ParseError: bad input. Please report a bug on https://github.com/psf/black/issues.
This invalid output might be helpful: /tmp/blk_iwhhpmsr.log
```

This also restores what @ichard26 described as missing:

> Usually Black would emit a helpful `INTERNAL ERROR: Black produced invalid code` error, but that's been broken for a while now.

The change is one `try`/`except` around the second pass. `ASTSafetyError`, `InvalidInput`, `dump_to_file` and `_black_info()` are all already imported, and the message reuses the exact wording `assert_equivalent()` uses for the same class of failure, so there is one phrasing for "Black produced invalid code", not two.

### Scope

Only the forced second pass is wrapped. The first pass parses the user's source, so a genuine syntax error there still reports the way it always did, and `test_invalid_input_error_includes_path_location` passes unchanged. Exit code stays 123 in both cases.

This does not make the affected files formattable, which Jelle judged not possible. #3702 and #3705 report the same underlying situation and would get the same clearer error.

### Checklist

- [x] Add tests
- [x] Update `CHANGES.md` (follow-up commit, since it wants the PR number)

`test_fmt_off_reindent_reports_black_not_the_user` asserts the new message, and asserts the old `cannot parse: <path>:` form is *absent*, so a regression back to blaming the user fails the test. Reverting only `src/black/__init__.py` and keeping the test fails it.

Full suite: 555 passed / 2 skipped on this branch against 554 passed / 2 skipped on `main` on the same machine, no failures either side, the difference being the added test.

I used an AI assistant while working on this. The reproduction, the comparison against a genuine syntax error, and the decision to reuse the existing `INTERNAL ERROR` wording rather than invent a second one are mine, and I ran every result quoted here.
