### PR TITLE
Fall back to the default configuration when sources share no project root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,9 @@
   --target-version flag (#5167)
 - `--line-ranges` no longer inserts an empty line after a docstring when the range
   covers only the docstring itself (#5312)
-- Fall back to the default configuration, with a warning, when the given sources
-  share no common project root (for example, they are on different drives on
-  Windows) instead of crashing (#5386)
+- Fall back to the default configuration, with a warning, when the given sources share
+  no common project root (for example, they are on different drives on Windows) instead
+  of crashing (#5386)
 
 ### Highlights
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
   --target-version flag (#5167)
 - `--line-ranges` no longer inserts an empty line after a docstring when the range
   covers only the docstring itself (#5312)
+- Fall back to the default configuration, with a warning, when the given sources
+  share no common project root (for example, they are on different drives on
+  Windows) instead of crashing (#5386)
 
 ### Highlights
 

--- a/src/black/__init__.py
+++ b/src/black/__init__.py
@@ -618,6 +618,20 @@ def main(
     )
     ctx.obj["root"] = root
 
+    if (
+        code is None
+        and root is None
+        and not quiet
+        and ctx.get_parameter_source("config") != ParameterSource.COMMANDLINE
+    ):
+        err(
+            "No project root could be identified: the given sources share no"
+            " common parent directory (for example, they are on different"
+            " drives). Black will use its default configuration. Pass"
+            " --config to select a configuration file or --quiet to silence"
+            " this warning."
+        )
+
     if verbose:
         if root:
             out(
@@ -717,7 +731,6 @@ def main(
             lines=lines,
         )
     else:
-        assert root is not None  # root is only None if code is not None
         try:
             sources = get_sources(
                 root=root,
@@ -778,7 +791,7 @@ def main(
 
 def get_sources(
     *,
-    root: Path,
+    root: Path | None,
     src: tuple[str, ...],
     quiet: bool,
     verbose: bool,
@@ -792,7 +805,9 @@ def get_sources(
     """Compute the set of files to be formatted."""
     sources: set[Path] = set()
 
-    assert root.is_absolute(), f"INTERNAL ERROR: `root` must be absolute but is {root}"
+    assert (
+        root is None or root.is_absolute()
+    ), f"INTERNAL ERROR: `root` must be absolute but is {root}"
     using_default_exclude = exclude is None
     exclude = re_compile_maybe_verbose(DEFAULT_EXCLUDES) if exclude is None else exclude
     gitignore: dict[Path, GitIgnoreSpec] | None = None
@@ -812,14 +827,22 @@ def get_sources(
             path = Path(s)
             is_stdin = False
 
+        # When the sources share no common parent, there is no project root.
+        # Fall back to a per-source root so that exclusion, symlink, and
+        # gitignore handling still work for each source independently.
+        if root is None:
+            src_root = path.resolve() if path.is_dir() else path.resolve().parent
+        else:
+            src_root = root
+
         # Compare the logic here to the logic in `gen_python_files`.
         if is_stdin or path.is_file():
-            if resolves_outside_root_or_cannot_stat(path, root, report):
+            if resolves_outside_root_or_cannot_stat(path, src_root, report):
                 if verbose:
                     out(f'Skipping invalid source: "{path}"', fg="red")
                 continue
 
-            root_relative_path = best_effort_relative_path(path, root).as_posix()
+            root_relative_path = best_effort_relative_path(path, src_root).as_posix()
             root_relative_path = "/" + root_relative_path
 
             # Hard-exclude any files that matches the `--force-exclude` regex.
@@ -841,19 +864,19 @@ def get_sources(
                 out(f'Found input source: "{path}"', fg="blue")
             sources.add(path)
         elif path.is_dir():
-            path = root / (path.resolve().relative_to(root))
+            path = src_root / (path.resolve().relative_to(src_root))
             if verbose:
                 out(f'Found input source directory: "{path}"', fg="blue")
 
             if using_default_exclude:
                 gitignore = {
-                    root: root_gitignore,
+                    src_root: root_gitignore,
                     path: get_gitignore(path),
                 }
             sources.update(
                 gen_python_files(
                     path.iterdir(),
-                    root,
+                    src_root,
                     include,
                     exclude,
                     extend_exclude,

--- a/src/black/files.py
+++ b/src/black/files.py
@@ -45,7 +45,7 @@ def _cached_resolve(path: Path) -> Path:
 
 def find_project_root(
     srcs: Sequence[str | Path], stdin_filename: str | None = None
-) -> tuple[Path, str]:
+) -> tuple[Path | None, str | None]:
     """Return a directory containing .git, .hg, or pyproject.toml.
 
     pyproject.toml files are only considered if they contain a [tool.black]
@@ -56,6 +56,10 @@ def find_project_root(
 
     If no directory in the tree contains a marker that would specify it's the
     project root, the root of the file system is returned.
+
+    If the sources share no common parent at all (for example, they live on
+    different drives on Windows), there is no project root and
+    ``(None, None)`` is returned.
 
     Returns a two-tuple with the first element as the project root path and
     the second element as a string describing the method by which the
@@ -75,7 +79,7 @@ def find_project_root(
 
 
 @lru_cache
-def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
+def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path | None, str | None]:
     path_srcs = [Path(src) for src in srcs]
 
     # A list of lists of parents for each 'src'. 'src' is included as a
@@ -84,10 +88,10 @@ def _find_project_root_cached(srcs: tuple[str, ...]) -> tuple[Path, str]:
         list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
     ]
 
-    common_base = max(
-        set.intersection(*(set(parents) for parents in src_parents)),
-        key=lambda path: path.parts,
-    )
+    common_parents = set.intersection(*(set(parents) for parents in src_parents))
+    if not common_parents:
+        return None, None
+    common_base = max(common_parents, key=lambda path: path.parts)
 
     for directory in (common_base, *common_base.parents):
         if (directory / ".git").exists():
@@ -109,9 +113,10 @@ def find_pyproject_toml(
 ) -> str | None:
     """Find the absolute filepath to a pyproject.toml if it exists"""
     path_project_root, _ = find_project_root(path_search_start, stdin_filename)
-    path_pyproject_toml = path_project_root / "pyproject.toml"
-    if path_pyproject_toml.is_file():
-        return str(path_pyproject_toml)
+    if path_project_root is not None:
+        path_pyproject_toml = path_project_root / "pyproject.toml"
+        if path_pyproject_toml.is_file():
+            return str(path_pyproject_toml)
 
     try:
         path_user_pyproject_toml = find_user_pyproject_toml()
@@ -247,8 +252,10 @@ def find_user_pyproject_toml() -> Path:
 
 
 @lru_cache
-def get_gitignore(root: Path) -> GitIgnoreSpec:
+def get_gitignore(root: Path | None) -> GitIgnoreSpec:
     """Return a GitIgnoreSpec matching gitignore content if present."""
+    if root is None:
+        return GitIgnoreSpec.from_lines([])
     gitignore = root / ".gitignore"
     lines: list[str] = []
     if gitignore.is_file():

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -1858,6 +1858,98 @@ class BlackTestCase(BlackBaseTestCase):
                 (src_dir.resolve(), "pyproject.toml"),
             )
 
+    @pytest.mark.incompatible_with_mypyc
+    def test_find_project_root_no_common_parent(self) -> None:
+        # Absolute vs relative paths share no parents on any platform. That is
+        # the same empty-intersection situation as C:\... and D:\... on Windows.
+        cases: list[tuple[str, ...]] = [("/work/app/a.py", "tmp/b.py")]
+        if sys.platform == "win32":
+            cases.append((r"C:\work\app\a.py", r"D:\tmp\b.py"))
+
+        for srcs in cases:
+            parents = [set(Path(src).parents) for src in srcs]
+            self.assertFalse(set.intersection(*parents))
+            with self.subTest(srcs=srcs):
+                self.assertEqual(
+                    black.files._find_project_root_cached(srcs), (None, None)
+                )
+
+        if sys.platform == "win32":
+            self.assertEqual(
+                black.find_project_root((r"C:\work\app\a.py", r"D:\tmp\b.py")),
+                (None, None),
+            )
+
+    @pytest.mark.incompatible_with_mypyc
+    @patch("black.files.find_user_pyproject_toml")
+    def test_find_pyproject_toml_no_common_parent(
+        self, find_user_pyproject_toml: MagicMock
+    ) -> None:
+        if system() != "Windows":
+            return
+
+        with TemporaryDirectory() as workspace:
+            user_config = Path(workspace) / "user-pyproject.toml"
+            user_config.write_text("[tool.black]", encoding="utf-8")
+            find_user_pyproject_toml.return_value = user_config
+
+            # Sources on different drives share no project root, so the
+            # project-level config is skipped and the user-level config
+            # applies, same as when the project root has no pyproject.toml.
+            result = black.files.find_pyproject_toml(
+                (r"C:\work\app\a.py", r"D:\tmp\b.py")
+            )
+            self.assertEqual(result, str(user_config))
+
+    @pytest.mark.incompatible_with_mypyc
+    @patch("black.files.find_user_pyproject_toml")
+    @patch("black.files.find_project_root")
+    @patch("black.find_project_root")
+    def test_no_common_parent_warns_and_formats(
+        self,
+        find_project_root: MagicMock,
+        files_find_project_root: MagicMock,
+        find_user_pyproject_toml: MagicMock,
+    ) -> None:
+        find_project_root.return_value = (None, None)
+        files_find_project_root.return_value = (None, None)
+        find_user_pyproject_toml.return_value = Path("does-not-exist")
+
+        runner = BlackRunner()
+        with TemporaryDirectory() as workspace:
+            root = Path(workspace)
+            project1 = root / "project1"
+            project2 = root / "project2"
+            project1.mkdir()
+            project2.mkdir()
+            (project1 / "a.py").write_text("x=1\n", encoding="utf-8")
+            (project2 / "b.py").write_text("y=2\n", encoding="utf-8")
+
+            def invoke(args: list[str]) -> tuple[int, str]:
+                for path in (project1 / "a.py", project2 / "b.py"):
+                    path.write_text("x=1\n", encoding="utf-8")
+                result = runner.invoke(
+                    black.main,
+                    [str(project1), str(project2), *args],
+                    catch_exceptions=False,
+                )
+                return result.exit_code, result.output
+
+            exit_code, output = invoke([])
+            assert exit_code == 0, output
+            assert "No project root could be identified" in output
+            assert "reformatted" in output
+            assert "a.py" in output and "b.py" in output
+
+            exit_code, output = invoke(["--quiet"])
+            assert exit_code == 0, output
+            assert "No project root could be identified" not in output
+
+            exit_code, output = invoke(["--config", str(THIS_DIR / "empty.toml")])
+            assert exit_code == 0, output
+            assert "No project root could be identified" not in output
+            assert "reformatted" in output
+
     @patch(
         "black.files.find_user_pyproject_toml",
     )


### PR DESCRIPTION
## Description

Closes #5379
Closes #5422

Fixes the crash in #5379: when the given sources share no common parent directory — for example, they live on different drives on Windows — `find_project_root` raised `ValueError: max() iterable argument is empty` during CLI startup, before any file was formatted.

This implements the option @cobaltt7 preferred in the issue discussion: treat the situation as *no config found* rather than an error.

- `find_project_root` returns `(None, None)` when the sources' parent sets do not intersect, instead of crashing.
- No project-level `pyproject.toml` is discovered in that case; the user-level config applies as usual, otherwise Black's defaults are used.
- A warning is printed (`No project root could be identified: ... Pass --config ... or --quiet ...`), silenced by passing `--config` explicitly or by `--quiet`. (The issue comment mentioned a `--silent` flag; Black's closest equivalent is `--quiet`.)
- Formatting continues.

One structural point that the "no config found" framing alone doesn't cover: the project root is not used only for config discovery — it also anchors gitignore handling, `--exclude`/`--force-exclude` matching, and the symlink-outside-root guard in `get_sources`/`gen_python_files`, and `child.relative_to(root)` can never work across drives with a single root. So when no common root exists, this PR falls back to a **per-source root**: each top-level source (its directory, for files) acts as the root for its own discovery/exclusion handling. Same-drive invocations are completely unchanged.

Note #5385 implements the alternative route from the same comment (a usage error). Whichever route the maintainers prefer is fine by me — the per-source-root fallback here is also what lets formatting continue when `--config` is passed explicitly, which that comment asked for from the error route as well. Happy to rebase, adjust, or reshape this PR either way.

## Checklist

- [x] The change is adequately tested (new tests cover the `(None, None)` return, config discovery skipping the project root, the warning and its `--config`/`--quiet` gating, and end-to-end formatting with per-source roots; verified on Windows against real cross-drive paths, where the original crash reproduces on `main`).

Refs #5379
