### PR TITLE
Raise UsageError when sources share no common project root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,8 @@
 - Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors instead
   of crashing (#5211)
 - Ignore permission errors when reading cache (#5258)
+- Raise a usage error instead of crashing when sources on different drives share
+  no common project root (#PR)
 
 ### Packaging
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,7 +109,7 @@
   of crashing (#5211)
 - Ignore permission errors when reading cache (#5258)
 - Raise a usage error instead of crashing when sources on different drives share
-  no common project root (#PR)
+  no common project root (#5385)
 
 ### Packaging
 

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Union
 
+import click
 from mypy_extensions import mypyc_attr
 from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
@@ -57,6 +58,9 @@ def find_project_root(
     If no directory in the tree contains a marker that would specify it's the
     project root, the root of the file system is returned.
 
+    Raises click.UsageError if the sources share no common parent (for example
+    they are on different Windows drives).
+
     Returns a two-tuple with the first element as the project root path and
     the second element as a string describing the method by which the
     project root was discovered.
@@ -84,10 +88,12 @@ def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
         list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
     ]
 
-    common_base = max(
-        set.intersection(*(set(parents) for parents in src_parents)),
-        key=lambda path: path.parts,
-    )
+    common_parents = set.intersection(*(set(parents) for parents in src_parents))
+    if not common_parents:
+        raise click.UsageError(
+            "Sources on different drives share no common project root."
+        )
+    common_base = max(common_parents, key=lambda path: path.parts)
 
     for directory in (common_base, *common_base.parents):
         if (directory / ".git").exists():

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1858,6 +1858,20 @@ class BlackTestCase(BlackBaseTestCase):
                 (src_dir.resolve(), "pyproject.toml"),
             )
 
+    def test_find_project_root_no_common_parent(self) -> None:
+        # Absolute vs relative paths share no parents on any platform. That is
+        # the same empty-intersection situation as C:\... and D:\... on Windows.
+        cases: list[tuple[str, str]] = [("/work/app/a.py", "tmp/b.py")]
+        if sys.platform == "win32":
+            cases.append((r"C:\work\app\a.py", r"D:\tmp\b.py"))
+
+        for srcs in cases:
+            parents = [set(Path(src).parents) for src in srcs]
+            self.assertFalse(set.intersection(*parents))
+            with self.subTest(srcs=srcs):
+                with pytest.raises(click.UsageError, match="different drives"):
+                    black.files._find_project_root_cached(srcs)
+
     @patch(
         "black.files.find_user_pyproject_toml",
     )


### PR DESCRIPTION
### Description

Fixes #5379.

`find_project_root` passed an empty parent-path intersection to `max()`, which raises `ValueError` when sources live on different Windows drives. It now raises `click.UsageError` instead. Same-drive and POSIX paths that share a parent are unchanged.

### Checklist - did you ...

- [x] Implement any code style changes under the `--preview` style, following the stability policy?
- [x] Add an entry in `CHANGES.md` if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?