### PR TITLE
Skip symlink tests when the platform forbids creating one

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -2644,6 +2644,20 @@ class TestCaching:
             assert len(set(keys)) == len(modes)
 
 
+def symlink_or_skip(link: Path, target: Path | str) -> None:
+    """Create a symlink, or skip the test where the platform forbids one.
+
+    Windows refuses symlink creation unless the process is elevated or
+    Developer Mode is enabled, so these tests cannot run for an ordinary
+    Windows contributor. Same treatment as test_broken_symlink, which has
+    guarded this since GH #287.
+    """
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as e:
+        pytest.skip(f"Can't create symlinks: {e}")
+
+
 def assert_collected_sources(
     src: Sequence[str | Path],
     expected: Sequence[str | Path],
@@ -3039,7 +3053,7 @@ class TestFileCollection:
             actual = tmp / "actual"
             actual.mkdir()
             symlink = tmp / "symlink"
-            symlink.symlink_to(actual)
+            symlink_or_skip(symlink, actual)
 
             actual_proj = actual / "project"
             actual_proj.mkdir()
@@ -3063,7 +3077,7 @@ class TestFileCollection:
 
                 # a few tricky tests for force_exclude
                 flat_symlink = symlink_proj / "symlink_module.py"
-                flat_symlink.symlink_to(actual_proj / "module.py")
+                symlink_or_skip(flat_symlink, actual_proj / "module.py")
                 assert_collected_sources(
                     src=[flat_symlink],
                     root=symlink_proj.resolve(),
@@ -3074,7 +3088,7 @@ class TestFileCollection:
                 target = actual_proj / "target"
                 target.mkdir()
                 (target / "another.py").write_text("print('hello')", encoding="utf-8")
-                (symlink_proj / "nested").symlink_to(target)
+                symlink_or_skip(symlink_proj / "nested", target)
 
                 assert_collected_sources(
                     src=[symlink_proj / "nested" / "another.py"],
@@ -3102,7 +3116,7 @@ class TestFileCollection:
             target = tmp / "outside_root" / "a.py"
             target.parent.mkdir()
             target.write_text("print('hello')", encoding="utf-8")
-            (root / "a.py").symlink_to(target)
+            symlink_or_skip(root / "a.py", target)
 
             stdin_filename = str(root / "a.py")
             assert_collected_sources(
@@ -3188,7 +3202,7 @@ class TestFileCollection:
             tmp = Path(tempdir).resolve()
             (tmp / "exclude").mkdir()
             (tmp / "exclude" / "a.py").write_text("print('hello')", encoding="utf-8")
-            (tmp / "symlink.py").symlink_to(tmp / "exclude" / "a.py")
+            symlink_or_skip(tmp / "symlink.py", tmp / "exclude" / "a.py")
 
             stdin_filename = str(tmp / "symlink.py")
             expected = [f"__BLACK_STDIN_FILENAME__{stdin_filename}"]


### PR DESCRIPTION
Fixes #5389.

## What

Three tests in `TestFileCollection` create symlinks without any guard, so the test suite fails with `OSError: [WinError 1314]` for any Windows contributor who is neither elevated nor running with Developer Mode enabled:

- `test_get_sources_symlink_and_force_exclude`
- `test_get_sources_with_stdin_symlink_outside_root`
- `test_get_sources_with_stdin_filename_and_force_exclude_and_symlink`

This is the same problem #287 fixed in 2018 for `test_broken_symlink` — that guard is still in place and working, but the three tests above were added later without it. CI cannot catch the regression because the Windows runner can create symlinks; only an ordinary local Windows checkout fails.

## Change

Add a module-level `symlink_or_skip(link, target)` helper next to the other test utilities and use it at all five `symlink_to` call sites in `TestFileCollection`:

```python
def symlink_or_skip(link: Path, target: Path | str) -> None:
    try:
        link.symlink_to(target)
    except (OSError, NotImplementedError) as e:
        pytest.skip(f"Can't create symlinks: {e}")
```

Notes:

- `pytest.skip` instead of `self.skipTest`, since `TestFileCollection` is a plain pytest class, not a `unittest.TestCase` (`test_broken_symlink` keeps its existing `skipTest` guard).
- Centralising the helper means the next symlink test picks up the guard by default, which is what would have prevented this recurrence.
- The fix follows the approach suggested in the issue (thanks @iam-kira for the detailed report and verification).

## Verification

- Before: `3 failed, 442 passed` on Windows (WinError 1314) — matches the issue report.
- After: `0 failed / 442 passed`, with the three tests reporting `SKIPPED (Can't create symlinks: ...)`.
- Full suite: `442 passed, 7 skipped, 8 subtests passed` (`pytest --ignore=tests/test_blackd.py`).
- `black --check tests/test_black.py`, `flake8`, `isort --check-only`, and `mypy` all pass.

## Changelog

Test-only change with no user-facing behaviour impact, so I believe no `CHANGES.md` entry is needed — happy to add one under the appropriate heading if you prefer.
